### PR TITLE
fix(backend): enforce report dedupe with DB-level constraint (#209)

### DIFF
--- a/xconfess-backend/migrations/20260221-add-report-dedupe-constraint.ts
+++ b/xconfess-backend/migrations/20260221-add-report-dedupe-constraint.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Enforce report deduplication at DB level.
+ * Prevents concurrent duplicate reports from the same user for the same confession.
+ * Partial unique index: applies only when reporter_id IS NOT NULL (logged-in users).
+ * Anonymous reports (reporter_id IS NULL) continue to use app-level dedupe.
+ */
+export class AddReportDedupeConstraint20260221 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_reports_dedupe_confession_reporter
+      ON reports(confession_id, reporter_id)
+      WHERE reporter_id IS NOT NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS idx_reports_dedupe_confession_reporter;
+    `);
+  }
+}


### PR DESCRIPTION
- Add partial unique index idx_reports_dedupe_confession_reporter on (confession_id, reporter_id) WHERE reporter_id IS NOT NULL
- Handle PostgreSQL 23505 unique violation in ReportsService.createReport
- Return clear duplicate-report message on conflict
- Fix merge conflict, duplicate imports, and resolvedBy property name
close #209 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate reports to prevent users from reporting the same item multiple times.
  * Enhanced error messages when attempting to submit duplicate reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->