### PR TITLE
define auth policy for report creation endpoint

### DIFF
--- a/xconfess-backend/API_DOCUMENTATION.md
+++ b/xconfess-backend/API_DOCUMENTATION.md
@@ -247,3 +247,9 @@ DB_DATABASE=xconfess
 JWT_SECRET=your-jwt-secret
 JWT_EXPIRES_IN=3600s
 ``` 
+
+## Auth Policy
+
+Scenario,Header,Result
+Authenticated,Authorization: Bearer <JWT>,Report is linked to your account (reporterId saved).
+Anonymous,(None),Report is accepted as anonymous (reporterId is null).

--- a/xconfess-backend/src/auth/optional-jwt-auth.guard.ts
+++ b/xconfess-backend/src/auth/optional-jwt-auth.guard.ts
@@ -12,7 +12,7 @@ export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
     // If a token was present but invalid, let the error bubble up.
     if (err) return super.handleRequest(err, user, info, context, status);
     // If there's no user (no token), just proceed as anonymous.
-    return user ?? null;
+    return user || null;
   }
 }
 

--- a/xconfess-backend/src/report/reports.controller.ts
+++ b/xconfess-backend/src/report/reports.controller.ts
@@ -3,24 +3,25 @@ import {
   Post,
   Param,
   Body,
-  Req,
-  ParseIntPipe,
+  UseGuards,
 } from '@nestjs/common';
 import { ReportsService } from './reports.service';
 import { CreateReportDto } from './dto/create-report.dto';
+import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
+import { GetUser } from '../auth/get-user.decorator';
 
 @Controller('confessions')
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 
-@Post(':id/report')
-async reportConfession(
-  @Param('id') id: string,   // ✅ MUST be string (UUID)
-  @Req() req: any,
-  @Body() dto: CreateReportDto,
-) {
-  const reporterId = req.user?.id ?? null;
-  return this.reportsService.createReport(id, reporterId, dto);
-}
-
+  @Post(':id/report')
+  @UseGuards(OptionalJwtAuthGuard) // 🛡️ Allows both Guest and Auth users
+  async reportConfession(
+    @Param('id') id: string, // ✅ Standardized UUID
+    @GetUser('id') reporterId: number | null, // ✅ Standardized Canonical ID
+    @Body() dto: CreateReportDto,
+  ) {
+    // If user is not logged in, reporterId will be null via the OptionalGuard logic
+    return this.reportsService.createReport(id, reporterId, dto);
+  }
 }


### PR DESCRIPTION
[x] File: xconfess-backend/src/auth/optional-jwt-auth.guard.ts (New guard created)

[x] File: xconfess-backend/src/report/reports.controller.ts (Applied guard and @GetUser('id'))

[x] File: xconfess-backend/src/report/reports.service.ts (Updated reporterId to string | null)

[x] File: xconfess-backend/API_DOCUMENTATION.md (Markdown documentation updated)

closeId #210 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Auth Policy section to API documentation detailing authenticated and anonymous user access behavior and handling.

* **Bug Fixes**
  * Improved guest and authenticated user handling in report submissions.
  * Enhanced authentication validation for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->