### PR TITLE
fix: replace hard reload auth redirect with router-aware flow (#263)

### DIFF
--- a/xconfess-frontend/app/(dashboard)/layout.tsx
+++ b/xconfess-frontend/app/(dashboard)/layout.tsx
@@ -1,14 +1,19 @@
 import Header from "@/app/components/layout/Header";
+import { AuthGuard } from "@/app/components/AuthGuard";
 
 export default function DashboardLayout({
-  children,
+	children,
 }: {
-  children: React.ReactNode;
+	children: React.ReactNode;
 }) {
-  return (
-    <div className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">
-      <Header />
-      <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6">{children}</main>
-    </div>
-  );
+	return (
+		<AuthGuard>
+			<div className='min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100'>
+				<Header />
+				<main className='mx-auto max-w-3xl px-4 py-8 sm:px-6'>
+					{children}
+				</main>
+			</div>
+		</AuthGuard>
+	);
 }

--- a/xconfess-frontend/app/lib/api/client.ts
+++ b/xconfess-frontend/app/lib/api/client.ts
@@ -1,100 +1,101 @@
-import axios, { AxiosError, AxiosResponse } from 'axios';
-import { logError, getErrorMessage } from '@/app/lib/utils/errorHandler';
-import { AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY } from './constants';
+import axios, { AxiosError, AxiosResponse } from "axios";
+import { logError, getErrorMessage } from "@/app/lib/utils/errorHandler";
+import { AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY } from "./constants";
+import { useAuthStore } from "@/app/lib/store/authStore";
 
 const apiClient = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
-  headers: { 'Content-Type': 'application/json' },
-  timeout: 30000, // 30 second timeout
+	baseURL: process.env.NEXT_PUBLIC_API_URL,
+	headers: { "Content-Type": "application/json" },
+	timeout: 30000,
 });
 
 // Request interceptor for adding auth token
 apiClient.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem(AUTH_TOKEN_KEY);
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    logError(error, 'API Request Interceptor');
-    return Promise.reject(error);
-  }
+	(config) => {
+		const token = localStorage.getItem(AUTH_TOKEN_KEY);
+		if (token) {
+			config.headers.Authorization = `Bearer ${token}`;
+		}
+		return config;
+	},
+	(error) => {
+		logError(error, "API Request Interceptor");
+		return Promise.reject(error);
+	},
 );
 
 // Extend AxiosRequestConfig to support per-request retry tracking
-declare module 'axios' {
-  interface InternalAxiosRequestConfig {
-    __retryCount?: number;
-  }
+declare module "axios" {
+	interface InternalAxiosRequestConfig {
+		__retryCount?: number;
+	}
 }
 
 const MAX_RETRIES = 3;
 
 // Response interceptor for error handling and retries
 apiClient.interceptors.response.use(
-  (response: AxiosResponse) => response,
-  async (error: AxiosError) => {
-    const config = error.config;
-    if (!config) {
-      return Promise.reject(error);
-    }
+	(response: AxiosResponse) => response,
+	async (error: AxiosError) => {
+		const config = error.config;
+		if (!config) {
+			return Promise.reject(error);
+		}
 
-    // Initialize per-request retry count
-    config.__retryCount = config.__retryCount ?? 0;
+		config.__retryCount = config.__retryCount ?? 0;
 
-    // Handle 401 Unauthorized — no retry, redirect to login
-    if (error.response?.status === 401) {
-      localStorage.removeItem(AUTH_TOKEN_KEY);
-      localStorage.removeItem(REFRESH_TOKEN_KEY);
-      
-      // Redirect to login
-      if (typeof window !== 'undefined') {
-        window.location.href = '/login';
-      }
+		// Handle 401 Unauthorized — clear auth state and let AuthGuard handle redirect
+		if (error.response?.status === 401) {
+			// Signal the store: clears localStorage tokens + resets isAuthenticated.
+			// AuthGuard detects isAuthenticated: false and does router.push('/login').
+			useAuthStore.getState().logout();
 
-      logError(error, 'API Client - Unauthorized', { url: config.url });
-      return Promise.reject(error);
-    }
+			logError(error, "API Client - Unauthorized", { url: config.url });
+			return Promise.reject(error);
+		}
 
-    // Handle 403 Forbidden — no retry
-    if (error.response?.status === 403) {
-      logError(error, 'API Client - Forbidden', { url: config.url });
-      return Promise.reject(error);
-    }
+		// Handle 403 Forbidden — no retry
+		if (error.response?.status === 403) {
+			logError(error, "API Client - Forbidden", { url: config.url });
+			return Promise.reject(error);
+		}
 
-    // Determine if this error is retryable
-    const isRetryable =
-      error.response?.status === 429 ||
-      error.response?.status !== undefined && error.response.status >= 500 ||
-      !error.response; // network error
+		// Determine if this error is retryable
+		const isRetryable =
+			error.response?.status === 429 ||
+			(error.response?.status !== undefined &&
+				error.response.status >= 500) ||
+			!error.response; // network error
 
-    if (isRetryable && config.__retryCount < MAX_RETRIES) {
-      config.__retryCount++;
-      const delayMs = Math.pow(2, config.__retryCount) * 1000;
+		if (isRetryable && config.__retryCount < MAX_RETRIES) {
+			config.__retryCount++;
+			const delayMs = Math.pow(2, config.__retryCount) * 1000;
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+			return apiClient(config);
+		}
 
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-      return apiClient(config);
-    }
+		const context = !error.response
+			? "API Client - Network Error"
+			: error.response.status === 429
+				? "API Client - Too Many Requests"
+				: error.response.status >= 500
+					? "API Client - Server Error"
+					: "API Client - Request Failed";
 
-    // Log after retries exhausted or non-retryable error
-    const context = !error.response
-      ? 'API Client - Network Error'
-      : error.response.status === 429
-        ? 'API Client - Too Many Requests'
-        : error.response.status >= 500
-          ? 'API Client - Server Error'
-          : 'API Client - Request Failed';
+		logError(
+			error,
+			config.__retryCount > 0
+				? `${context} (after ${config.__retryCount} retries)`
+				: context,
+			{
+				url: config.url,
+				status: error.response?.status,
+				retries: config.__retryCount,
+			},
+		);
 
-    logError(error, config.__retryCount > 0 ? `${context} (after ${config.__retryCount} retries)` : context, {
-      url: config.url,
-      status: error.response?.status,
-      retries: config.__retryCount,
-    });
-
-    return Promise.reject(error);
-  }
+		return Promise.reject(error);
+	},
 );
 
 export default apiClient;


### PR DESCRIPTION
Closes #263

## Changes
- `client.ts`: Removed `window.location.href = '/login'` from the 401 handler. 
  Now calls `useAuthStore.getState().logout()` directly — this clears localStorage tokens 
  and resets `isAuthenticated` to false without a hard reload.
- `(dashboard)/layout.tsx`: Wrapped layout with `AuthGuard`, which already uses 
  `router.push('/login')` and handles the soft redirect when auth state drops.

## How redirect loops are prevented
`AuthGuard` only exists inside `(dashboard)/layout.tsx`. The `/login` and `/register` 
pages live under `(auth)/` and are never wrapped by it, so no loop is possible.

## Testing
- Trigger a 401 from any protected API call → app redirects to `/login` without full page reload
- App state (scroll position, non-auth store slices) is preserved across the redirect
- Logging in and out works normally
- Navigating directly to `/login` while unauthenticated does not loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard access now protected with authentication guard.

* **Bug Fixes**
  * Improved handling of unauthorized sessions with enhanced logout flow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->