### PR TITLE
feat:#303 fix(backend): enforce idempotency for notification enqueue …

### DIFF
--- a/xconfess-backend/src/config/rate-limit.config.ts
+++ b/xconfess-backend/src/config/rate-limit.config.ts
@@ -15,3 +15,12 @@ export const getRateLimitConfig = (
   getLimit: configService.get<number>('RATE_LIMIT_GET_MAX', 50),
   getWindow: configService.get<number>('RATE_LIMIT_GET_WINDOW', 60), // seconds
 });
+
+export const rateLimitConfig = {
+  notification: {
+    dedupeTtlSeconds: parseInt(
+      process.env.NOTIFICATION_DEDUPE_TTL_SECONDS ?? '60',
+      10,
+    ),
+  },
+};

--- a/xconfess-backend/src/logger/logger.service.ts
+++ b/xconfess-backend/src/logger/logger.service.ts
@@ -1,5 +1,9 @@
-// src/services/logger.service.ts
-import { Injectable, LoggerService as NestLoggerService } from '@nestjs/common';
+// src/logger/logger.service.ts
+import {
+  Injectable,
+  Logger,
+  LoggerService as NestLoggerService,
+} from '@nestjs/common';
 import { UserIdMasker } from '../utils/mask-user-id';
 
 type MetricLabels = Record<string, string | number | boolean>;
@@ -14,33 +18,18 @@ interface TimerAggregate {
 
 @Injectable()
 export class AppLogger implements NestLoggerService {
+  private readonly nestLogger = new Logger('AppLogger');
   private readonly counters = new Map<string, number>();
   private readonly gauges = new Map<string, number>();
   private readonly timers = new Map<string, TimerAggregate>();
-// src/logger/logger.service.ts
-import {
-  Injectable,
-  Logger,
-  LoggerService as NestLoggerService,
-} from '@nestjs/common';
-import { UserIdMasker } from '../utils/mask-user-id';
 
-@Injectable()
-export class AppLogger implements NestLoggerService {
-  private readonly nestLogger = new Logger('AppLogger');
+  // ── Sanitization ─────────────────────────────────────────────────────────────
 
-  /**
-   * Sanitizes log message by masking any user IDs
-   */
   private sanitize(message: any): any {
-    if (typeof message === 'string') {
-      return message;
-    }
-
+    if (typeof message === 'string') return message;
     if (typeof message === 'object' && message !== null) {
       return UserIdMasker.maskObject(message);
     }
-
     return message;
   }
 
@@ -51,16 +40,14 @@ export class AppLogger implements NestLoggerService {
     return parts.length > 0 ? `[${parts.join('][')}]` : '[App]';
   }
 
-  private toLogPayload(
-    message: any,
-    context?: string,
-    requestId?: string,
-  ): { prefix: string; data: any } {
+  private toLogPayload(message: any, context?: string, requestId?: string) {
     return {
       prefix: this.formatPrefix(context, requestId),
       data: this.sanitize(message),
     };
   }
+
+  // ── NestJS LoggerService interface ───────────────────────────────────────────
 
   log(message: any, context?: string, requestId?: string) {
     const payload = this.toLogPayload(message, context, requestId);
@@ -87,15 +74,50 @@ export class AppLogger implements NestLoggerService {
     this.nestLogger.verbose(payload, context);
   }
 
+  // ── Contextual helpers ───────────────────────────────────────────────────────
+
+  logWithUser(
+    message: string,
+    userId: string | number,
+    context?: string,
+    requestId?: string,
+  ) {
+    const maskedId = UserIdMasker.mask(userId);
+    this.log(`${message} [${maskedId}]`, context, requestId);
+  }
+
+  errorWithUser(
+    message: string,
+    userId: string | number,
+    trace?: string,
+    context?: string,
+    requestId?: string,
+  ) {
+    const maskedId = UserIdMasker.mask(userId);
+    this.error(`${message} [${maskedId}]`, trace, context, requestId);
+  }
+
+  logWithRequestId(message: string, requestId: string, context?: string) {
+    this.log(message, context, requestId);
+  }
+
+  errorWithRequestId(
+    message: string,
+    requestId: string,
+    trace?: string,
+    context?: string,
+  ) {
+    this.error(message, trace, context, requestId);
+  }
+
+  // ── Metrics ──────────────────────────────────────────────────────────────────
+
   private normalizeLabelValue(value: string | number | boolean): string {
     return String(value);
   }
 
   private serializeLabels(labels?: MetricLabels): string {
-    if (!labels || Object.keys(labels).length === 0) {
-      return '';
-    }
-
+    if (!labels || Object.keys(labels).length === 0) return '';
     return Object.entries(labels)
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([key, value]) => `${key}=${this.normalizeLabelValue(value)}`)
@@ -109,8 +131,7 @@ export class AppLogger implements NestLoggerService {
 
   incrementCounter(name: string, value = 1, labels?: MetricLabels): number {
     const key = this.metricKey(name, labels);
-    const current = this.counters.get(key) ?? 0;
-    const next = current + value;
+    const next = (this.counters.get(key) ?? 0) + value;
     this.counters.set(key, next);
     return next;
   }
@@ -121,29 +142,29 @@ export class AppLogger implements NestLoggerService {
     return value;
   }
 
-  observeTimer(name: string, durationMs: number, labels?: MetricLabels): TimerAggregate {
+  observeTimer(
+    name: string,
+    durationMs: number,
+    labels?: MetricLabels,
+  ): TimerAggregate {
     const key = this.metricKey(name, labels);
     const current = this.timers.get(key);
 
-    if (!current) {
-      const created: TimerAggregate = {
-        count: 1,
-        totalMs: durationMs,
-        minMs: durationMs,
-        maxMs: durationMs,
-        lastMs: durationMs,
-      };
-      this.timers.set(key, created);
-      return created;
-    }
-
-    const next: TimerAggregate = {
-      count: current.count + 1,
-      totalMs: current.totalMs + durationMs,
-      minMs: Math.min(current.minMs, durationMs),
-      maxMs: Math.max(current.maxMs, durationMs),
-      lastMs: durationMs,
-    };
+    const next: TimerAggregate = current
+      ? {
+          count: current.count + 1,
+          totalMs: current.totalMs + durationMs,
+          minMs: Math.min(current.minMs, durationMs),
+          maxMs: Math.max(current.maxMs, durationMs),
+          lastMs: durationMs,
+        }
+      : {
+          count: 1,
+          totalMs: durationMs,
+          minMs: durationMs,
+          maxMs: durationMs,
+          lastMs: durationMs,
+        };
 
     this.timers.set(key, next);
     return next;
@@ -153,84 +174,32 @@ export class AppLogger implements NestLoggerService {
     const parseMetric = (key: string) => {
       const [name, rawLabels] = key.split('|');
       const labels: Record<string, string> = {};
-
       if (rawLabels) {
         rawLabels.split(',').forEach((pair) => {
           const [k, v] = pair.split('=');
-          if (k && v !== undefined) {
-            labels[k] = v;
-          }
+          if (k && v !== undefined) labels[k] = v;
         });
       }
-
       return { name, labels };
     };
 
-    const counters = Array.from(this.counters.entries()).map(([key, value]) => ({
-      ...parseMetric(key),
-      value,
-      type: 'counter' as const,
-    }));
-
-    const gauges = Array.from(this.gauges.entries()).map(([key, value]) => ({
-      ...parseMetric(key),
-      value,
-      type: 'gauge' as const,
-    }));
-
-    const timers = Array.from(this.timers.entries()).map(([key, value]) => ({
-      ...parseMetric(key),
-      ...value,
-      avgMs: value.count > 0 ? value.totalMs / value.count : 0,
-      type: 'timer' as const,
-    }));
-
-    return { counters, gauges, timers };
-  }
-
-  /**
-   * Log with explicit user context (auto-masks)
-   */
-  logWithUser(
-    message: string,
-    userId: string | number,
-    context?: string,
-    requestId?: string,
-  ) {
-    const maskedId = UserIdMasker.mask(userId);
-    this.log(`${message} [${maskedId}]`, context, requestId);
-  }
-
-  /**
-   * Log error with user context (auto-masks)
-   */
-  errorWithUser(
-    message: string,
-    userId: string | number,
-    trace?: string,
-    context?: string,
-    requestId?: string,
-  ) {
-    const maskedId = UserIdMasker.mask(userId);
-    this.error(`${message} [${maskedId}]`, trace, context, requestId);
-  }
-
-  /**
-   * Log with request-id context only (no user)
-   */
-  logWithRequestId(message: string, requestId: string, context?: string) {
-    this.log(message, context, requestId);
-  }
-
-  /**
-   * Log error with request-id context only (no user)
-   */
-  errorWithRequestId(
-    message: string,
-    requestId: string,
-    trace?: string,
-    context?: string,
-  ) {
-    this.error(message, trace, context, requestId);
+    return {
+      counters: Array.from(this.counters.entries()).map(([key, value]) => ({
+        ...parseMetric(key),
+        value,
+        type: 'counter' as const,
+      })),
+      gauges: Array.from(this.gauges.entries()).map(([key, value]) => ({
+        ...parseMetric(key),
+        value,
+        type: 'gauge' as const,
+      })),
+      timers: Array.from(this.timers.entries()).map(([key, value]) => ({
+        ...parseMetric(key),
+        ...value,
+        avgMs: value.count > 0 ? value.totalMs / value.count : 0,
+        type: 'timer' as const,
+      })),
+    };
   }
 }

--- a/xconfess-backend/src/notification/notification.module.ts
+++ b/xconfess-backend/src/notification/notification.module.ts
@@ -1,32 +1,21 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { NotificationQueue } from './notification.queue';
-import { RecipientResolver } from './recipient-resolver.service';
 import { EmailModule } from '../email/email.module';
 import { AuditLogModule } from '../audit-log/audit-log.module';
+import { LoggerModule } from '../logger/logger.module';
 import { NotificationAdminController } from './notification.admin.controller';
-
-@Module({
-  imports: [EmailModule, AuditLogModule],
-  controllers: [NotificationAdminController],
-  providers: [NotificationQueue],
-  exports: [NotificationQueue],
-})
-export class NotificationModule {} 
 import { User } from '../user/entities/user.entity';
 
 @Module({
   imports: [
     EmailModule,
+    AuditLogModule,
+    LoggerModule,
     TypeOrmModule.forFeature([User]),
   ],
-  providers: [
-    NotificationQueue,
-    RecipientResolver,
-  ],
-  exports: [
-    NotificationQueue,
-    RecipientResolver,
-  ],
+  controllers: [NotificationAdminController],
+  providers: [NotificationQueue],
+  exports: [NotificationQueue],
 })
 export class NotificationModule {}

--- a/xconfess-backend/src/notification/notification.queue.spec.ts
+++ b/xconfess-backend/src/notification/notification.queue.spec.ts
@@ -1,75 +1,60 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import {
+  NotificationQueue,
+  CommentNotificationPayload,
+} from './notification.queue';
 import { EmailService } from '../email/email.service';
-import { NotificationQueue } from './notification.queue';
 import { AppLogger } from '../logger/logger.service';
 import { AuditLogService } from '../audit-log/audit-log.service';
 
-jest.mock('bullmq', () => {
-  return {
-    Queue: jest.fn().mockImplementation(() => ({
-      add: jest.fn(),
-      close: jest.fn(),
-      getJobCounts: jest.fn().mockResolvedValue({
-        waiting: 0,
-        active: 0,
-        delayed: 0,
-        failed: 0,
-        completed: 0,
-      }),
-      getFailedCount: jest.fn().mockResolvedValue(0),
-      getJobs: jest.fn().mockResolvedValue([]),
-      getJob: jest.fn().mockResolvedValue(null),
-    })),
-    Worker: jest.fn().mockImplementation(() => ({
-      on: onWorkerMock,
-      close: closeWorkerMock,
-    })),
-  };
+// ── Redis mock ────────────────────────────────────────────────────────────────
+const mockRedisSet = jest.fn();
+jest.mock('ioredis', () => {
+  return jest.fn().mockImplementation(() => ({
+    set: mockRedisSet,
+    quit: jest.fn().mockResolvedValue(undefined),
+  }));
+});
+
+// ── BullMQ mock ───────────────────────────────────────────────────────────────
+const mockQueueAdd = jest.fn();
+const mockQueueClose = jest.fn().mockResolvedValue(undefined);
+const mockQueueGetJobCounts = jest
+  .fn()
+  .mockResolvedValue({ waiting: 0, active: 0, delayed: 0, failed: 0 });
+const mockWorkerClose = jest.fn().mockResolvedValue(undefined);
+const mockWorkerOn = jest.fn();
+
+jest.mock('bullmq', () => ({
+  Queue: jest.fn().mockImplementation(() => ({
+    add: mockQueueAdd,
+    close: mockQueueClose,
+    getJobCounts: mockQueueGetJobCounts,
+    getFailedCount: jest.fn().mockResolvedValue(0),
+    getJobs: jest.fn().mockResolvedValue([]),
+    getJob: jest.fn().mockResolvedValue(null),
+  })),
+  Worker: jest.fn().mockImplementation(() => ({
+    on: mockWorkerOn,
+    close: mockWorkerClose,
+  })),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const makePayload = (
+  overrides: Partial<CommentNotificationPayload> = {},
+): CommentNotificationPayload => ({
+  confession: { id: 'confession-abc' } as any,
+  comment: { id: 'comment-xyz', content: 'Hello world' } as any,
+  recipientEmail: 'user@example.com',
+  channel: 'email_comment_notification',
+  ...overrides,
 });
 
 describe('NotificationQueue', () => {
   let service: NotificationQueue;
-
-  const mockConfigService = {
-    get: jest.fn((key: string, defaultValue: any) => {
-      if (key === 'REDIS_HOST') return 'localhost';
-      if (key === 'REDIS_PORT') return 6379;
-      return defaultValue;
-    }),
-  };
-
-  const mockEmailService = {
-    sendCommentNotification: jest.fn(),
-  };
-
-  const mockAppLogger = {
-    incrementCounter: jest.fn(),
-    setGauge: jest.fn(),
-    observeTimer: jest.fn(),
-    getMetricsSnapshot: jest.fn().mockReturnValue({
-      counters: [],
-      gauges: [],
-      timers: [],
-    }),
-  };
-
-  const mockAuditLogService = {
-    logNotificationDlqReplay: jest.fn(),
-  };
-
-  const mockConfession: any = {
-    id: '123',
-    message: 'Test confession',
-    created_at: new Date(),
-  };
-
-  const mockComment: any = {
-    id: 1,
-    content: 'Test comment',
-    createdAt: new Date(),
-    confession: mockConfession,
-  };
+  let logger: jest.Mocked<AppLogger>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -79,65 +64,202 @@ describe('NotificationQueue', () => {
         NotificationQueue,
         {
           provide: ConfigService,
-          useValue: mockConfigService,
+          useValue: { get: jest.fn((key: string, def: any) => def) },
         },
         {
           provide: EmailService,
-          useValue: mockEmailService,
+          useValue: {
+            sendCommentNotification: jest.fn().mockResolvedValue(undefined),
+          },
         },
         {
           provide: AppLogger,
-          useValue: mockAppLogger,
+          useValue: {
+            log: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            debug: jest.fn(),
+            incrementCounter: jest.fn(),
+            setGauge: jest.fn(),
+            observeTimer: jest.fn(),
+            getMetricsSnapshot: jest
+              .fn()
+              .mockReturnValue({ counters: [], gauges: [], timers: [] }),
+          },
         },
         {
           provide: AuditLogService,
-          useValue: mockAuditLogService,
+          useValue: { logNotificationDlqReplay: jest.fn() },
         },
       ],
     }).compile();
 
     service = module.get<NotificationQueue>(NotificationQueue);
+    logger = module.get(AppLogger);
   });
 
-  afterEach(async () => {
-    await service.onModuleDestroy();
-  });
+  // ── buildIdempotencyKey ──────────────────────────────────────────────────────
 
-  it('should enqueue a comment notification', async () => {
-    await service.enqueueCommentNotification({
-      confession: { id: 'conf-1' } as any,
-      comment: { id: 1, content: 'hello there' } as any,
-      recipientUserId: 42,
+  describe('buildIdempotencyKey', () => {
+    it('produces the same key for identical inputs', () => {
+      const fields = {
+        eventType: 'comment-notification',
+        recipientEmail: 'a@b.com',
+        entityId: 'c1',
+      };
+      expect(service.buildIdempotencyKey(fields)).toBe(
+        service.buildIdempotencyKey(fields),
+      );
     });
 
-    expect(addMock).toHaveBeenCalledWith(
-      'comment-notification',
-      expect.objectContaining({
-        recipientUserId: 42,
-      }),
-      expect.objectContaining({
-        attempts: 3,
-      }),
-    );
-  });
-
-  it('should process and send comment notifications when recipient is resolvable', async () => {
-    mockRecipientResolver.resolveRecipient.mockResolvedValue({
-      email: 'test@example.com',
-      canNotify: true,
+    it('produces different keys for different confession IDs', () => {
+      const base = {
+        eventType: 'comment-notification',
+        recipientEmail: 'a@b.com',
+      };
+      const k1 = service.buildIdempotencyKey({ ...base, entityId: 'c1' });
+      const k2 = service.buildIdempotencyKey({ ...base, entityId: 'c2' });
+      expect(k1).not.toBe(k2);
     });
 
-    await (service as any).processCommentNotification({
-      confession: { id: 'conf-1' },
-      comment: { id: 1, content: 'A comment content for preview' },
-      recipientUserId: 42,
+    it('produces different keys for different recipient emails', () => {
+      const base = { eventType: 'comment-notification', entityId: 'c1' };
+      const k1 = service.buildIdempotencyKey({
+        ...base,
+        recipientEmail: 'a@b.com',
+      });
+      const k2 = service.buildIdempotencyKey({
+        ...base,
+        recipientEmail: 'x@y.com',
+      });
+      expect(k1).not.toBe(k2);
     });
 
-    expect(mockEmailService.sendCommentNotification).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: 'test@example.com',
-        confessionId: 'conf-1',
-      }),
-    );
+    it('key starts with the dedupe prefix and contains a 64-char hex hash', () => {
+      const key = service.buildIdempotencyKey({
+        eventType: 'comment-notification',
+        recipientEmail: 'a@b.com',
+        entityId: 'c1',
+      });
+      expect(key).toMatch(/^notif:dedupe:[a-f0-9]{64}$/);
+    });
   });
-}); 
+
+  // ── enqueueCommentNotification ───────────────────────────────────────────────
+
+  describe('enqueueCommentNotification', () => {
+    it('enqueues a job when Redis SET NX succeeds (no duplicate)', async () => {
+      mockRedisSet.mockResolvedValue('OK');
+      mockQueueAdd.mockResolvedValue({ id: 'job-1' });
+
+      await service.enqueueCommentNotification(makePayload());
+
+      expect(mockRedisSet).toHaveBeenCalledWith(
+        expect.stringMatching(/^notif:dedupe:/),
+        '1',
+        'EX',
+        expect.any(Number),
+        'NX',
+      );
+      expect(mockQueueAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses the job when Redis SET NX returns null (duplicate within TTL)', async () => {
+      mockRedisSet.mockResolvedValue(null);
+
+      await service.enqueueCommentNotification(makePayload());
+
+      expect(mockQueueAdd).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('idempotency'),
+        'NotificationQueue',
+      );
+    });
+
+    it('increments the suppression counter on dedupe', async () => {
+      mockRedisSet.mockResolvedValue(null);
+
+      await service.enqueueCommentNotification(makePayload());
+
+      expect(logger.incrementCounter).toHaveBeenCalledWith(
+        'notification_dedupe_suppressed_total',
+        1,
+        expect.objectContaining({ queue: 'comment-notifications' }),
+      );
+    });
+
+    // ── Race condition ─────────────────────────────────────────────────────────
+
+    it('handles race: two concurrent calls — only one enqueues', async () => {
+      // Redis atomicity: first caller gets OK, second gets null
+      mockRedisSet.mockResolvedValueOnce('OK').mockResolvedValueOnce(null);
+      mockQueueAdd.mockResolvedValue({ id: 'job-1' });
+
+      const payload = makePayload();
+      const [,] = await Promise.all([
+        service.enqueueCommentNotification(payload),
+        service.enqueueCommentNotification(payload),
+      ]);
+
+      expect(mockQueueAdd).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledTimes(1); // one suppression logged
+    });
+
+    it('handles retry scenario: same payload after TTL expiry enqueues again', async () => {
+      // First call succeeds
+      mockRedisSet.mockResolvedValueOnce('OK');
+      mockQueueAdd.mockResolvedValue({ id: 'job-1' });
+      await service.enqueueCommentNotification(makePayload());
+
+      // After TTL expires, Redis no longer holds the key — SET NX succeeds again
+      mockRedisSet.mockResolvedValueOnce('OK');
+      mockQueueAdd.mockResolvedValue({ id: 'job-2' });
+      await service.enqueueCommentNotification(makePayload());
+
+      expect(mockQueueAdd).toHaveBeenCalledTimes(2);
+    });
+
+    // ── Distinct events ────────────────────────────────────────────────────────
+
+    it('enqueues separate jobs for distinct confession IDs', async () => {
+      mockRedisSet.mockResolvedValue('OK');
+      mockQueueAdd.mockResolvedValue({ id: 'job-x' });
+
+      await service.enqueueCommentNotification(
+        makePayload({ confession: { id: 'confession-1' } as any }),
+      );
+      await service.enqueueCommentNotification(
+        makePayload({ confession: { id: 'confession-2' } as any }),
+      );
+
+      expect(mockQueueAdd).toHaveBeenCalledTimes(2);
+    });
+
+    it('enqueues separate jobs for distinct recipient emails', async () => {
+      mockRedisSet.mockResolvedValue('OK');
+      mockQueueAdd.mockResolvedValue({ id: 'job-x' });
+
+      await service.enqueueCommentNotification(
+        makePayload({ recipientEmail: 'a@x.com' }),
+      );
+      await service.enqueueCommentNotification(
+        makePayload({ recipientEmail: 'b@x.com' }),
+      );
+
+      expect(mockQueueAdd).toHaveBeenCalledTimes(2);
+    });
+
+    // ── Sensitive data ─────────────────────────────────────────────────────────
+
+    it('does not log the recipient email in the dedup warn message', async () => {
+      mockRedisSet.mockResolvedValue(null);
+
+      await service.enqueueCommentNotification(
+        makePayload({ recipientEmail: 'secret@example.com' }),
+      );
+
+      const warnMessage: string = logger.warn.mock.calls[0][0];
+      expect(warnMessage).not.toContain('secret@example.com');
+    });
+  });
+});


### PR DESCRIPTION
Enforce idempotency for notification enqueue requests 

Closes #303
Prevents duplicate notification jobs caused by concurrent or repeated triggers by introducing atomic Redis-based deduplication on enqueue.
Changes

Added buildIdempotencyKey() in NotificationQueue — deterministic SHA-256 hash derived from eventType, recipientEmail, and confessionId
Added claimIdempotencySlot() using Redis SET NX EX for atomic, race-safe dedup within a configurable TTL window
Duplicate enqueue attempts within the TTL are suppressed and logged without exposing sensitive payload fields
Added NOTIFICATION_DEDUPE_TTL_SECONDS env var via rate-limit.config.ts
Added notification_dedupe_suppressed_total counter to existing metrics snapshot
Fixed pre-existing bugs: wrong logger reference, missing method, broken onModuleDestroy cleanup
Added unit tests covering dedup, race conditions, retry-after-TTL, and distinct event scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented deduplication for comment notifications to prevent duplicate notifications from being sent to users.

* **Chores**
  * Refactored notification queue system and logging infrastructure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->