### PR TITLE
Feat frontend emoji literal-Replace emoji literals with Icon components in ReactionButtons

### DIFF
--- a/xconfess-frontend/app/components/confession/ReactionButtons.tsx
+++ b/xconfess-frontend/app/components/confession/ReactionButtons.tsx
@@ -51,17 +51,13 @@ export const ReactionButton = ({
       disabled={isPending}
       aria-label={`React with ${type}`}
       className={cn(
-        "relative flex items-center gap-2 px-4 py-2 rounded-full justify-center touch-manipulation",
-        "min-w-11 min-h-11",
-        "transition-all duration-200 ease-out",
-        "bg-zinc-800 hover:bg-zinc-700",
-        "active:scale-95",
+        "relative flex items-center gap-2 px-4 py-2 rounded-full justify-center touch-manipulation min-w-11 min-h-11 transition-all duration-200 ease-out bg-zinc-800 active:scale-95",
         active && (type !== "like" ? "bg-pink-600 text-white" : "bg-blue-600 text-white"),
         isAnimating && "animate-reaction-bounce",
         type !== "like" ? "hover:bg-pink-700" : "hover:bg-blue-700"
       )}
     >
-      <span className="text-lg select-none text-inherit">
+      <span className="select-none">
         <Icon size={18} />
       </span>
 


### PR DESCRIPTION
**refactor: update ReactionButton component to use icons and improve styling**

closes #214 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reaction buttons now use icon graphics instead of emoji for a cleaner look.
  * Updated sizing and spacing for reaction controls for more consistent layout.
  * Enhanced hover states with distinct visual feedback per reaction type.
  * Text and icon color/spacing behavior aligned for improved readability and interaction consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->