### PR TITLE
fix(backend): gate TypeORM synchronize by environment

### DIFF
--- a/xconfess-backend/README.md
+++ b/xconfess-backend/README.md
@@ -65,17 +65,41 @@ npm run test:cov
 Copy `.env.example` to `.env` and update the values:
 
 ```env
-DATABASE_URL=postgresql://user:pass@localhost:5432/xconfess
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_NAME=xconfess
 JWT_SECRET=your-secret-key
 PORT=5000
+NODE_ENV=development
+APP_ENV=local
+TYPEORM_SYNCHRONIZE=false
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 ```
 
+### TypeORM Synchronize Policy
+
+- Default is `false` in all environments.
+- Sync is enabled only when both conditions are true:
+  - environment is local/dev (`NODE_ENV` or `APP_ENV` is `local`/`dev`/`development`)
+  - `TYPEORM_SYNCHRONIZE=true`
+- In non-dev environments, schema sync remains disabled even if the flag is set.
+
 ## Database Migrations
 
+Migrations are the authoritative schema-evolution mechanism for non-dev environments.
+
 ```bash
+# generate a migration from local entity changes
+npm run migration:generate -- ./migrations/<migration-name>
+
+# apply pending migrations
 npm run migration:run
+
+# revert the latest migration (if needed)
+npm run migration:revert
 ```
 
 ## API Documentation

--- a/xconfess-backend/src/config/database.config.ts
+++ b/xconfess-backend/src/config/database.config.ts
@@ -2,21 +2,42 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 
-export const getTypeOrmConfig = (configService: ConfigService): TypeOrmModuleOptions => ({
-  type: 'postgres',
-  host: configService.get<string>('DB_HOST'),
-  port: configService.get<number>('DB_PORT'),
-  username: configService.get<string>('DB_USERNAME'),
-  password: configService.get<string>('DB_PASSWORD'),
-  database: configService.get<string>('DB_NAME'),
-  entities: [__dirname + '/../**/*.entity{.ts,.js}'],
-  synchronize: true, // Set to false in production!
-  autoLoadEntities: true,
-  extra: {
-    max: 20,
-    min: 5,
-    idleTimeoutMillis: 30000,
-    connectionTimeoutMillis: 2000,
-  },
-  logging: configService.get<string>('NODE_ENV') === 'development',
-});
+const TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
+
+export const getTypeOrmConfig = (
+  configService: ConfigService,
+): TypeOrmModuleOptions => {
+  const nodeEnv = (configService.get<string>('NODE_ENV') || '').toLowerCase();
+  const appEnv = (configService.get<string>('APP_ENV') || '').toLowerCase();
+  const syncOptIn = (configService.get<string>('TYPEORM_SYNCHRONIZE') || '').toLowerCase();
+
+  const isLocalDevEnv =
+    nodeEnv === 'development' ||
+    nodeEnv === 'dev' ||
+    nodeEnv === 'local' ||
+    appEnv === 'development' ||
+    appEnv === 'dev' ||
+    appEnv === 'local';
+
+  // Conservative default: never sync unless explicitly opted-in in local/dev only.
+  const synchronize = isLocalDevEnv && TRUE_VALUES.has(syncOptIn);
+
+  return {
+    type: 'postgres',
+    host: configService.get<string>('DB_HOST'),
+    port: configService.get<number>('DB_PORT'),
+    username: configService.get<string>('DB_USERNAME'),
+    password: configService.get<string>('DB_PASSWORD'),
+    database: configService.get<string>('DB_NAME'),
+    entities: [__dirname + '/../**/*.entity{.ts,.js}'],
+    synchronize,
+    autoLoadEntities: true,
+    extra: {
+      max: 20,
+      min: 5,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 2000,
+    },
+    logging: nodeEnv === 'development',
+  };
+};


### PR DESCRIPTION
close #216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Environment configuration now uses individual database variables instead of a single DATABASE_URL.
  * Added TypeORM schema synchronization policy documentation for local and production environments.
  * Documented database migration procedures for non-development deployments.
  * Clarified local Swagger API documentation accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->