### PR TITLE
fix: Migrate auth token handling from localStorage to secure sessions (#367)

### DIFF
--- a/xconfess-frontend/app/api/auth/session/route.ts
+++ b/xconfess-frontend/app/api/auth/session/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
+const SESSION_COOKIE_NAME = "xconfess_session";
+
+export async function POST(request: Request) {
+    try {
+        const body = await request.json();
+        const { email, password } = body;
+
+        const response = await fetch(`${API_URL}/auth/login`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, password }),
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ message: "Login failed" }));
+            return NextResponse.json(
+                { message: error.message ?? "Login failed" },
+                { status: response.status }
+            );
+        }
+
+        const data = await response.json();
+        const token = data.access_token;
+
+        // Set HttpOnly cookie with the access token
+        cookies().set(SESSION_COOKIE_NAME, token, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            sameSite: "lax",
+            maxAge: 60 * 60 * 24 * 7, // 1 week
+            path: "/",
+        });
+
+        return NextResponse.json({ user: data.user });
+    } catch (error) {
+        return NextResponse.json(
+            { message: "An unexpected error occurred during login" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function GET() {
+    const cookieStore = cookies();
+    const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+
+    if (!token) {
+        return NextResponse.json({ authenticated: false }, { status: 401 });
+    }
+
+    try {
+        // Bridges the session to the backend to get current user info
+        const response = await fetch(`${API_URL}/auth/profile`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+
+        if (!response.ok) {
+            cookieStore.delete(SESSION_COOKIE_NAME);
+            return NextResponse.json({ authenticated: false }, { status: 401 });
+        }
+
+        const user = await response.json();
+        return NextResponse.json({ authenticated: true, user });
+    } catch (error) {
+        return NextResponse.json({ authenticated: false }, { status: 500 });
+    }
+}
+
+export async function DELETE() {
+    cookies().delete(SESSION_COOKIE_NAME);
+    return NextResponse.json({ success: true });
+}

--- a/xconfess-frontend/app/lib/api/client.ts
+++ b/xconfess-frontend/app/lib/api/client.ts
@@ -12,10 +12,8 @@ const apiClient = axios.create({
 // Request interceptor for adding auth token
 apiClient.interceptors.request.use(
 	(config) => {
-		const token = localStorage.getItem(AUTH_TOKEN_KEY);
-		if (token) {
-			config.headers.Authorization = `Bearer ${token}`;
-		}
+		// Tokens are now handled via secure session cookies
+		config.withCredentials = true;
 		return config;
 	},
 	(error) => {

--- a/xconfess-frontend/app/lib/store/authStore.ts
+++ b/xconfess-frontend/app/lib/store/authStore.ts
@@ -41,11 +41,6 @@ export const useAuthStore = create<AuthStoreState>()(
       setError: (error) => set({ error }),
 
       logout: () => {
-        if (typeof window !== "undefined") {
-          localStorage.removeItem(AUTH_TOKEN_KEY);
-          localStorage.removeItem(USER_DATA_KEY);
-          localStorage.removeItem(ANONYMOUS_USER_ID_KEY);
-        }
         set({
           user: null,
           isAuthenticated: false,
@@ -55,19 +50,9 @@ export const useAuthStore = create<AuthStoreState>()(
       },
 
       hydrateFromStorage: () => {
+        // Hydration from localStorage is disabled for security
+        // State will be populated by AuthProvider from session cookie
         if (typeof window === "undefined") return;
-        const token = localStorage.getItem(AUTH_TOKEN_KEY);
-        const userJson = localStorage.getItem(USER_DATA_KEY);
-        if (!token) {
-          set({ user: null, isAuthenticated: false });
-          return;
-        }
-        try {
-          const user = userJson ? (JSON.parse(userJson) as User) : null;
-          set({ user, isAuthenticated: !!user });
-        } catch {
-          set({ user: null, isAuthenticated: false });
-        }
       },
     }),
     {


### PR DESCRIPTION
This PR migrates the authentication strategy from localStorage to secure HttpOnly sessions to reduce the XSS blast radius.

### Changes
- Created a new Next.js API route `/api/auth/session` as a proxy for the backend auth service.
- Updated `authService.ts`, `client.ts`, and `auth.ts` to use session cookies instead of localStorage tokens.
- Modified `AuthProvider.tsx` and `authStore.ts` to align with the cookie-based approach.
- Updated the login page to use the new session flow.

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication security by implementing server-managed session handling, replacing client-side token storage.
  * Enhanced logout functionality to properly clear sessions server-side.

* **Refactor**
  * Redesigned authentication flow for improved reliability and security posture with centralized session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->