### PR TITLE
feat(backend): cover core journey and align messaging/logging

### DIFF
--- a/xconfess-backend/src/common/crypto.util.ts
+++ b/xconfess-backend/src/common/crypto.util.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 
-const ENCRYPTION_KEY = process.env.EMAIL_ENCRYPTION_KEY || 'default_key_32_bytes_long_1234567890!';
+const ENCRYPTION_KEY =
+  process.env.EMAIL_ENCRYPTION_KEY || '0123456789abcdef0123456789abcdef';
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 

--- a/xconfess-backend/src/logger/logger.service.spec.ts
+++ b/xconfess-backend/src/logger/logger.service.spec.ts
@@ -1,18 +1,26 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { LoggerService } from './logger.service';
+import { AppLogger } from './logger.service';
 
-describe('LoggerService', () => {
-  let service: LoggerService;
+describe('AppLogger', () => {
+  let service: AppLogger;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [LoggerService],
-    }).compile();
-
-    service = module.get<LoggerService>(LoggerService);
+  beforeEach(() => {
+    service = new AppLogger();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should mask user ids inside object payloads', () => {
+    const payload = { userId: '1234567890abcdef', action: 'test' };
+    const sanitized = (service as any).sanitize(payload);
+
+    expect(sanitized).toEqual(
+      expect.objectContaining({
+        userId: expect.any(String),
+        action: 'test',
+      }),
+    );
+    expect(sanitized.userId).not.toBe(payload.userId);
   });
 });

--- a/xconfess-backend/src/logger/logger.service.ts
+++ b/xconfess-backend/src/logger/logger.service.ts
@@ -1,9 +1,15 @@
 // src/logger/logger.service.ts
-import { Injectable, LoggerService as NestLoggerService } from '@nestjs/common';
-import { UserIdMasker } from 'src/utils/mask-user-id';
+import {
+  Injectable,
+  Logger,
+  LoggerService as NestLoggerService,
+} from '@nestjs/common';
+import { UserIdMasker } from '../utils/mask-user-id';
 
 @Injectable()
 export class AppLogger implements NestLoggerService {
+  private readonly nestLogger = new Logger('AppLogger');
+
   /**
    * Sanitizes log message by masking any user IDs
    */
@@ -26,34 +32,40 @@ export class AppLogger implements NestLoggerService {
     return parts.length > 0 ? `[${parts.join('][')}]` : '[App]';
   }
 
+  private toLogPayload(
+    message: any,
+    context?: string,
+    requestId?: string,
+  ): { prefix: string; data: any } {
+    return {
+      prefix: this.formatPrefix(context, requestId),
+      data: this.sanitize(message),
+    };
+  }
+
   log(message: any, context?: string, requestId?: string) {
-    console.log(this.formatPrefix(context, requestId), this.sanitize(message));
+    const payload = this.toLogPayload(message, context, requestId);
+    this.nestLogger.log(payload, context);
   }
 
   error(message: any, trace?: string, context?: string, requestId?: string) {
-    console.error(
-      this.formatPrefix(context, requestId),
-      this.sanitize(message),
-      trace || '',
-    );
+    const payload = this.toLogPayload(message, context, requestId);
+    this.nestLogger.error(payload, trace, context);
   }
 
   warn(message: any, context?: string, requestId?: string) {
-    console.warn(this.formatPrefix(context, requestId), this.sanitize(message));
+    const payload = this.toLogPayload(message, context, requestId);
+    this.nestLogger.warn(payload, context);
   }
 
   debug(message: any, context?: string, requestId?: string) {
-    console.debug(
-      this.formatPrefix(context, requestId),
-      this.sanitize(message),
-    );
+    const payload = this.toLogPayload(message, context, requestId);
+    this.nestLogger.debug(payload, context);
   }
 
   verbose(message: any, context?: string, requestId?: string) {
-    console.log(
-      `[VERBOSE]${this.formatPrefix(context, requestId)}`,
-      this.sanitize(message),
-    );
+    const payload = this.toLogPayload(message, context, requestId);
+    this.nestLogger.verbose(payload, context);
   }
 
   /**

--- a/xconfess-backend/src/messages/dto/message.dto.ts
+++ b/xconfess-backend/src/messages/dto/message.dto.ts
@@ -24,3 +24,13 @@ export class ReplyMessageDto {
   @MaxLength(1000)
   reply: string;
 }
+
+export class GetMessagesQueryDto {
+  @ApiProperty({ description: 'UUID of the confession thread' })
+  @IsUUID()
+  confession_id: string;
+
+  @ApiProperty({ description: 'UUID of the sender anonymous user' })
+  @IsUUID()
+  sender_id: string;
+}

--- a/xconfess-backend/src/messages/dto/view-messages.dto.ts
+++ b/xconfess-backend/src/messages/dto/view-messages.dto.ts
@@ -1,6 +1,6 @@
-import { IsInt } from 'class-validator';
+import { IsUUID } from 'class-validator';
 
 export class ViewMessagesDto {
-  @IsInt()
-  confession_id: number;
+  @IsUUID()
+  confession_id: string;
 }

--- a/xconfess-backend/src/messages/messages.controller.ts
+++ b/xconfess-backend/src/messages/messages.controller.ts
@@ -5,10 +5,12 @@ import {
   UseGuards,
   Get,
   Query,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { MessagesService } from './messages.service';
-import { CreateMessageDto, ReplyMessageDto } from './dto/message.dto';
+import { CreateMessageDto, GetMessagesQueryDto, ReplyMessageDto } from './dto/message.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { NotificationQueue } from '../notification/notification.queue';
 import { GetUser } from '../auth/get-user.decorator';
@@ -28,6 +30,7 @@ export class MessagesController {
   @ApiOperation({ summary: 'Send an anonymous message to a confession author' })
   @ApiResponse({ status: 201, description: 'Message sent successfully' })
   @ApiResponse({ status: 404, description: 'Confession not found' })
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async sendMessage(@Body() dto: CreateMessageDto, @GetUser() user: User) {
     const message = await this.messagesService.create(dto, user);
     // Confessions are anonymous; no email notification is sent here.
@@ -39,6 +42,7 @@ export class MessagesController {
   @ApiOperation({ summary: 'Reply to an anonymous message (author only, single reply)' })
   @ApiResponse({ status: 200, description: 'Reply sent successfully' })
   @ApiResponse({ status: 403, description: 'Not the author or already replied' })
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async replyMessage(@Body() dto: ReplyMessageDto, @GetUser() user: User) {
     await this.messagesService.reply(dto, user);
     return { success: true };
@@ -58,14 +62,14 @@ export class MessagesController {
   @ApiQuery({ name: 'sender_id', required: true, description: 'Sender anonymous user ID' })
   @ApiResponse({ status: 200, description: 'Messages returned successfully' })
   @ApiResponse({ status: 403, description: 'Not part of this conversation' })
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async getMessages(
-    @Query('confession_id') confession_id: string,
-    @Query('sender_id') sender_id: string,
+    @Query() query: GetMessagesQueryDto,
     @GetUser() user: User,
   ) {
     const messages = await this.messagesService.findForConfessionThread(
-      confession_id,
-      sender_id,
+      query.confession_id,
+      query.sender_id,
       user,
     );
     // Hide sender info for anonymity

--- a/xconfess-backend/src/messages/messages.service.spec.ts
+++ b/xconfess-backend/src/messages/messages.service.spec.ts
@@ -128,7 +128,9 @@ describe('MessagesService', () => {
       jest.spyOn(userAnonRepo, 'find').mockResolvedValue([{ anonymousUserId: mockAnonId }] as any);
       const mockSave = jest.fn().mockImplementation((m) => Promise.resolve({ ...m }));
       const mockManager = { save: mockSave };
-      jest.spyOn(messageRepo.manager, 'transaction').mockImplementation(async (fn) => fn(mockManager) as any);
+      jest
+        .spyOn(messageRepo.manager as any, 'transaction')
+        .mockImplementation(async (fn: any) => fn(mockManager));
 
       await service.reply({ message_id: 1, reply: 'Got it!' }, mockUser);
       expect(message.hasReply).toBe(true);

--- a/xconfess-backend/src/messages/messages.service.ts
+++ b/xconfess-backend/src/messages/messages.service.ts
@@ -30,7 +30,7 @@ export class MessagesService {
     user: User,
   ): Promise<Message> {
     const confession = await this.confessionRepository.findOne({
-      where: { id: String(createMessageDto.confession_id) },
+      where: { id: createMessageDto.confession_id },
       relations: ['anonymousUser'],
     });
     if (!confession) throw new NotFoundException('Confession not found');

--- a/xconfess-backend/src/notification/notification.queue.spec.ts
+++ b/xconfess-backend/src/notification/notification.queue.spec.ts
@@ -2,32 +2,34 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { EmailService } from '../email/email.service';
 import { NotificationQueue } from './notification.queue';
+import { RecipientResolver } from './recipient-resolver.service';
+
+const addMock = jest.fn();
+const closeQueueMock = jest.fn();
+const closeWorkerMock = jest.fn();
+const onWorkerMock = jest.fn();
 
 jest.mock('bullmq', () => {
   return {
     Queue: jest.fn().mockImplementation(() => ({
-      add: jest.fn(),
-      close: jest.fn(),
+      add: addMock,
+      close: closeQueueMock,
     })),
     Worker: jest.fn().mockImplementation(() => ({
-      on: jest.fn(),
-      close: jest.fn(),
+      on: onWorkerMock,
+      close: closeWorkerMock,
     })),
   };
 });
 
 describe('NotificationQueue', () => {
   let service: NotificationQueue;
-  let emailService: EmailService;
 
   const mockConfigService = {
     get: jest.fn((key: string, defaultValue: any) => {
-      const config = {
-        REDIS_HOST: 'localhost',
-        REDIS_PORT: 6379,
-        FRONTEND_URL: 'http://localhost:3000',
-      };
-      return config[key] || defaultValue;
+      if (key === 'REDIS_HOST') return 'localhost';
+      if (key === 'REDIS_PORT') return 6379;
+      return defaultValue;
     }),
   };
 
@@ -35,20 +37,13 @@ describe('NotificationQueue', () => {
     sendCommentNotification: jest.fn(),
   };
 
-  const mockConfession: any = {
-    id: '123',
-    message: 'Test confession',
-    created_at: new Date(),
-  };
-
-  const mockComment: any = {
-    id: 1,
-    content: 'Test comment',
-    createdAt: new Date(),
-    confession: mockConfession,
+  const mockRecipientResolver = {
+    resolveRecipient: jest.fn(),
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         NotificationQueue,
@@ -60,52 +55,55 @@ describe('NotificationQueue', () => {
           provide: EmailService,
           useValue: mockEmailService,
         },
+        {
+          provide: RecipientResolver,
+          useValue: mockRecipientResolver,
+        },
       ],
     }).compile();
 
     service = module.get<NotificationQueue>(NotificationQueue);
-    emailService = module.get<EmailService>(EmailService);
   });
 
   afterEach(async () => {
     await service.onModuleDestroy();
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-
-  it('should enqueue a comment notification (queue.add)', async () => {
-    const payload = {
-      confession: mockConfession,
-      comment: mockComment,
-      recipientEmail: 'test@example.com',
-    };
-
-    await service.enqueueCommentNotification(payload);
-    // In unit tests we mock BullMQ; we just verify enqueue was called successfully.
-    expect(true).toBe(true);
-  });
-
-  it('should create an anonymized preview of the comment', async () => {
-    const longComment = {
-      ...mockComment,
-      content: 'This is a very long comment that should be truncated to create a preview. It contains more than 100 characters to test the truncation functionality.',
-    };
-
-    const payload = {
-      confession: mockConfession,
-      comment: longComment,
-      recipientEmail: 'test@example.com',
-    };
-
-    // Call the internal processor directly for deterministic unit testing.
-    await (service as any).processNotification(payload);
-
-    expect(mockEmailService.sendCommentNotification).toHaveBeenCalledWith({
-      to: 'test@example.com',
-      confessionId: mockConfession.id,
-      commentPreview: expect.stringMatching(/^This is a very long comment.*\.\.\.$/),
+  it('should enqueue a comment notification', async () => {
+    await service.enqueueCommentNotification({
+      confession: { id: 'conf-1' } as any,
+      comment: { id: 1, content: 'hello there' } as any,
+      recipientUserId: 42,
     });
+
+    expect(addMock).toHaveBeenCalledWith(
+      'comment-notification',
+      expect.objectContaining({
+        recipientUserId: 42,
+      }),
+      expect.objectContaining({
+        attempts: 3,
+      }),
+    );
   });
-}); 
+
+  it('should process and send comment notifications when recipient is resolvable', async () => {
+    mockRecipientResolver.resolveRecipient.mockResolvedValue({
+      email: 'test@example.com',
+      canNotify: true,
+    });
+
+    await (service as any).processCommentNotification({
+      confession: { id: 'conf-1' },
+      comment: { id: 1, content: 'A comment content for preview' },
+      recipientUserId: 42,
+    });
+
+    expect(mockEmailService.sendCommentNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'test@example.com',
+        confessionId: 'conf-1',
+      }),
+    );
+  });
+});

--- a/xconfess-backend/src/user/user.service.ts
+++ b/xconfess-backend/src/user/user.service.ts
@@ -52,6 +52,24 @@ export class UserService {
     }
   }
 
+  async findByUsername(username: string): Promise<User | null> {
+    try {
+      this.logger.debug(`Finding user by username`);
+      const normalizedUsername = username.trim();
+      const user = await this.userRepository.findOne({
+        where: { username: normalizedUsername },
+      });
+      return user;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Error finding user by username: ${errorMessage}`);
+      throw new InternalServerErrorException(
+        `Error finding user: ${errorMessage}`,
+      );
+    }
+  }
+
   async findById(id: number): Promise<User | null> {
     try {
       this.logger.debug(`Finding user by ID: ${id}`);

--- a/xconfess-backend/test/core-journey.e2e-spec.ts
+++ b/xconfess-backend/test/core-journey.e2e-spec.ts
@@ -1,0 +1,282 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { UserController } from '../src/user/user.controller';
+import { AuthController } from '../src/auth/auth.controller';
+import { ConfessionController } from '../src/confession/confession.controller';
+import { ReactionController } from '../src/reaction/reaction.controller';
+import { UserService } from '../src/user/user.service';
+import { AuthService } from '../src/auth/auth.service';
+import { ConfessionService } from '../src/confession/confession.service';
+import { ReactionService } from '../src/reaction/reaction.service';
+import { JwtAuthGuard } from '../src/auth/jwt-auth.guard';
+import { CryptoUtil } from '../src/common/crypto.util';
+import { UserRole } from '../src/user/entities/user.entity';
+
+describe('Core Journey (e2e)', () => {
+  let app: INestApplication;
+
+  const usersByEmail = new Map<string, any>();
+  const usersByUsername = new Map<string, any>();
+  const confessions: any[] = [];
+  const reactions: any[] = [];
+
+  const authorAnonId = '11111111-1111-4111-8111-111111111111';
+  const confessionId = '22222222-2222-4222-8222-222222222222';
+  const reactionId = '33333333-3333-4333-8333-333333333333';
+
+  const mockUserService = {
+    findByEmail: jest.fn(async (email: string) => usersByEmail.get(email) ?? null),
+    findByUsername: jest.fn(
+      async (username: string) => usersByUsername.get(username) ?? null,
+    ),
+    create: jest.fn(async (email: string, _password: string, username: string) => {
+      const encrypted = CryptoUtil.encrypt(email);
+      const user = {
+        id: 1,
+        username,
+        password: 'hashed',
+        emailEncrypted: encrypted.encrypted,
+        emailIv: encrypted.iv,
+        emailTag: encrypted.tag,
+        emailHash: CryptoUtil.hash(email),
+        role: UserRole.USER,
+        is_active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      usersByEmail.set(email, user);
+      usersByUsername.set(username, user);
+      return user;
+    }),
+    findById: jest.fn(async (id: number) => {
+      for (const user of usersByEmail.values()) {
+        if (user.id === id) return user;
+      }
+      return null;
+    }),
+  };
+
+  const mockAuthService = {
+    login: jest.fn(async (email: string) => {
+      const user = usersByEmail.get(email);
+      if (!user) {
+        throw new Error('Invalid credentials');
+      }
+      return {
+        access_token: 'test-access-token',
+        anonymousUserId: authorAnonId,
+        user: {
+          id: user.id,
+          username: user.username,
+          email,
+          role: user.role,
+          is_active: user.is_active,
+        },
+      };
+    }),
+    validateUserById: jest.fn(async (id: number) => {
+      const user = await mockUserService.findById(id);
+      if (!user) return null;
+      return {
+        id: user.id,
+        username: user.username,
+        email: 'core-journey@example.com',
+        role: user.role,
+        is_active: user.is_active,
+      };
+    }),
+  };
+
+  const mockConfessionService = {
+    create: jest.fn(async (dto: any) => {
+      const confession = {
+        id: confessionId,
+        message: dto.message,
+        gender: dto.gender ?? null,
+        created_at: new Date().toISOString(),
+      };
+      confessions.push(confession);
+      return confession;
+    }),
+    getConfessions: jest.fn(async () => ({
+      data: confessions,
+      meta: { total: confessions.length, page: 1, limit: 10, totalPages: 1 },
+    })),
+    search: jest.fn(),
+    fullTextSearch: jest.fn(),
+    getTrendingConfessions: jest.fn(async () => ({ data: [] })),
+    getAllTags: jest.fn(async () => []),
+    getConfessionsByTag: jest.fn(),
+    getDeletedConfessions: jest.fn(),
+    verifyStellarAnchor: jest.fn(),
+    anchorConfession: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    restore: jest.fn(),
+    getConfessionByIdWithViewCount: jest.fn(),
+  };
+
+  const mockReactionService = {
+    createReaction: jest.fn(async (dto: any) => {
+      const reaction = {
+        id: reactionId,
+        emoji: dto.emoji,
+        confession: { id: dto.confessionId },
+        anonymousUser: { id: dto.anonymousUserId },
+      };
+      reactions.push(reaction);
+      return reaction;
+    }),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [
+        UserController,
+        AuthController,
+        ConfessionController,
+        ReactionController,
+      ],
+      providers: [
+        { provide: UserService, useValue: mockUserService },
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: ConfessionService, useValue: mockConfessionService },
+        { provide: ReactionService, useValue: mockReactionService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context: any) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = { id: 1 };
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    usersByEmail.clear();
+    usersByUsername.clear();
+    confessions.length = 0;
+    reactions.length = 0;
+  });
+
+  it('covers register -> login -> guarded route -> create confession -> fetch feed -> react', async () => {
+    const registerResponse = await request(app.getHttpServer())
+      .post('/api/users/register')
+      .send({
+        username: 'core-journey-user',
+        email: 'core-journey@example.com',
+        password: 'password123',
+      })
+      .expect(201);
+
+    expect(registerResponse.body).toEqual(
+      expect.objectContaining({
+        user: expect.objectContaining({
+          id: 1,
+          username: 'core-journey-user',
+          email: 'core-journey@example.com',
+          is_active: true,
+        }),
+      }),
+    );
+
+    const loginResponse = await request(app.getHttpServer())
+      .post('/api/users/login')
+      .send({
+        email: 'core-journey@example.com',
+        password: 'password123',
+      })
+      .expect(200);
+
+    expect(loginResponse.body).toEqual(
+      expect.objectContaining({
+        access_token: expect.any(String),
+        anonymousUserId: authorAnonId,
+        user: expect.objectContaining({
+          id: 1,
+          username: 'core-journey-user',
+          email: 'core-journey@example.com',
+        }),
+      }),
+    );
+
+    const guardedResponse = await request(app.getHttpServer())
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${loginResponse.body.access_token}`)
+      .expect(200);
+
+    expect(guardedResponse.body).toEqual(
+      expect.objectContaining({
+        id: 1,
+        username: 'core-journey-user',
+        email: 'core-journey@example.com',
+      }),
+    );
+
+    const createConfessionResponse = await request(app.getHttpServer())
+      .post('/api/confessions')
+      .send({
+        title: 'Core journey',
+        body: 'This is my core journey confession',
+        message: 'This is my core journey confession',
+        gender: 'male',
+      })
+      .expect(201);
+
+    expect(createConfessionResponse.body).toEqual(
+      expect.objectContaining({
+        id: confessionId,
+        message: 'This is my core journey confession',
+      }),
+    );
+
+    const feedResponse = await request(app.getHttpServer())
+      .get('/api/confessions')
+      .query({ page: 1, limit: 10, sort: 'newest' })
+      .expect(200);
+
+    expect(feedResponse.body).toEqual(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            id: confessionId,
+            message: 'This is my core journey confession',
+          }),
+        ]),
+        meta: expect.objectContaining({ total: 1 }),
+      }),
+    );
+
+    const reactionResponse = await request(app.getHttpServer())
+      .post('/api/reactions')
+      .send({
+        confessionId,
+        anonymousUserId: authorAnonId,
+        emoji: 'like',
+      })
+      .expect(201);
+
+    expect(reactionResponse.body).toEqual(
+      expect.objectContaining({
+        id: reactionId,
+        emoji: 'like',
+        confession: expect.objectContaining({ id: confessionId }),
+        anonymousUser: expect.objectContaining({ id: authorAnonId }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
- add e2e core journey test for register/login/confession/feed/reaction

- enforce UUID validation for message confession thread endpoints

- refactor AppLogger away from direct console usage

- align user auth endpoints for /users register/login path

Closes #201

Closes #246

Closes #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User registration and login endpoints now available
  * Enhanced message querying with improved validation

* **Improvements**
  * Message API response now includes `messageId` field for easier reference
  * Strengthened input validation requiring UUID format for message queries
  * Better request tracking and user context in application logs

* **Tests**
  * Added comprehensive end-to-end test coverage for core user flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->