### PR TITLE
feat(notification): add retry policy, DLQ handling, and admin visibility

### DIFF
--- a/xconfess-backend/src/notifications/dlq-admin.controller.ts
+++ b/xconfess-backend/src/notifications/dlq-admin.controller.ts
@@ -1,0 +1,112 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Delete,
+  Query,
+  NotFoundException,
+  // UseGuards,
+} from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue, Job } from 'bull';
+import { NotificationJobData, NOTIFICATION_DLQ, NOTIFICATION_QUEUE } from '../processors/notification.processor';
+// import { AdminGuard } from '../../auth/guards/admin.guard';
+
+interface DlqJobView {
+  id:           string | number | undefined;
+  userId:       string;
+  type:         string;
+  title:        string;
+  failedAt:     string | undefined;
+  attemptsMade: number | undefined;
+  lastError:    string | undefined;
+  enqueuedAt:   number;
+}
+
+function toView(job: Job<NotificationJobData>): DlqJobView {
+  return {
+    id:           job.id,
+    userId:       job.data.userId,
+    type:         job.data.type,
+    title:        job.data.title,
+    failedAt:     job.data._meta?.failedAt,
+    attemptsMade: job.data._meta?.attemptsMade,
+    lastError:    job.data._meta?.lastError,
+    enqueuedAt:   job.timestamp,
+  };
+}
+
+/**
+ * Admin-only controller for dead-letter queue visibility and management.
+ *
+ * Endpoints:
+ *   GET    /admin/dlq              – list failed notification jobs (paginated)
+ *   GET    /admin/dlq/:id          – inspect a single DLQ job
+ *   POST   /admin/dlq/:id/retry    – re-enqueue a DLQ job for reprocessing
+ *   DELETE /admin/dlq/:id          – permanently remove a DLQ job
+ *   DELETE /admin/dlq              – drain the entire DLQ (use with caution)
+ */
+// @UseGuards(AdminGuard)   ← uncomment once AdminGuard is in place
+@Controller('admin/dlq')
+export class DlqAdminController {
+  constructor(
+    @InjectQueue(NOTIFICATION_DLQ)  private readonly dlq: Queue<NotificationJobData>,
+    @InjectQueue(NOTIFICATION_QUEUE) private readonly mainQueue: Queue<NotificationJobData>,
+  ) {}
+
+  // ----------------------------------------------------------------- list
+  @Get()
+  async list(
+    @Query('start') start = '0',
+    @Query('end')   end   = '49',
+  ): Promise<{ total: number; jobs: DlqJobView[] }> {
+    const [jobs, total] = await Promise.all([
+      this.dlq.getJobs(['wait', 'completed', 'failed', 'delayed'], +start, +end),
+      this.dlq.count(),
+    ]);
+
+    return { total, jobs: jobs.map(toView) };
+  }
+
+  // ----------------------------------------------------------------- get one
+  @Get(':id')
+  async getOne(@Param('id') id: string): Promise<DlqJobView> {
+    const job = await this.dlq.getJob(id);
+    if (!job) throw new NotFoundException(`DLQ job ${id} not found`);
+    return toView(job);
+  }
+
+  // ----------------------------------------------------------------- retry
+  @Post(':id/retry')
+  async retry(
+    @Param('id') id: string,
+  ): Promise<{ message: string; newJobId: string | number | undefined }> {
+    const dlqJob = await this.dlq.getJob(id);
+    if (!dlqJob) throw new NotFoundException(`DLQ job ${id} not found`);
+
+    // Strip _meta so the job processes cleanly
+    const { _meta, ...payload } = dlqJob.data;
+    const newJob = await this.mainQueue.add('send-notification', payload);
+
+    await dlqJob.remove();
+
+    return { message: 'Re-enqueued for reprocessing', newJobId: newJob.id };
+  }
+
+  // ----------------------------------------------------------------- delete one
+  @Delete(':id')
+  async remove(@Param('id') id: string): Promise<{ message: string }> {
+    const job = await this.dlq.getJob(id);
+    if (!job) throw new NotFoundException(`DLQ job ${id} not found`);
+    await job.remove();
+    return { message: `DLQ job ${id} removed` };
+  }
+
+  // ----------------------------------------------------------------- drain all
+  @Delete()
+  async drain(): Promise<{ message: string }> {
+    await this.dlq.empty();
+    return { message: 'DLQ drained' };
+  }
+}

--- a/xconfess-backend/src/notifications/notification.queue.ts
+++ b/xconfess-backend/src/notifications/notification.queue.ts
@@ -1,0 +1,97 @@
+import { Processor, Process, OnQueueFailed, OnQueueCompleted, InjectQueue } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job, Queue } from 'bull';
+import { EmailNotificationService } from '../services/email-notification.service';
+import { NotificationType } from '../entities/notification.entity';
+
+export const NOTIFICATION_QUEUE = 'notifications';
+export const NOTIFICATION_DLQ   = 'notifications-dlq';
+
+export interface NotificationJobData {
+  userId: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  metadata?: {
+    messageId?: string;
+    senderId?: string;
+    senderAnonymousId?: string;
+    messageCount?: number;
+    messageIds?: string[];
+  };
+  /** Attached on failure for ops visibility */
+  _meta?: {
+    originalJobId: string | undefined;
+    failedAt: string;
+    attemptsMade: number;
+    lastError: string;
+  };
+}
+
+@Processor(NOTIFICATION_QUEUE)
+export class NotificationProcessor {
+  private readonly logger = new Logger(NotificationProcessor.name);
+
+  constructor(
+    private readonly emailNotificationService: EmailNotificationService,
+    @InjectQueue(NOTIFICATION_DLQ) private readonly dlq: Queue<NotificationJobData>,
+  ) {}
+
+  // ------------------------------------------------------------------ process
+  @Process('send-notification')
+  async handleSendNotification(job: Job<NotificationJobData>): Promise<void> {
+    this.logger.log(
+      `Processing notification job ${job.id} (attempt ${job.attemptsMade + 1})` +
+      ` → userId: ${job.data.userId}`,
+    );
+
+    await this.emailNotificationService.sendEmail(job.data);
+  }
+
+  // --------------------------------------------------------------- on:failed
+  /**
+   * Called after every failed attempt.
+   * When all attempts are exhausted Bull marks the job "failed" — we then
+   * copy the full payload + error context into the dead-letter queue.
+   */
+  @OnQueueFailed()
+  async onFailed(job: Job<NotificationJobData>, error: Error): Promise<void> {
+    const maxAttempts = job.opts.attempts ?? 1;
+
+    this.logger.warn(
+      `Job ${job.id} failed (attempt ${job.attemptsMade}/${maxAttempts}): ${error.message}`,
+    );
+
+    const isExhausted = job.attemptsMade >= maxAttempts;
+
+    if (isExhausted) {
+      this.logger.error(
+        `Job ${job.id} exhausted all retries — moving to DLQ`,
+        error.stack,
+      );
+
+      await this.dlq.add(
+        'dead-letter',
+        {
+          ...job.data,
+          _meta: {
+            originalJobId: String(job.id),
+            failedAt:      new Date().toISOString(),
+            attemptsMade:  job.attemptsMade,
+            lastError:     error.message,
+          },
+        },
+        {
+          removeOnComplete: false,
+          removeOnFail: false,
+        },
+      );
+    }
+  }
+
+  // -------------------------------------------------------------- on:completed
+  @OnQueueCompleted()
+  onCompleted(job: Job<NotificationJobData>): void {
+    this.logger.log(`Job ${job.id} completed successfully`);
+  }
+}

--- a/xconfess-backend/src/notifications/notifications.module.ts
+++ b/xconfess-backend/src/notifications/notifications.module.ts
@@ -9,25 +9,55 @@ import { EmailNotificationService } from './services/email-notification.service'
 import { NotificationController } from './notifications.controller';
 import { NotificationProcessor } from './processors/notification.processor';
 import { NotificationGateway } from './gateways/notification.gateway';
+import { DlqAdminController } from './controllers/dlq-admin.controller';
 
+/**
+ * Retry / backoff strategy
+ * ─────────────────────────
+ * attempts : 5   (1 initial + 4 retries)
+ * backoff  : exponential starting at 2 s
+ *
+ * Delay schedule (approx.)
+ *   attempt 1 →   0 s  (immediate)
+ *   attempt 2 →   2 s
+ *   attempt 3 →   4 s
+ *   attempt 4 →   8 s
+ *   attempt 5 →  16 s
+ *
+ * After attempt 5 the processor moves the job to the dead-letter queue.
+ */
 @Module({
   imports: [
     TypeOrmModule.forFeature([Notification, NotificationPreference]),
+
+    // ── Main notification queue ──────────────────────────────────────────────
     BullModule.registerQueue({
       name: 'notifications',
       defaultJobOptions: {
-        attempts: 3,
+        attempts: 5,
         backoff: {
           type: 'exponential',
           delay: 2000,
         },
-        removeOnComplete: true,
+        removeOnComplete: { count: 500 }, // keep last 500 for observability
+        removeOnFail: false,              // keep failed jobs until DLQ ack
+      },
+    }),
+
+    // ── Dead-letter queue ────────────────────────────────────────────────────
+    // No processor consumes this queue — it exists for ops inspection and
+    // manual / scheduled reprocessing only.
+    BullModule.registerQueue({
+      name: 'notifications-dlq',
+      defaultJobOptions: {
+        removeOnComplete: false,
         removeOnFail: false,
       },
     }),
+
     ConfigModule,
   ],
-  controllers: [NotificationController],
+  controllers: [NotificationController, DlqAdminController],
   providers: [
     NotificationService,
     EmailNotificationService,

--- a/xconfess-backend/src/notifications/notifications.service.spec.ts
+++ b/xconfess-backend/src/notifications/notifications.service.spec.ts
@@ -1,18 +1,113 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotificationsService } from './notifications.service';
+import { getQueueToken } from '@nestjs/bull';
+import { Job, Queue } from 'bull';
+import { NotificationProcessor, NOTIFICATION_DLQ, NotificationJobData } from './notification.processor';
+import { EmailNotificationService } from '../services/email-notification.service';
+import { NotificationType } from '../entities/notification.entity';
 
-describe('NotificationsService', () => {
-  let service: NotificationsService;
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeJob(overrides: Partial<Job<NotificationJobData>> = {}): Job<NotificationJobData> {
+  return {
+    id: 'job-1',
+    timestamp: Date.now(),
+    data: {
+      userId:  'user-uuid-123',
+      type:    NotificationType.NEW_MESSAGE,
+      title:   'New message',
+      message: 'You have a new confession',
+      metadata: { senderId: 'sender-uuid' },
+    },
+    attemptsMade: 1,
+    opts: { attempts: 5 },
+    ...overrides,
+  } as unknown as Job<NotificationJobData>;
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe('NotificationProcessor', () => {
+  let processor: NotificationProcessor;
+  let emailNotificationService: jest.Mocked<EmailNotificationService>;
+  let dlqMock: jest.Mocked<Pick<Queue, 'add'>>;
 
   beforeEach(async () => {
+    dlqMock = { add: jest.fn().mockResolvedValue({ id: 'dlq-1' }) };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [NotificationsService],
+      providers: [
+        NotificationProcessor,
+        {
+          provide:  EmailNotificationService,
+          useValue: { sendEmail: jest.fn() },
+        },
+        {
+          provide:  getQueueToken(NOTIFICATION_DLQ),
+          useValue: dlqMock,
+        },
+      ],
     }).compile();
 
-    service = module.get<NotificationsService>(NotificationsService);
+    processor             = module.get(NotificationProcessor);
+    emailNotificationService = module.get(EmailNotificationService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  // ── process ────────────────────────────────────────────────────────────────
+
+  it('calls emailNotificationService.sendEmail with correct job data', async () => {
+    const job = makeJob();
+    await processor.handleSendNotification(job);
+    expect(emailNotificationService.sendEmail).toHaveBeenCalledWith(job.data);
+  });
+
+  it('propagates email errors so Bull can retry', async () => {
+    emailNotificationService.sendEmail.mockRejectedValueOnce(new Error('SMTP timeout'));
+    const job = makeJob();
+    await expect(processor.handleSendNotification(job)).rejects.toThrow('SMTP timeout');
+  });
+
+  // ── onFailed — non-exhausted ───────────────────────────────────────────────
+
+  it('does NOT move to DLQ when retries remain', async () => {
+    const job = makeJob({ attemptsMade: 2, opts: { attempts: 5 } });
+    await processor.onFailed(job, new Error('Transient'));
+    expect(dlqMock.add).not.toHaveBeenCalled();
+  });
+
+  // ── onFailed — exhausted ──────────────────────────────────────────────────
+
+  it('moves job to DLQ when all attempts are exhausted', async () => {
+    const error = new Error('Permanent failure');
+    const job   = makeJob({ id: 'job-99', attemptsMade: 5, opts: { attempts: 5 } });
+
+    await processor.onFailed(job, error);
+
+    expect(dlqMock.add).toHaveBeenCalledTimes(1);
+
+    const [jobName, dlqPayload, dlqOpts] = dlqMock.add.mock.calls[0];
+
+    expect(jobName).toBe('dead-letter');
+
+    // Original fields preserved
+    expect(dlqPayload.userId).toBe('user-uuid-123');
+    expect(dlqPayload.type).toBe(NotificationType.NEW_MESSAGE);
+
+    // _meta block populated correctly
+    expect(dlqPayload._meta).toMatchObject({
+      originalJobId: 'job-99',
+      attemptsMade:  5,
+      lastError:     'Permanent failure',
+    });
+    expect(dlqPayload._meta.failedAt).toBeTruthy();
+
+    // DLQ jobs must be retained for ops inspection
+    expect(dlqOpts).toMatchObject({ removeOnComplete: false, removeOnFail: false });
+  });
+
+  // ── onCompleted ───────────────────────────────────────────────────────────
+
+  it('logs completion without throwing', () => {
+    const job = makeJob();
+    expect(() => processor.onCompleted(job)).not.toThrow();
   });
 });


### PR DESCRIPTION
- Bump retry attempts from 3 → 5 with exponential backoff (2s base)
- Register notifications-dlq queue for exhausted jobs
- Move failed jobs to DLQ via @OnQueueFailed with full _meta context
- Add DlqAdminController with list, inspect, retry, and drain endpoints
- Keep removeOnComplete as { count: 500 } for ops observability
- Add unit tests covering retry gating and DLQ routing logic

Adds a bounded retry policy and dead-letter queue (DLQ) to the notification pipeline,
replacing the previous silent-drop behaviour on email/queue failures.

## Changes
- **notification.module.ts** — bumped `attempts` 3 → 5, switched `removeOnComplete`
  to `{ count: 500 }`, registered `notifications-dlq` queue
- **notification.processor.ts** — wired `@OnQueueFailed` to route exhausted jobs into
  the DLQ with `_meta` (originalJobId, failedAt, attemptsMade, lastError)
- **dlq-admin.controller.ts** — new ops-facing REST controller under `/admin/dlq`
  with list (paginated), inspect, retry, and drain endpoints
- **notification.processor.spec.ts** — unit tests covering successful processing,
  error propagation, retry gating, and DLQ write with correct metadata

## Retry Schedule
| Attempt | Delay |
|---------|-------|
| 1 | immediate |
| 2 | ~2s |
| 3 | ~4s |
| 4 | ~8s |
| 5 | ~16s |

## How to Test
1. Simulate transient failure — mock `EmailNotificationService.sendEmail` to throw
   on attempts 1–2, succeed on 3. Verify no DLQ write occurs.
2. Simulate permanent failure — mock all 5 attempts to throw. Verify job appears
   in `notifications-dlq` with correct `_meta` payload.
3. Hit `GET /admin/dlq` and confirm the failed job is listed with error context.
4. Hit `POST /admin/dlq/:id/retry` and confirm job re-enters the main queue.

## Notes
- `DlqAdminController` has `@UseGuards(AdminGuard)` commented in — uncomment once
  the guard is wired up to avoid exposing the endpoint publicly.
- No consumer is registered for `notifications-dlq` by design; reprocessing is
  manual via the admin endpoint or a scheduled job.

Closes #299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dead-letter queue administration capabilities, enabling operators to list, retrieve, retry, remove, and drain failed notifications.
  * Enhanced notification retry mechanism with increased retry attempts and improved job retention for better observability.

* **Tests**
  * Added tests covering notification processing and failure handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->