### PR TITLE
fix(backend): normalize confession owner relation usage (anonymousUse…

### DIFF
--- a/xconfess-backend/src/confession/entities/confession.entity.ts
+++ b/xconfess-backend/src/confession/entities/confession.entity.ts
@@ -37,6 +37,11 @@ export class AnonymousConfession {
   @CreateDateColumn({ name: 'created_at' })
   created_at: Date;
 
+  /**
+   * Owner relation - use anonymousUser, NOT user.
+   * The confession entity defines owner relation as anonymousUser.
+   * Always use confession.anonymousUser for ownership checks and relation loading.
+   */
   @ManyToOne(
     () => AnonymousUser,
     (anonymousUser) => anonymousUser.confessions,

--- a/xconfess-backend/src/messages/messages.service.ts
+++ b/xconfess-backend/src/messages/messages.service.ts
@@ -31,6 +31,7 @@ export class MessagesService {
   ): Promise<Message> {
     const confession = await this.confessionRepository.findOne({
       where: { id: String(createMessageDto.confession_id) },
+      relations: ['anonymousUser'],
     });
     if (!confession) throw new NotFoundException('Confession not found');
 

--- a/xconfess-backend/src/reaction/reaction.service.ts
+++ b/xconfess-backend/src/reaction/reaction.service.ts
@@ -22,6 +22,7 @@ export class ReactionService {
   async createReaction(dto: CreateReactionDto): Promise<Reaction> {
     const confession = await this.confessionRepo.findOne({
       where: { id: dto.confessionId },
+      relations: ['anonymousUser'],
     });
 
     if (!confession) {


### PR DESCRIPTION
…r vs user)

- Add relations: ['anonymousUser'] to confession queries in messages.service.create()
- Add relations: ['anonymousUser'] to confession queries in reaction.service.createReaction()
- Add documentation comment to confession entity clarifying anonymousUser relation usage
- Ensure all confession queries that need owner relation load anonymousUser correctly

This fixes runtime access to non-existent confession.user and ensures ownership checks use valid relation data. Relation-based queries now load expected owner record.

Closes #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized data retrieval for confession-related operations to improve backend performance and reliability.
  * Enhanced consistency in how confession data is loaded and accessed across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->