### PR TITLE
feat(contract): add event nonces, payload bounds, and model-based lifecycle tests

### DIFF
--- a/xconfess-contracts/contracts/error.rs
+++ b/xconfess-contracts/contracts/error.rs
@@ -11,6 +11,8 @@ pub enum ContractError {
     InvalidInput,       // input value invalid
     Overflow,           // arithmetic overflow
     CooldownActive,     // update cooldown not elapsed
+    PayloadTooLarge,    // emitted payload or metadata exceeds configured bound
+    MetadataTooLong,    // metadata field length exceeded
 
     /// ===========================================
     /// Confession module errors
@@ -30,6 +32,7 @@ pub enum ContractError {
     /// ===========================================
     ReportExists,       // user already reported
     InvalidReportReason,// report reason not allowed
+    ReportReasonTooLong,// report reason exceeds configured max
 }
 
 impl ContractError {
@@ -40,6 +43,8 @@ impl ContractError {
             ContractError::InvalidInput => 1002,
             ContractError::Overflow => 1003,
             ContractError::CooldownActive => 1004,
+            ContractError::PayloadTooLarge => 1005,
+            ContractError::MetadataTooLong => 1006,
 
             ContractError::ConfessionExists => 2000,
             ContractError::ConfessionEmpty => 2001,
@@ -50,6 +55,7 @@ impl ContractError {
 
             ContractError::ReportExists => 4000,
             ContractError::InvalidReportReason => 4001,
+            ContractError::ReportReasonTooLong => 4002,
         }
     }
 
@@ -60,6 +66,8 @@ impl ContractError {
             ContractError::InvalidInput => "invalid input",
             ContractError::Overflow => "arithmetic overflow",
             ContractError::CooldownActive => "cooldown period not elapsed",
+            ContractError::PayloadTooLarge => "payload exceeds configured limit",
+            ContractError::MetadataTooLong => "metadata field too long",
 
             ContractError::ConfessionExists => "confession already exists",
             ContractError::ConfessionEmpty => "confession content empty",
@@ -70,6 +78,7 @@ impl ContractError {
 
             ContractError::ReportExists => "report already exists",
             ContractError::InvalidReportReason => "report reason invalid",
+            ContractError::ReportReasonTooLong => "report reason too long",
         }
     }
 }

--- a/xconfess-contracts/contracts/events.rs
+++ b/xconfess-contracts/contracts/events.rs
@@ -14,6 +14,60 @@ pub const REPORT_EVENT: Symbol = symbol_short!("report");
 pub const ROLE_EVENT: Symbol = symbol_short!("role");
 
 /// ===========================================
+/// EVENT NONCE STORAGE
+/// ===========================================
+///
+/// Nonces are monotonic counters used by indexers to:
+/// - detect gaps (missing events)
+/// - detect duplicates/replays
+/// - enforce deterministic in-stream ordering
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum EventNonceKey {
+    Confession(u64),
+    Reaction(u64),
+    Report(u64),
+    Role(Address, Symbol),
+    Governance(Symbol),
+}
+
+fn read_nonce(env: &Env, key: &EventNonceKey) -> u64 {
+    env.storage().instance().get(key).unwrap_or(0u64)
+}
+
+fn bump_nonce(env: &Env, key: EventNonceKey) -> u64 {
+    let next = read_nonce(env, &key)
+        .checked_add(1)
+        .expect("event nonce overflow");
+    env.storage().instance().set(&key, &next);
+    next
+}
+
+pub fn latest_confession_nonce(env: &Env, confession_id: u64) -> u64 {
+    read_nonce(env, &EventNonceKey::Confession(confession_id))
+}
+
+pub fn latest_reaction_nonce(env: &Env, confession_id: u64) -> u64 {
+    read_nonce(env, &EventNonceKey::Reaction(confession_id))
+}
+
+pub fn latest_report_nonce(env: &Env, confession_id: u64) -> u64 {
+    read_nonce(env, &EventNonceKey::Report(confession_id))
+}
+
+pub fn latest_role_nonce(env: &Env, user: Address, role: Symbol) -> u64 {
+    read_nonce(env, &EventNonceKey::Role(user, role))
+}
+
+pub fn latest_governance_nonce(env: &Env, stream: Symbol) -> u64 {
+    read_nonce(env, &EventNonceKey::Governance(stream))
+}
+
+pub fn next_governance_nonce(env: &Env, stream: Symbol) -> u64 {
+    bump_nonce(env, EventNonceKey::Governance(stream))
+}
+
+/// ===========================================
 /// CONFESSION EVENT (V1) WITH OPTIONAL CORRELATION ID
 /// ===========================================
 #[contracttype]
@@ -23,6 +77,7 @@ pub struct ConfessionEvent {
     pub confession_id: u64,
     pub author: Address,
     pub content_hash: Symbol,
+    pub nonce: u64,
     pub timestamp: u64,
     pub correlation_id: Option<Symbol>, // new optional field
 }
@@ -34,11 +89,14 @@ pub fn emit_confession(
     content_hash: Symbol,
     correlation_id: Option<Symbol>, // optional parameter
 ) {
+    let nonce = bump_nonce(env, EventNonceKey::Confession(confession_id));
+
     let payload = ConfessionEvent {
         event_version: EVENT_VERSION_V1,
         confession_id,
         author,
         content_hash,
+        nonce,
         timestamp: env.ledger().timestamp(),
         correlation_id,
     };
@@ -56,6 +114,7 @@ pub struct ReactionEvent {
     pub confession_id: u64,
     pub reactor: Address,
     pub reaction_type: Symbol,
+    pub nonce: u64,
     pub timestamp: u64,
     pub correlation_id: Option<Symbol>,
 }
@@ -67,11 +126,14 @@ pub fn emit_reaction(
     reaction_type: Symbol,
     correlation_id: Option<Symbol>,
 ) {
+    let nonce = bump_nonce(env, EventNonceKey::Reaction(confession_id));
+
     let payload = ReactionEvent {
         event_version: EVENT_VERSION_V1,
         confession_id,
         reactor,
         reaction_type,
+        nonce,
         timestamp: env.ledger().timestamp(),
         correlation_id,
     };
@@ -89,6 +151,7 @@ pub struct ReportEvent {
     pub confession_id: u64,
     pub reporter: Address,
     pub reason: Symbol,
+    pub nonce: u64,
     pub timestamp: u64,
     pub correlation_id: Option<Symbol>,
 }
@@ -100,11 +163,14 @@ pub fn emit_report(
     reason: Symbol,
     correlation_id: Option<Symbol>,
 ) {
+    let nonce = bump_nonce(env, EventNonceKey::Report(confession_id));
+
     let payload = ReportEvent {
         event_version: EVENT_VERSION_V1,
         confession_id,
         reporter,
         reason,
+        nonce,
         timestamp: env.ledger().timestamp(),
         correlation_id,
     };
@@ -122,6 +188,7 @@ pub struct RoleEvent {
     pub user: Address,
     pub role: Symbol,
     pub granted: bool,
+    pub nonce: u64,
     pub timestamp: u64,
     pub correlation_id: Option<Symbol>,
 }
@@ -133,11 +200,14 @@ pub fn emit_role(
     granted: bool,
     correlation_id: Option<Symbol>,
 ) {
+    let nonce = bump_nonce(env, EventNonceKey::Role(user.clone(), role.clone()));
+
     let payload = RoleEvent {
         event_version: EVENT_VERSION_V1,
         user,
         role,
         granted,
+        nonce,
         timestamp: env.ledger().timestamp(),
         correlation_id,
     };

--- a/xconfess-contracts/contracts/governance/events.rs
+++ b/xconfess-contracts/contracts/governance/events.rs
@@ -1,29 +1,121 @@
-use soroban_sdk::{symbol_short, Address, Env};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String as SorobanString};
+use crate::events::next_governance_nonce;
+
+// #403: bound governance free-form metadata to keep event payloads predictable.
+pub const MAX_GOV_TEXT_LEN: usize = 128;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GovernanceProposedEvent {
+    pub nonce: u64,
+    pub timestamp: u64,
+    pub current: Address,
+    pub proposed: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GovernanceAcceptedEvent {
+    pub nonce: u64,
+    pub timestamp: u64,
+    pub old: Address,
+    pub new_admin: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GovernanceCancelledEvent {
+    pub nonce: u64,
+    pub timestamp: u64,
+    pub admin: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GovernanceInvariantViolationEvent {
+    pub nonce: u64,
+    pub timestamp: u64,
+    pub operation: SorobanString,
+    pub reason: SorobanString,
+    pub attempted_by: Address,
+}
 
 pub fn proposed(e: &Env, current: Address, proposed: Address) {
-    e.events().publish(
-        (symbol_short!("gov_prop"),),
-        (current, proposed),
-    );
+    let stream = symbol_short!("gov_prop");
+    let payload = GovernanceProposedEvent {
+        nonce: next_governance_nonce(e, stream.clone()),
+        timestamp: e.ledger().timestamp(),
+        current,
+        proposed,
+    };
+    e.events().publish((stream,), payload);
 }
 
 pub fn accepted(e: &Env, old: Address, new_admin: Address) {
-    e.events().publish(
-        (symbol_short!("gov_acc"),),
-        (old, new_admin),
-    );
+    let stream = symbol_short!("gov_acc");
+    let payload = GovernanceAcceptedEvent {
+        nonce: next_governance_nonce(e, stream.clone()),
+        timestamp: e.ledger().timestamp(),
+        old,
+        new_admin,
+    };
+    e.events().publish((stream,), payload);
 }
 
 pub fn cancelled(e: &Env, admin: Address) {
-    e.events().publish(
-        (symbol_short!("gov_can"),),
+    let stream = symbol_short!("gov_can");
+    let payload = GovernanceCancelledEvent {
+        nonce: next_governance_nonce(e, stream.clone()),
+        timestamp: e.ledger().timestamp(),
         admin,
-    );
+    };
+    e.events().publish((stream,), payload);
 }
 
 pub fn invariant_violation(e: &Env, operation: &str, reason: &str, attempted_by: Address) {
-    e.events().publish(
-        (symbol_short!("gov_inv"),),
-        (operation, reason, attempted_by),
-    );
+    if operation.len() > MAX_GOV_TEXT_LEN {
+        panic!("governance operation metadata too long");
+    }
+    if reason.len() > MAX_GOV_TEXT_LEN {
+        panic!("governance reason metadata too long");
+    }
+
+    let stream = symbol_short!("gov_inv");
+    let payload = GovernanceInvariantViolationEvent {
+        nonce: next_governance_nonce(e, stream.clone()),
+        timestamp: e.ledger().timestamp(),
+        operation: SorobanString::from_str(e, operation),
+        reason: SorobanString::from_str(e, reason),
+        attempted_by,
+    };
+    e.events().publish((stream,), payload);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::latest_governance_nonce;
+    use soroban_sdk::testutils::Address as _;
+
+    #[test]
+    fn governance_metadata_exact_limit_succeeds() {
+        let env = Env::default();
+        let actor = Address::generate(&env);
+        let op = "o".repeat(MAX_GOV_TEXT_LEN);
+        let reason = "r".repeat(MAX_GOV_TEXT_LEN);
+
+        invariant_violation(&env, &op, &reason, actor);
+        assert_eq!(latest_governance_nonce(&env, symbol_short!("gov_inv")), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "governance reason metadata too long")]
+    fn governance_metadata_limit_plus_one_rejected() {
+        let env = Env::default();
+        let actor = Address::generate(&env);
+        let op = "o".repeat(MAX_GOV_TEXT_LEN);
+        let reason = "r".repeat(MAX_GOV_TEXT_LEN + 1);
+
+        invariant_violation(&env, &op, &reason, actor);
+    }
 }

--- a/xconfess-contracts/contracts/lib.rs
+++ b/xconfess-contracts/contracts/lib.rs
@@ -1,10 +1,37 @@
-use soroban_sdk::{Env, Symbol};
+use soroban_sdk::{Address, Env, Symbol};
+
+pub mod events;
+pub mod pagination;
+pub mod report;
 
 // Define deterministic errors
 pub const ERR_DUPLICATE_REPORT: &str = "duplicate_report";
 pub const ERR_COOLDOWN_ACTIVE: &str = "cooldown_active";
+pub const ERR_REASON_EMPTY: &str = "reason_empty";
+pub const ERR_REASON_TOO_LONG: &str = "reason_too_long";
 
 // Helper for generating a key for actor-confession mapping
 pub fn report_key(actor: &Symbol, confession_id: &Symbol) -> Vec<u8> {
     [actor.as_bytes(), confession_id.as_bytes()].concat()
+}
+
+// Read helpers for indexer reconciliation.
+pub fn latest_confession_event_nonce(env: &Env, confession_id: u64) -> u64 {
+    events::latest_confession_nonce(env, confession_id)
+}
+
+pub fn latest_reaction_event_nonce(env: &Env, confession_id: u64) -> u64 {
+    events::latest_reaction_nonce(env, confession_id)
+}
+
+pub fn latest_report_event_nonce(env: &Env, confession_id: u64) -> u64 {
+    events::latest_report_nonce(env, confession_id)
+}
+
+pub fn latest_role_event_nonce(env: &Env, user: Address, role: Symbol) -> u64 {
+    events::latest_role_nonce(env, user, role)
+}
+
+pub fn latest_governance_event_nonce(env: &Env, stream: Symbol) -> u64 {
+    events::latest_governance_nonce(env, stream)
 }

--- a/xconfess-contracts/contracts/pagination/confession.rs
+++ b/xconfess-contracts/contracts/pagination/confession.rs
@@ -1,5 +1,8 @@
 use soroban_sdk::{contracttype, Env, Vec};
 
+// #403: explicit bounds to keep storage/event payloads predictable.
+pub const MAX_CONFESSION_CONTENT_LEN: u32 = 2048;
+
 #[contracttype]
 #[derive(Clone)]
 pub struct Confession {
@@ -17,6 +20,13 @@ pub enum ConfessionKey {
 }
 
 pub fn create(env: &Env, content: soroban_sdk::String) -> u64 {
+    if content.len() == 0 {
+        panic!("confession content empty");
+    }
+    if content.len() > MAX_CONFESSION_CONTENT_LEN {
+        panic!("confession content too long");
+    }
+
     let mut id: u64 = env
         .storage()
         .instance()

--- a/xconfess-contracts/contracts/report.rs
+++ b/xconfess-contracts/contracts/report.rs
@@ -1,5 +1,23 @@
-use soroban_sdk::{contractimpl, symbol, Env, Symbol, Storage};
-use crate::lib::{report_key, ERR_DUPLICATE_REPORT, ERR_COOLDOWN_ACTIVE};
+use soroban_sdk::{contractimpl, contracttype, symbol, Env, String as SorobanString, Symbol, Storage};
+use crate::{
+    report_key, ERR_COOLDOWN_ACTIVE, ERR_DUPLICATE_REPORT, ERR_REASON_EMPTY, ERR_REASON_TOO_LONG,
+};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ReportNonceKey {
+    Stream(Symbol),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReportSubmittedEvent {
+    pub confession_id: Symbol,
+    pub actor: Symbol,
+    pub reason: SorobanString,
+    pub nonce: u64,
+    pub timestamp: u64,
+}
 
 pub struct ReportContract;
 
@@ -7,9 +25,53 @@ pub struct ReportContract;
 impl ReportContract {
     // Cooldown window in seconds
     pub const COOLDOWN: u64 = 3600; // 1 hour
+    // #403: hard bound for report reason payload.
+    pub const MAX_REPORT_REASON_LEN: u32 = 128;
 
-    // Submit a report
+    fn latest_nonce_internal(env: &Env, confession_id: &Symbol) -> u64 {
+        env.storage()
+            .instance()
+            .get(&ReportNonceKey::Stream(confession_id.clone()))
+            .unwrap_or(0_u64)
+    }
+
+    fn bump_nonce(env: &Env, confession_id: &Symbol) -> u64 {
+        let next = Self::latest_nonce_internal(env, confession_id)
+            .checked_add(1)
+            .expect("report event nonce overflow");
+
+        env.storage()
+            .instance()
+            .set(&ReportNonceKey::Stream(confession_id.clone()), &next);
+
+        next
+    }
+
+    // Backward-compatible entrypoint: uses a default bounded reason.
     pub fn submit_report(env: Env, actor: Symbol, confession_id: Symbol) -> Result<(), Symbol> {
+        let default_reason = SorobanString::from_str(&env, "generic");
+        Self::submit_report_with_reason(
+            env,
+            actor,
+            confession_id,
+            default_reason,
+        )
+    }
+
+    // Submit a report with explicit reason (bounded for gas/indexer safety).
+    pub fn submit_report_with_reason(
+        env: Env,
+        actor: Symbol,
+        confession_id: Symbol,
+        reason: SorobanString,
+    ) -> Result<(), Symbol> {
+        if reason.len() == 0 {
+            return Err(symbol!(ERR_REASON_EMPTY));
+        }
+        if reason.len() > Self::MAX_REPORT_REASON_LEN {
+            return Err(symbol!(ERR_REASON_TOO_LONG));
+        }
+
         let storage = env.storage();
         let key = report_key(&actor, &confession_id);
 
@@ -25,6 +87,22 @@ impl ReportContract {
         // Save current timestamp for this actor-confession
         storage.set(&key, &env.ledger().timestamp());
 
+        // Emit deterministic report lifecycle event with monotonic nonce.
+        let nonce = Self::bump_nonce(&env, &confession_id);
+        let payload = ReportSubmittedEvent {
+            confession_id: confession_id.clone(),
+            actor: actor.clone(),
+            reason,
+            nonce,
+            timestamp: env.ledger().timestamp(),
+        };
+        env.events().publish((symbol!("report"),), payload);
+
         Ok(())
+    }
+
+    // Read helper for reconciliation/indexers.
+    pub fn latest_report_nonce(env: Env, confession_id: Symbol) -> u64 {
+        Self::latest_nonce_internal(&env, &confession_id)
     }
 }

--- a/xconfess-contracts/contracts/tests/bounded_payloads.test.rs
+++ b/xconfess-contracts/contracts/tests/bounded_payloads.test.rs
@@ -1,0 +1,26 @@
+use soroban_sdk::{Env, String as SorobanString};
+use xconfess_contract::pagination::confession::{create, MAX_CONFESSION_CONTENT_LEN};
+
+#[test]
+fn confession_content_exact_limit_succeeds() {
+    let env = Env::default();
+    let content = SorobanString::from_str(
+        &env,
+        &"a".repeat(MAX_CONFESSION_CONTENT_LEN as usize),
+    );
+
+    let id = create(&env, content);
+    assert_eq!(id, 1);
+}
+
+#[test]
+#[should_panic(expected = "confession content too long")]
+fn confession_content_limit_plus_one_rejected() {
+    let env = Env::default();
+    let content = SorobanString::from_str(
+        &env,
+        &"a".repeat((MAX_CONFESSION_CONTENT_LEN + 1) as usize),
+    );
+
+    let _ = create(&env, content);
+}

--- a/xconfess-contracts/contracts/tests/event_decoder_compat.test.rs
+++ b/xconfess-contracts/contracts/tests/event_decoder_compat.test.rs
@@ -11,10 +11,13 @@ fn event_contains_version() {
         confession_id: 1,
         author: addr,
         content_hash: soroban_sdk::symbol_short!("hash"),
+        nonce: 1,
         timestamp: 0,
+        correlation_id: None,
     };
 
     assert_eq!(event.event_version, 1);
+    assert_eq!(event.nonce, 1);
 }
 
 #[test]

--- a/xconfess-contracts/contracts/tests/event_nonce_ordering.test.rs
+++ b/xconfess-contracts/contracts/tests/event_nonce_ordering.test.rs
@@ -1,0 +1,101 @@
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+use xconfess_contract::events::{
+    emit_confession, emit_reaction, emit_report, emit_role, latest_confession_nonce,
+    latest_governance_nonce, latest_reaction_nonce, latest_report_nonce, latest_role_nonce,
+    next_governance_nonce,
+};
+
+#[test]
+fn confession_nonce_increments_by_one_per_entity_stream() {
+    let env = Env::default();
+    let author = Address::generate(&env);
+
+    emit_confession(
+        &env,
+        42,
+        author.clone(),
+        symbol_short!("hash_a"),
+        None,
+    );
+    emit_confession(
+        &env,
+        42,
+        author,
+        symbol_short!("hash_b"),
+        None,
+    );
+
+    assert_eq!(latest_confession_nonce(&env, 42), 2);
+}
+
+#[test]
+fn reaction_report_and_role_nonces_are_monotonic_and_independent() {
+    let env = Env::default();
+    let actor = Address::generate(&env);
+
+    emit_reaction(&env, 7, actor.clone(), symbol_short!("like"), None);
+    emit_reaction(&env, 7, actor.clone(), symbol_short!("love"), None);
+    emit_report(&env, 7, actor.clone(), symbol_short!("spam"), None);
+    emit_report(&env, 7, actor.clone(), symbol_short!("abuse"), None);
+    emit_role(
+        &env,
+        actor.clone(),
+        symbol_short!("admin"),
+        true,
+        None,
+    );
+    emit_role(
+        &env,
+        actor.clone(),
+        symbol_short!("admin"),
+        false,
+        None,
+    );
+
+    assert_eq!(latest_reaction_nonce(&env, 7), 2);
+    assert_eq!(latest_report_nonce(&env, 7), 2);
+    assert_eq!(latest_role_nonce(&env, actor, symbol_short!("admin")), 2);
+}
+
+#[test]
+fn governance_nonce_is_monotonic_per_stream_symbol() {
+    let env = Env::default();
+
+    let stream = symbol_short!("gov_acc");
+    assert_eq!(latest_governance_nonce(&env, stream.clone()), 0);
+    assert_eq!(next_governance_nonce(&env, stream.clone()), 1);
+    assert_eq!(next_governance_nonce(&env, stream.clone()), 2);
+    assert_eq!(latest_governance_nonce(&env, stream), 2);
+}
+
+#[test]
+fn nonce_sequence_supports_gap_duplicate_and_order_checks() {
+    // Simulated ingestion stream from an indexer consumer.
+    let observed = [1_u64, 2, 2, 4, 3, 5];
+
+    let mut expected_next = 1_u64;
+    let mut gaps = 0_u64;
+    let mut duplicates = 0_u64;
+    let mut out_of_order = 0_u64;
+
+    for nonce in observed {
+        if nonce == expected_next {
+            expected_next += 1;
+        } else if nonce < expected_next {
+            // Already seen this nonce or sequence moved past it.
+            if nonce + 1 == expected_next {
+                duplicates += 1;
+            } else {
+                out_of_order += 1;
+            }
+        } else {
+            // Missing range [expected_next, nonce)
+            gaps += nonce - expected_next;
+            expected_next = nonce + 1;
+        }
+    }
+
+    assert_eq!(gaps, 1); // missing nonce = 3 before seeing 4
+    assert_eq!(duplicates, 1); // duplicate nonce = 2
+    assert_eq!(out_of_order, 1); // late arrival nonce = 3 after 4
+}

--- a/xconfess-contracts/contracts/tests/model/actions.rs
+++ b/xconfess-contracts/contracts/tests/model/actions.rs
@@ -1,0 +1,17 @@
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Action {
+    Create { actor: u32 },
+    React { actor: u32, confession_id: u32 },
+    Report {
+        actor: u32,
+        confession_id: u32,
+        reason_len: u32,
+    },
+    Resolve { admin: u32, confession_id: u32 },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Outcome {
+    Applied,
+    Rejected(&'static str),
+}

--- a/xconfess-contracts/contracts/tests/model/generator.rs
+++ b/xconfess-contracts/contracts/tests/model/generator.rs
@@ -1,0 +1,65 @@
+use super::actions::Action;
+
+#[derive(Clone, Debug)]
+pub struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    pub fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        // Deterministic LCG; stable across platforms.
+        self.state = self
+            .state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1);
+        (self.state >> 32) as u32
+    }
+
+    fn bounded(&mut self, max_exclusive: u32) -> u32 {
+        if max_exclusive == 0 {
+            0
+        } else {
+            self.next_u32() % max_exclusive
+        }
+    }
+}
+
+pub fn generate_actions(seed: u64, steps: usize) -> Vec<Action> {
+    let mut rng = Lcg::new(seed);
+    let mut actions = Vec::with_capacity(steps);
+    let mut max_conf_id_seen = 0_u32;
+
+    for _ in 0..steps {
+        let pick = rng.bounded(4);
+        let actor = rng.bounded(6);
+        let confession_id = rng.bounded(max_conf_id_seen.saturating_add(3));
+
+        let action = match pick {
+            0 => {
+                max_conf_id_seen = max_conf_id_seen.saturating_add(1);
+                Action::Create { actor }
+            }
+            1 => Action::React {
+                actor,
+                confession_id,
+            },
+            2 => Action::Report {
+                actor,
+                confession_id,
+                reason_len: rng.bounded(160),
+            },
+            _ => Action::Resolve {
+                admin: rng.bounded(3),
+                confession_id,
+            },
+        };
+
+        actions.push(action);
+    }
+
+    actions
+}

--- a/xconfess-contracts/contracts/tests/model/mod.rs
+++ b/xconfess-contracts/contracts/tests/model/mod.rs
@@ -1,0 +1,5 @@
+pub mod actions;
+pub mod generator;
+pub mod observed;
+pub mod reference;
+pub mod replay;

--- a/xconfess-contracts/contracts/tests/model/observed.rs
+++ b/xconfess-contracts/contracts/tests/model/observed.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeSet;
+
+use super::actions::{Action, Outcome};
+use super::reference::{ConfessionState, ModelState};
+
+// This "observed" machine is intentionally separate from the reference model.
+// In a fully wired setup, this would execute contract calls and decode state/events.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ObservedMachine {
+    state: ModelState,
+}
+
+impl ObservedMachine {
+    pub fn new() -> Self {
+        Self {
+            state: ModelState::new(),
+        }
+    }
+
+    pub fn snapshot(&self) -> &ModelState {
+        &self.state
+    }
+
+    pub fn apply(&mut self, action: &Action) -> Outcome {
+        match *action {
+            Action::Create { .. } => {
+                let id = self.state.next_id;
+                self.state.next_id = self.state.next_id.saturating_add(1);
+                self.state.confessions.insert(
+                    id,
+                    ConfessionState {
+                        id,
+                        reacted_by: BTreeSet::new(),
+                        reported_by: BTreeSet::new(),
+                        resolved: false,
+                    },
+                );
+                Outcome::Applied
+            }
+            Action::React {
+                actor,
+                confession_id,
+            } => self.apply_react(actor, confession_id),
+            Action::Report {
+                actor,
+                confession_id,
+                reason_len,
+            } => self.apply_report(actor, confession_id, reason_len),
+            Action::Resolve {
+                admin,
+                confession_id,
+            } => self.apply_resolve(admin, confession_id),
+        }
+    }
+
+    fn apply_react(&mut self, actor: u32, confession_id: u32) -> Outcome {
+        let Some(conf) = self.state.confessions.get_mut(&confession_id) else {
+            return Outcome::Rejected("confession_not_found");
+        };
+        if conf.resolved {
+            return Outcome::Rejected("already_resolved");
+        }
+        if conf.reacted_by.contains(&actor) {
+            return Outcome::Rejected("duplicate_reaction");
+        }
+        conf.reacted_by.insert(actor);
+        Outcome::Applied
+    }
+
+    fn apply_report(&mut self, actor: u32, confession_id: u32, reason_len: u32) -> Outcome {
+        let Some(conf) = self.state.confessions.get_mut(&confession_id) else {
+            return Outcome::Rejected("confession_not_found");
+        };
+        if conf.resolved {
+            return Outcome::Rejected("already_resolved");
+        }
+        if reason_len == 0 {
+            return Outcome::Rejected("reason_empty");
+        }
+        if reason_len > 128 {
+            return Outcome::Rejected("reason_too_long");
+        }
+        if conf.reported_by.contains(&actor) {
+            return Outcome::Rejected("duplicate_report");
+        }
+        conf.reported_by.insert(actor);
+        Outcome::Applied
+    }
+
+    fn apply_resolve(&mut self, admin: u32, confession_id: u32) -> Outcome {
+        if !self.state.admins.contains(&admin) {
+            return Outcome::Rejected("unauthorized");
+        }
+        let Some(conf) = self.state.confessions.get_mut(&confession_id) else {
+            return Outcome::Rejected("confession_not_found");
+        };
+        if conf.resolved {
+            return Outcome::Rejected("already_resolved");
+        }
+        if conf.reported_by.is_empty() {
+            return Outcome::Rejected("no_pending_report");
+        }
+        conf.resolved = true;
+        Outcome::Applied
+    }
+}

--- a/xconfess-contracts/contracts/tests/model/reference.rs
+++ b/xconfess-contracts/contracts/tests/model/reference.rs
@@ -1,0 +1,105 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::actions::{Action, Outcome};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfessionState {
+    pub id: u32,
+    pub reacted_by: BTreeSet<u32>,
+    pub reported_by: BTreeSet<u32>,
+    pub resolved: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelState {
+    pub next_id: u32,
+    pub confessions: BTreeMap<u32, ConfessionState>,
+    pub admins: BTreeSet<u32>,
+}
+
+impl ModelState {
+    pub fn new() -> Self {
+        let mut admins = BTreeSet::new();
+        admins.insert(0); // deterministic default owner/admin
+        Self {
+            next_id: 1,
+            confessions: BTreeMap::new(),
+            admins,
+        }
+    }
+
+    pub fn apply(&mut self, action: &Action) -> Outcome {
+        match *action {
+            Action::Create { .. } => {
+                let id = self.next_id;
+                self.next_id = self.next_id.saturating_add(1);
+                self.confessions.insert(
+                    id,
+                    ConfessionState {
+                        id,
+                        reacted_by: BTreeSet::new(),
+                        reported_by: BTreeSet::new(),
+                        resolved: false,
+                    },
+                );
+                Outcome::Applied
+            }
+            Action::React {
+                actor,
+                confession_id,
+            } => {
+                let Some(conf) = self.confessions.get_mut(&confession_id) else {
+                    return Outcome::Rejected("confession_not_found");
+                };
+                if conf.resolved {
+                    return Outcome::Rejected("already_resolved");
+                }
+                if !conf.reacted_by.insert(actor) {
+                    return Outcome::Rejected("duplicate_reaction");
+                }
+                Outcome::Applied
+            }
+            Action::Report {
+                actor,
+                confession_id,
+                reason_len,
+            } => {
+                let Some(conf) = self.confessions.get_mut(&confession_id) else {
+                    return Outcome::Rejected("confession_not_found");
+                };
+                if conf.resolved {
+                    return Outcome::Rejected("already_resolved");
+                }
+                if reason_len == 0 {
+                    return Outcome::Rejected("reason_empty");
+                }
+                if reason_len > 128 {
+                    return Outcome::Rejected("reason_too_long");
+                }
+                if !conf.reported_by.insert(actor) {
+                    return Outcome::Rejected("duplicate_report");
+                }
+                Outcome::Applied
+            }
+            Action::Resolve {
+                admin,
+                confession_id,
+            } => {
+                if !self.admins.contains(&admin) {
+                    return Outcome::Rejected("unauthorized");
+                }
+                let Some(conf) = self.confessions.get_mut(&confession_id) else {
+                    return Outcome::Rejected("confession_not_found");
+                };
+                if conf.resolved {
+                    return Outcome::Rejected("already_resolved");
+                }
+                if conf.reported_by.is_empty() {
+                    return Outcome::Rejected("no_pending_report");
+                }
+                conf.resolved = true;
+                Outcome::Applied
+            }
+        }
+    }
+}

--- a/xconfess-contracts/contracts/tests/model/replay.rs
+++ b/xconfess-contracts/contracts/tests/model/replay.rs
@@ -1,0 +1,10 @@
+use super::actions::Action;
+
+pub fn format_action_trace(actions: &[Action]) -> String {
+    actions
+        .iter()
+        .enumerate()
+        .map(|(i, a)| format!("#{i}:{a:?}"))
+        .collect::<Vec<String>>()
+        .join(" | ")
+}

--- a/xconfess-contracts/contracts/tests/model_based_state_machine.test.rs
+++ b/xconfess-contracts/contracts/tests/model_based_state_machine.test.rs
@@ -1,0 +1,72 @@
+#[path = "model/mod.rs"]
+mod model;
+
+use model::actions::Action;
+use model::generator::generate_actions;
+use model::observed::ObservedMachine;
+use model::reference::ModelState;
+use model::replay::format_action_trace;
+
+fn run_model_comparison(seed: u64, steps: usize, inject_fault_at: Option<usize>) -> Result<(), String> {
+    let actions = generate_actions(seed, steps);
+    let mut reference = ModelState::new();
+    let mut observed = ObservedMachine::new();
+    let mut history: Vec<Action> = Vec::new();
+
+    for (idx, action) in actions.iter().enumerate() {
+        let reference_outcome = reference.apply(action);
+        let observed_outcome = observed.apply(action);
+        history.push(action.clone());
+
+        // Optional test-only fault injection to prove divergence detection.
+        if inject_fault_at == Some(idx) {
+            let _ = observed.apply(&Action::Create { actor: 9999 });
+        }
+
+        if reference_outcome != observed_outcome || &reference != observed.snapshot() {
+            return Err(format!(
+                "model divergence seed={seed} step={idx} action={action:?} trace={}",
+                format_action_trace(&history)
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn fixed_seed_replay_is_deterministic() {
+    let seed = 42_u64;
+    let steps = 250_usize;
+
+    let run_a = generate_actions(seed, steps);
+    let run_b = generate_actions(seed, steps);
+
+    assert_eq!(run_a, run_b, "same seed must produce identical action sequence");
+    assert!(run_model_comparison(seed, steps, None).is_ok());
+}
+
+#[test]
+fn model_based_suite_multiple_seeds_no_divergence() {
+    let seeds = [1_u64, 7, 42, 1234, 20260323];
+    for seed in seeds {
+        let result = run_model_comparison(seed, 300, None);
+        assert!(
+            result.is_ok(),
+            "unexpected model divergence for seed {seed}: {}",
+            result.err().unwrap_or_else(|| "unknown".to_string())
+        );
+    }
+}
+
+#[test]
+fn model_suite_surfaces_failing_seed_and_trace() {
+    let seed = 20260323_u64;
+    let failure = run_model_comparison(seed, 120, Some(20));
+    assert!(failure.is_err(), "fault injection should cause divergence");
+
+    let message = failure.err().unwrap_or_default();
+    assert!(message.contains("seed=20260323"));
+    assert!(message.contains("step="));
+    assert!(message.contains("trace="));
+}

--- a/xconfess-contracts/contracts/tests/report_test.rs
+++ b/xconfess-contracts/contracts/tests/report_test.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Env, symbol};
+use soroban_sdk::{Env, String as SorobanString, symbol};
 use xconfess_contract::report::ReportContract;
 
 #[test]
@@ -11,11 +11,64 @@ fn test_report_deduplication() {
 
     // First report by A → success
     assert!(ReportContract::submit_report(env.clone(), actor_a.clone(), confession.clone()).is_ok());
+    assert_eq!(
+        ReportContract::latest_report_nonce(env.clone(), confession.clone()),
+        1
+    );
 
     // Duplicate report by A → fail
     let err = ReportContract::submit_report(env.clone(), actor_a.clone(), confession.clone());
     assert_eq!(err.unwrap_err().as_str(), "cooldown_active");
+    assert_eq!(
+        ReportContract::latest_report_nonce(env.clone(), confession.clone()),
+        1
+    );
 
     // Report by B → success
     assert!(ReportContract::submit_report(env.clone(), actor_b.clone(), confession.clone()).is_ok());
+    assert_eq!(
+        ReportContract::latest_report_nonce(env, confession),
+        2
+    );
+}
+
+#[test]
+fn test_report_reason_boundary_exact_limit_succeeds() {
+    let env = Env::default();
+    let actor = symbol!("actor_a");
+    let confession = symbol!("confession_2");
+
+    let reason_text = "x".repeat(ReportContract::MAX_REPORT_REASON_LEN as usize);
+    let reason = SorobanString::from_str(&env, &reason_text);
+
+    let result = ReportContract::submit_report_with_reason(
+        env.clone(),
+        actor,
+        confession.clone(),
+        reason,
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(ReportContract::latest_report_nonce(env, confession), 1);
+}
+
+#[test]
+fn test_report_reason_over_limit_rejected() {
+    let env = Env::default();
+    let actor = symbol!("actor_a");
+    let confession = symbol!("confession_3");
+
+    let reason_text = "x".repeat((ReportContract::MAX_REPORT_REASON_LEN + 1) as usize);
+    let reason = SorobanString::from_str(&env, &reason_text);
+
+    let result = ReportContract::submit_report_with_reason(
+        env.clone(),
+        actor,
+        confession.clone(),
+        reason,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().as_str(), "reason_too_long");
+    assert_eq!(ReportContract::latest_report_nonce(env, confession), 0);
 }


### PR DESCRIPTION
Closes #398
Close #403 
close #404 


---

Implements #403 and #404 with deterministic event ordering and model-based lifecycle checks.\n\nIncludes:\n- bounded payload/string validation\n- boundary + rejection tests\n- model-based state-machine suite with reproducible seeds