### PR TITLE
fix: restore npm-only workflow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ contracts/soroban-xconfess/
 
 - **Node.js** (v18+)
 - **PostgreSQL** (v14+)
-- **pnpm** or **npm**
+- **npm**
 - **Rust** (for Soroban development)
 - **Stellar CLI** (optional, for contract deployment)
 

--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "concurrently": "^8.2.2"
-  }
+  },
+  "packageManager": "npm@10.9.0"
 }

--- a/xconfess-frontend/README.md
+++ b/xconfess-frontend/README.md
@@ -6,12 +6,6 @@ First, run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation prerequisites to specify npm as the sole supported package manager.
  * Removed alternative development start commands; npm run dev is now the only documented method to start development.

* **Chores**
  * Added npm@10.9.0 package manager specification to project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->