### PR TITLE
Feat:Add Tagging System for Confessions

### DIFF
--- a/xconfess-backend/migrations/20260127-create-tags-system.ts
+++ b/xconfess-backend/migrations/20260127-create-tags-system.ts
@@ -1,0 +1,176 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateTagsSystem1738000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create tags table
+    await queryRunner.createTable(
+      new Table({
+        name: 'tags',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '50',
+            isUnique: true,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Create index on tag name
+    await queryRunner.createIndex(
+      'tags',
+      new TableIndex({
+        name: 'IDX_tags_name',
+        columnNames: ['name'],
+      }),
+    );
+
+    // Create confession_tags junction table
+    await queryRunner.createTable(
+      new Table({
+        name: 'confession_tags',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'confession_id',
+            type: 'uuid',
+          },
+          {
+            name: 'tag_id',
+            type: 'uuid',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Create indexes for efficient querying
+    await queryRunner.createIndex(
+      'confession_tags',
+      new TableIndex({
+        name: 'IDX_confession_tags_confession_id',
+        columnNames: ['confession_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'confession_tags',
+      new TableIndex({
+        name: 'IDX_confession_tags_tag_id',
+        columnNames: ['tag_id'],
+      }),
+    );
+
+    // Create composite unique index to prevent duplicate tag assignments
+    await queryRunner.createIndex(
+      'confession_tags',
+      new TableIndex({
+        name: 'IDX_confession_tags_confession_tag_unique',
+        columnNames: ['confession_id', 'tag_id'],
+        isUnique: true,
+      }),
+    );
+
+    // Add foreign key constraints
+    await queryRunner.createForeignKey(
+      'confession_tags',
+      new TableForeignKey({
+        columnNames: ['confession_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'anonymous_confessions',
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'confession_tags',
+      new TableForeignKey({
+        columnNames: ['tag_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'tags',
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    // Seed predefined tags
+    await queryRunner.query(`
+      INSERT INTO tags (name, description) VALUES
+        ('funny', 'Humorous or amusing confessions'),
+        ('sad', 'Sad or melancholic confessions'),
+        ('inspiring', 'Motivational or uplifting confessions'),
+        ('love', 'Confessions about love and relationships'),
+        ('heartbreak', 'Confessions about heartbreak and loss'),
+        ('advice', 'Seeking or giving advice'),
+        ('confession', 'General confessions'),
+        ('rant', 'Venting or expressing frustration'),
+        ('grateful', 'Expressing gratitude'),
+        ('regret', 'Confessions about regrets');
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop foreign keys
+    const confessionTagsTable = await queryRunner.getTable('confession_tags');
+    if (confessionTagsTable) {
+      const foreignKeys = confessionTagsTable.foreignKeys;
+      for (const foreignKey of foreignKeys) {
+        await queryRunner.dropForeignKey('confession_tags', foreignKey);
+      }
+    }
+
+    // Drop indexes
+    await queryRunner.dropIndex(
+      'confession_tags',
+      'IDX_confession_tags_confession_tag_unique',
+    );
+    await queryRunner.dropIndex(
+      'confession_tags',
+      'IDX_confession_tags_tag_id',
+    );
+    await queryRunner.dropIndex(
+      'confession_tags',
+      'IDX_confession_tags_confession_id',
+    );
+    await queryRunner.dropIndex('tags', 'IDX_tags_name');
+
+    // Drop tables
+    await queryRunner.dropTable('confession_tags');
+    await queryRunner.dropTable('tags');
+  }
+}

--- a/xconfess-backend/src/confession/confession.controller.ts
+++ b/xconfess-backend/src/confession/confession.controller.ts
@@ -1,7 +1,15 @@
-
 import {
-  Controller, Get, Post, Put, Delete,
-  Body, Param, Query, Req, UsePipes, ValidationPipe,
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  Req,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { ConfessionService } from './confession.service';
 import { CreateConfessionDto } from './dto/create-confession.dto';
@@ -9,6 +17,7 @@ import { UpdateConfessionDto } from './dto/update-confession.dto';
 import { GetConfessionsDto } from './dto/get-confessions.dto';
 import { SearchConfessionDto } from './dto/search-confession.dto';
 import { AnchorConfessionDto } from '../stellar/dto/anchor-confession.dto';
+import { GetConfessionsByTagDto } from './dto/get-confessions-by-tag.dto';
 import { Request } from 'express';
 
 @Controller('confessions')
@@ -48,6 +57,17 @@ export class ConfessionController {
     return this.service.getTrendingConfessions();
   }
 
+  @Get('tags')
+  getAllTags() {
+    return this.service.getAllTags();
+  }
+
+  @Get('tags/:tag')
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  getByTag(@Param('tag') tag: string, @Query() dto: GetConfessionsByTagDto) {
+    return this.service.getConfessionsByTag(tag, dto);
+  }
+
   @Get(':id')
   getById(@Param('id') id: string, @Req() req: Request) {
     return this.service.getConfessionByIdWithViewCount(id, req);
@@ -60,10 +80,7 @@ export class ConfessionController {
 
   @Post(':id/anchor')
   @UsePipes(new ValidationPipe({ whitelist: true }))
-  anchorConfession(
-    @Param('id') id: string,
-    @Body() dto: AnchorConfessionDto,
-  ) {
+  anchorConfession(@Param('id') id: string, @Body() dto: AnchorConfessionDto) {
     return this.service.anchorConfession(id, dto);
   }
 

--- a/xconfess-backend/src/confession/confession.module.ts
+++ b/xconfess-backend/src/confession/confession.module.ts
@@ -1,12 +1,20 @@
 // src/confession/confession.module.ts
-import { Module, NestModule, MiddlewareConsumer, forwardRef } from '@nestjs/common';
+import {
+  Module,
+  NestModule,
+  MiddlewareConsumer,
+  forwardRef,
+} from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ConfessionController } from './confession.controller';
 import { ConfessionService } from './confession.service';
 import { AnonymousConfession } from './entities/confession.entity';
+import { Tag } from './entities/tag.entity';
+import { ConfessionTag } from './entities/confession-tag.entity';
 import { AnonymousConfessionRepository } from './repository/confession.repository';
 import { ConfessionViewCacheService } from './confession-view-cache.service';
+import { TagService } from './tag.service';
 import { ReactionModule } from '../reaction/reaction.module';
 import { AnonymousContextMiddleware } from '../middleware/anonymous-context.middleware';
 import { ModerationModule } from '../moderation/moderation.module';
@@ -27,7 +35,12 @@ class MockRedis {
     return 1;
   }
 
-  async set(key: string, value: string, _exFlag?: string, exSeconds?: number): Promise<string> {
+  async set(
+    key: string,
+    value: string,
+    _exFlag?: string,
+    exSeconds?: number,
+  ): Promise<string> {
     const expiry = exSeconds ? Date.now() + exSeconds * 1000 : undefined;
     this.store.set(key, { value, expiry });
     return 'OK';
@@ -46,7 +59,7 @@ class MockRedis {
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AnonymousConfession]),
+    TypeOrmModule.forFeature([AnonymousConfession, Tag, ConfessionTag]),
     EventEmitterModule.forRoot(),
     forwardRef(() => ReactionModule),
     ModerationModule,
@@ -58,6 +71,7 @@ class MockRedis {
     ConfessionService,
     AnonymousConfessionRepository,
     ConfessionViewCacheService,
+    TagService,
     { provide: 'VIEW_CACHE_EXPIRY', useValue: 60 * 60 },
     // Mock Redis provider for development without Redis server
     { provide: REDIS_TOKEN, useValue: new MockRedis() },

--- a/xconfess-backend/src/confession/dto/create-confession.dto.ts
+++ b/xconfess-backend/src/confession/dto/create-confession.dto.ts
@@ -4,6 +4,8 @@ import {
   IsOptional,
   IsEnum,
   MaxLength,
+  IsArray,
+  ArrayMaxSize,
 } from 'class-validator';
 import { Gender } from './get-confessions.dto';
 
@@ -26,6 +28,12 @@ export class CreateConfessionDto {
   @IsNotEmpty()
   @MaxLength(5000)
   body: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(3, { message: 'Maximum 3 tags allowed per confession' })
+  @IsString({ each: true })
+  tags?: string[];
 
   @IsOptional()
   @IsString()

--- a/xconfess-backend/src/confession/dto/get-confessions-by-tag.dto.ts
+++ b/xconfess-backend/src/confession/dto/get-confessions-by-tag.dto.ts
@@ -1,0 +1,22 @@
+import { IsString, IsOptional, IsInt, Min, Max, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SortOrder } from './get-confessions.dto';
+
+export class GetConfessionsByTagDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sort?: SortOrder;
+}

--- a/xconfess-backend/src/confession/entities/confession-tag.entity.ts
+++ b/xconfess-backend/src/confession/entities/confession-tag.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { AnonymousConfession } from './confession.entity';
+import { Tag } from './tag.entity';
+
+@Entity('confession_tags')
+@Index(['confession', 'tag'], { unique: true })
+export class ConfessionTag {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(
+    () => AnonymousConfession,
+    (confession) => confession.confessionTags,
+    {
+      onDelete: 'CASCADE',
+    },
+  )
+  @JoinColumn({ name: 'confession_id' })
+  @Index()
+  confession: AnonymousConfession;
+
+  @ManyToOne(() => Tag, (tag) => tag.confessionTags, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'tag_id' })
+  @Index()
+  tag: Tag;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
+}

--- a/xconfess-backend/src/confession/entities/confession.entity.ts
+++ b/xconfess-backend/src/confession/entities/confession.entity.ts
@@ -13,6 +13,7 @@ import { Reaction } from '../../reaction/entities/reaction.entity';
 import { AnonymousUser } from '../../user/entities/anonymous-user.entity';
 import { Gender } from '../dto/get-confessions.dto';
 import { Comment } from '../../comment/entities/comment.entity';
+import { ConfessionTag } from './confession-tag.entity';
 
 @Entity('anonymous_confessions')
 export class AnonymousConfession {
@@ -36,10 +37,14 @@ export class AnonymousConfession {
   @CreateDateColumn({ name: 'created_at' })
   created_at: Date;
 
-  @ManyToOne(() => AnonymousUser, (anonymousUser) => anonymousUser.confessions, {
-    nullable: false,
-    onDelete: 'CASCADE',
-  })
+  @ManyToOne(
+    () => AnonymousUser,
+    (anonymousUser) => anonymousUser.confessions,
+    {
+      nullable: false,
+      onDelete: 'CASCADE',
+    },
+  )
   @JoinColumn({ name: 'anonymous_user_id' })
   anonymousUser: AnonymousUser;
 
@@ -52,8 +57,16 @@ export class AnonymousConfession {
   @OneToMany(() => Comment, (comment) => comment.confession)
   comments: Comment[];
 
+  @OneToMany(() => ConfessionTag, (confessionTag) => confessionTag.confession)
+  confessionTags: ConfessionTag[];
+
   // Moderation fields
-  @Column('decimal', { name: 'moderation_score', precision: 5, scale: 4, default: 0 })
+  @Column('decimal', {
+    name: 'moderation_score',
+    precision: 5,
+    scale: 4,
+    default: 0,
+  })
   moderationScore: number;
 
   @Column('simple-array', { name: 'moderation_flags', default: '' })

--- a/xconfess-backend/src/confession/entities/tag.entity.ts
+++ b/xconfess-backend/src/confession/entities/tag.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  OneToMany,
+  Index,
+} from 'typeorm';
+import { ConfessionTag } from './confession-tag.entity';
+
+@Entity('tags')
+export class Tag {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 50, unique: true })
+  @Index()
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
+
+  @OneToMany(() => ConfessionTag, (confessionTag) => confessionTag.tag)
+  confessionTags: ConfessionTag[];
+}

--- a/xconfess-backend/src/confession/tag.service.ts
+++ b/xconfess-backend/src/confession/tag.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Tag } from './entities/tag.entity';
+
+@Injectable()
+export class TagService {
+  constructor(
+    @InjectRepository(Tag)
+    private readonly tagRepository: Repository<Tag>,
+  ) {}
+
+  /**
+   * Get all available tags
+   */
+  async getAllTags(): Promise<Tag[]> {
+    return this.tagRepository.find({
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * Validate that the provided tag names exist in the database
+   * @param tagNames Array of tag names to validate
+   * @returns Array of Tag entities
+   * @throws BadRequestException if any tag is invalid
+   */
+  async validateTags(tagNames: string[]): Promise<Tag[]> {
+    if (!tagNames || tagNames.length === 0) {
+      return [];
+    }
+
+    // Normalize tag names (lowercase, trim)
+    const normalizedNames = tagNames.map((name) => name.toLowerCase().trim());
+
+    // Remove duplicates
+    const uniqueNames = [...new Set(normalizedNames)];
+
+    // Check max limit
+    if (uniqueNames.length > 3) {
+      throw new BadRequestException('Maximum 3 tags allowed per confession');
+    }
+
+    // Find tags in database
+    const tags = await this.tagRepository.find({
+      where: { name: In(uniqueNames) },
+    });
+
+    // Check if all tags were found
+    if (tags.length !== uniqueNames.length) {
+      const foundNames = tags.map((tag) => tag.name);
+      const invalidTags = uniqueNames.filter(
+        (name) => !foundNames.includes(name),
+      );
+      throw new BadRequestException(
+        `Invalid tags: ${invalidTags.join(', ')}. Please use only predefined tags.`,
+      );
+    }
+
+    return tags;
+  }
+
+  /**
+   * Get a single tag by name
+   */
+  async getTagByName(name: string): Promise<Tag | null> {
+    return this.tagRepository.findOne({
+      where: { name: name.toLowerCase().trim() },
+    });
+  }
+
+  /**
+   * Get popular tags (most used)
+   * This is a placeholder for future enhancement
+   */
+  async getPopularTags(limit: number = 10): Promise<Tag[]> {
+    // For now, just return all tags
+    // In the future, we can join with confession_tags and count
+    return this.tagRepository.find({
+      take: limit,
+      order: { name: 'ASC' },
+    });
+  }
+}


### PR DESCRIPTION
Introduced a comprehensive tagging system that allows users to categorize confessions using predefined tags. This improves content discovery, filtering, and overall user experience.

---

##  Features

* ✅ Users can add **up to 3 tags** per confession
* ✅ **10 predefined tags**:

  * `funny`
  * `sad`
  * `inspiring`
  * `love`
  * `heartbreak`
  * `advice`
  * `confession`
  * `rant`
  * `grateful`
  * `regret`
* ✅ Tag validation with clear, helpful error messages
* ✅ Filter confessions by tag with **pagination support**
* ✅ Optimized database queries with proper indexing

---

## 

closes #66 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Tags system**: Users can now tag confessions with up to 3 tags to improve organization and discoverability.
* **Filter by tag**: New ability to browse and filter confessions by specific tags with pagination support.
* **View available tags**: Users can access the complete list of available tags in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->