### PR TITLE
feat: add user profile with statistics and badges

### DIFF
--- a/xconfess-frontend/app/components/profile/ProfileHeader.tsx
+++ b/xconfess-frontend/app/components/profile/ProfileHeader.tsx
@@ -13,7 +13,7 @@ const ProfileHeader = ({ profile }: Props) => {
       />
       <div>
         <h1 className="text-3xl font-bold">{profile.isAnonymous ? "Anonymous" : profile.username}</h1>
-        <p className="text-gray-400 text-sm">Member of LogiQuest</p>
+        <p className="text-gray-400 text-sm">Member of Xconfess</p>
       </div>
     </div>
   );

--- a/xconfess-frontend/app/components/profile/ProfileSettings.tsx
+++ b/xconfess-frontend/app/components/profile/ProfileSettings.tsx
@@ -13,7 +13,6 @@ const ProfileSettings = ({ profile, saveProfile }: Props) => {
     await saveProfile({ isAnonymous });
     alert("Profile updated!");
   };
-
   return (
     <div className="p-6 bg-gray-800 rounded space-y-4">
       <h2 className="text-xl font-bold">Profile Settings</h2>

--- a/xconfess-frontend/app/components/profile/ProfileStats.tsx
+++ b/xconfess-frontend/app/components/profile/ProfileStats.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { UserStats } from "../../api/user.api";
 
 interface Props { stats: UserStats; }
-
 const ProfileStats = ({ stats }: Props) => {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">


### PR DESCRIPTION
close#96

Adds a user profile page showing confession history, reaction stats, earned badges, and account settings while fully respecting user anonymity and privacy preferences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined profile component formatting and updated membership organization display in user profiles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->