### PR TITLE
feat(checkpoint): add deterministic checkpoint and snapshot reads

### DIFF
--- a/xconfess-contracts/contracts/checkpoint.rs
+++ b/xconfess-contracts/contracts/checkpoint.rs
@@ -1,0 +1,81 @@
+use soroban_sdk::{contracttype, Env, Vec};
+use crate::confession::Confession;
+use crate::reaction::Reaction;
+use crate::report::Report;
+
+/// Snapshot summaries for indexer consumption
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CheckpointSummary {
+    pub total_confessions: u64,
+    pub total_reactions: u64,
+    pub total_reports: u64,
+    pub latest_confession_id: u64,
+    pub latest_reaction_id: u64,
+    pub latest_report_id: u64,
+    pub version_marker: u32, // allows backward-compatible upgrades
+}
+
+/// Snapshot page for paginated reading
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SnapshotPage<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<u64>, // next starting id for pagination
+}
+
+/// ===========================================
+/// API: deterministic checkpoint reads
+/// ===========================================
+pub fn get_checkpoint_summary(
+    env: &Env,
+    confessions: &Vec<Confession>,
+    reactions: &Vec<Reaction>,
+    reports: &Vec<Report>,
+) -> CheckpointSummary {
+    let total_confessions = confessions.len() as u64;
+    let total_reactions = reactions.len() as u64;
+    let total_reports = reports.len() as u64;
+
+    let latest_confession_id = confessions.last().map(|c| c.id).unwrap_or(0);
+    let latest_reaction_id = reactions.last().map(|r| r.id).unwrap_or(0);
+    let latest_report_id = reports.last().map(|rep| rep.id).unwrap_or(0);
+
+    CheckpointSummary {
+        total_confessions,
+        total_reactions,
+        total_reports,
+        latest_confession_id,
+        latest_reaction_id,
+        latest_report_id,
+        version_marker: 1,
+    }
+}
+
+/// ===========================================
+/// API: deterministic paginated snapshot reads
+/// ===========================================
+pub fn get_snapshot_page<T: Clone>(
+    items: &Vec<T>,
+    start_id: u64,
+    page_size: u64,
+    get_id: impl Fn(&T) -> u64,
+) -> SnapshotPage<T> {
+    let mut page_items = Vec::new(items.env());
+    let mut next_cursor: Option<u64> = None;
+
+    for item in items.iter() {
+        let id = get_id(&item);
+        if id > start_id && page_items.len() < page_size as usize {
+            page_items.push(item.clone());
+        } else if id > start_id {
+            next_cursor = Some(id);
+            break;
+        }
+    }
+
+    SnapshotPage {
+        items: page_items,
+        next_cursor,
+    }
+}

--- a/xconfess-contracts/contracts/tests/checkpoint_tests.rs
+++ b/xconfess-contracts/contracts/tests/checkpoint_tests.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::{Env, vec};
+use xconfess_contract::checkpoint::{get_checkpoint_summary, get_snapshot_page};
+use xconfess_contract::confession::Confession;
+use xconfess_contract::reaction::Reaction;
+use xconfess_contract::report::Report;
+
+#[test]
+fn test_checkpoint_summary() {
+    let env = Env::default();
+
+    let confessions = vec![&env, Confession { confession_id: 1, author: env.accounts().next().unwrap(), content_hash: "hash1".into(), timestamp: 1 }];
+    let reactions = vec![&env, Reaction { reaction_id: 1, confession_id: 1, reactor: env.accounts().next().unwrap(), reaction_type: "like".into(), timestamp: 1 }];
+    let reports = vec![&env, Report { report_id: 1, confession_id: 1, reporter: env.accounts().next().unwrap(), reason: "spam".into(), timestamp: 1 }];
+
+    let summary = get_checkpoint_summary(&env, &confessions, &reactions, &reports);
+
+    assert_eq!(summary.total_confessions, 1);
+    assert_eq!(summary.total_reactions, 1);
+    assert_eq!(summary.total_reports, 1);
+    assert_eq!(summary.latest_confession_id, 1);
+}
+
+#[test]
+fn test_snapshot_page() {
+    let env = Env::default();
+    let confessions = vec![
+        &env, 
+        Confession { confession_id: 1, author: env.accounts().next().unwrap(), content_hash: "hash1".into(), timestamp: 1 },
+        Confession { confession_id: 2, author: env.accounts().next().unwrap(), content_hash: "hash2".into(), timestamp: 2 },
+    ];
+
+    let page = get_snapshot_page(&confessions, 0, 1, |c: &Confession| c.confession_id);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].confession_id, 1);
+    assert_eq!(page.next_cursor, Some(2));
+}


### PR DESCRIPTION
- Added CheckpointSummary struct to provide totals and latest IDs for confessions, reactions, and reports
- Implemented paginated SnapshotPage reads to fetch state incrementally from a start cursor
- Ensures deterministic outputs for stable off-chain indexer backfill
- Version marker included for backward-compatible snapshot evolution
- Unit tests cover summary correctness and pagination behavior

closes #392 