### PR TITLE
normalize JWT request user payload shape

### DIFF
--- a/xconfess-backend/src/auth/get-user.decorator.ts
+++ b/xconfess-backend/src/auth/get-user.decorator.ts
@@ -3,6 +3,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 export const GetUser = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
-    return request.user;
+    const user = request.user;
+    return data ? user?.[data] : user;
   },
-); 
+);

--- a/xconfess-backend/src/auth/jwt.strategy.ts
+++ b/xconfess-backend/src/auth/jwt.strategy.ts
@@ -18,6 +18,6 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   async validate(payload: any) {
     // Fetch the user from the database to get role
     const user = await this.userService.findById(payload.sub);
-    return { userId: payload.sub, username: payload.username, role: user?.role || UserRole.USER };
+    return { id: payload.sub, username: payload.username, role: user?.role || UserRole.USER };
   }
 }


### PR DESCRIPTION
The Problem
The JwtStrategy was returning inconsistent field names (sometimes userId, sometimes id), causing @GetUser() to fail or return undefined when services expected a specific key.

The Solution (The Canonical Contract)
Standardized Strategy: Updated JwtStrategy.validate to always return { id: payload.sub }. This ensures req.user.id is the single source of truth.

Smart Decorator: Enhanced @GetUser() to allow direct extraction (e.g., @GetUser('id')), making controller signatures cleaner and type-safe.

Controller Refactor: * Switched from passing the whole User object to passing the userId string.

Introduced formatUserResponse() to centralize the decryption logic for emailEncrypted.

Ensured sensitive operations fetch fresh data from the database using the canonical id instead of relying on potentially stale JWT payload data.

Service Alignment: Updated MessagesService and UserService methods to consistently accept userId: string.

Key Benefits
Consistency: No more guessing between id and userId.

Security: Decryption logic is now centralized and performed on fresh database records.

Performance: The JWT payload remains lean, containing only the identifier and essential claims.

closeId #190 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal API consistency and code reusability across authentication and user management endpoints. Changes streamline how user data is processed and returned internally, with no impact to external API behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->