### PR TITLE
fix: data export

### DIFF
--- a/xconfess-backend/src/data-export/data-export.controller.ts
+++ b/xconfess-backend/src/data-export/data-export.controller.ts
@@ -1,8 +1,20 @@
-import { Controller, Get, Param, Query, Res, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  Res,
+  UnauthorizedException,
+  BadRequestException,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { Response } from 'express';
 import * as crypto from 'crypto';
 import { DataExportService } from './data-export.service';
 import { ConfigService } from '@nestjs/config';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('data-export')
 export class DataExportController {
@@ -10,6 +22,34 @@ export class DataExportController {
     private readonly exportService: DataExportService,
     private readonly configService: ConfigService,
   ) { }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('request')
+  async requestExport(@Req() req: any) {
+    return this.exportService.requestExport(String(req.user.id));
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('history')
+  async history(@Req() req: any) {
+    const userId = String(req.user.id);
+    const latest = await this.exportService.getLatestExport(userId);
+    const history = await this.exportService.getExportHistory(userId);
+
+    return {
+      latest,
+      history,
+    };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/redownload')
+  async redownload(
+    @Param('id') id: string,
+    @Req() req: any,
+  ) {
+    return this.exportService.getRedownloadLink(id, String(req.user.id));
+  }
 
   @Get('download/:id')
   async download(

--- a/xconfess-backend/src/data-export/data-export.service.ts
+++ b/xconfess-backend/src/data-export/data-export.service.ts
@@ -9,6 +9,18 @@ import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { ExportRequest } from './entities/export-request.entity';
 
+export type ExportHistoryStatus = 'PENDING' | 'PROCESSING' | 'READY' | 'FAILED' | 'EXPIRED';
+
+export interface ExportHistoryItem {
+  id: string;
+  status: ExportHistoryStatus;
+  createdAt: Date;
+  expiresAt: number | null;
+  canRedownload: boolean;
+  canRequestNewLink: boolean;
+  downloadUrl: string | null;
+}
+
 @Injectable()
 export class DataExportService {
   constructor(
@@ -68,6 +80,71 @@ export class DataExportService {
       where: { id: requestId, userId },
       select: ['fileData', 'status'],
     });
+  }
+
+  private getExpiryTimestamp(createdAt: Date): number {
+    return new Date(createdAt).getTime() + 24 * 60 * 60 * 1000;
+  }
+
+  private isDownloadStillValid(request: Pick<ExportRequest, 'status' | 'createdAt'>): boolean {
+    if (request.status !== 'READY') {
+      return false;
+    }
+
+    return Date.now() <= this.getExpiryTimestamp(request.createdAt);
+  }
+
+  private toHistoryItem(request: Pick<ExportRequest, 'id' | 'status' | 'createdAt' | 'userId'>): ExportHistoryItem {
+    const expiresAt = request.status === 'READY' ? this.getExpiryTimestamp(request.createdAt) : null;
+    const canRedownload = this.isDownloadStillValid(request);
+    const normalizedStatus: ExportHistoryStatus =
+      request.status === 'READY' && !canRedownload
+        ? 'EXPIRED'
+        : (request.status as ExportHistoryStatus);
+
+    return {
+      id: request.id,
+      status: normalizedStatus,
+      createdAt: request.createdAt,
+      expiresAt,
+      canRedownload,
+      canRequestNewLink: normalizedStatus === 'EXPIRED',
+      downloadUrl: canRedownload ? this.generateSignedDownloadUrl(request.id, request.userId) : null,
+    };
+  }
+
+  async getExportHistory(userId: string, limit = 20): Promise<ExportHistoryItem[]> {
+    const requests = await this.exportRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+      select: ['id', 'status', 'createdAt', 'userId'],
+    });
+
+    return requests.map((request) => this.toHistoryItem(request));
+  }
+
+  async getLatestExport(userId: string): Promise<ExportHistoryItem | null> {
+    const latestRequest = await this.exportRepository.findOne({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      select: ['id', 'status', 'createdAt', 'userId'],
+    });
+
+    return latestRequest ? this.toHistoryItem(latestRequest) : null;
+  }
+
+  async getRedownloadLink(requestId: string, userId: string): Promise<{ downloadUrl: string }> {
+    const request = await this.exportRepository.findOne({
+      where: { id: requestId, userId },
+      select: ['id', 'status', 'createdAt', 'userId'],
+    });
+
+    if (!request || !this.isDownloadStillValid(request)) {
+      throw new BadRequestException('Secure download link is no longer available. Request a new export.');
+    }
+
+    return { downloadUrl: this.generateSignedDownloadUrl(request.id, request.userId) };
   }
 
   async compileUserData(userId: string): Promise<any> {

--- a/xconfess-contracts/Cargo.lock
+++ b/xconfess-contracts/Cargo.lock
@@ -1031,13 +1031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reputation-badges"
-version = "0.0.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/xconfess-frontend/app/(dashboard)/settings/data-export/DataExportRequest.tsx
+++ b/xconfess-frontend/app/(dashboard)/settings/data-export/DataExportRequest.tsx
@@ -1,39 +1,168 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { ShieldCheck, Download, Clock, AlertCircle } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { AlertCircle, CheckCircle2, Clock3, Download, RotateCw, ShieldCheck, XCircle } from 'lucide-react';
+import ErrorState from '@/app/components/common/ErrorState';
+import {
+  dataExportApi,
+  type DataExportHistoryItem,
+  type DataExportStatus,
+} from '@/app/lib/api/client';
 
 export default function DataExportRequest() {
-  const [exportReq, setExportReq] = useState<any>(null);
-  const [loading, setLoading] = useState(false);
+  const [history, setHistory] = useState<DataExportHistoryItem[]>([]);
+  const [loadingHistory, setLoadingHistory] = useState(true);
+  const [requestingExport, setRequestingExport] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [actionLoadingId, setActionLoadingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  // Poll for updates if the status is PENDING or PROCESSING
-  useEffect(() => {
-    let interval: NodeJS.Timeout;
-    if (exportReq?.status === 'PENDING' || exportReq?.status === 'PROCESSING') {
-      interval = setInterval(checkStatus, 5000);
+  const loadHistory = async (isRefresh = false) => {
+    if (isRefresh) {
+      setRefreshing(true);
+    } else {
+      setLoadingHistory(true);
     }
-    return () => clearInterval(interval);
-  }, [exportReq]);
 
-  const checkStatus = async () => {
-    const res = await fetch('/api/data-export/status');
-    const data = await res.json();
-    setExportReq(data);
-  };
-
-  const handleRequest = async () => {
-    setLoading(true);
     try {
-      const res = await fetch('/api/data-export/request', { method: 'POST' });
-      const data = await res.json();
-      setExportReq(data);
-    } catch (err) {
-      console.error("Export request failed");
+      const data = await dataExportApi.getHistory();
+      setHistory(data.history);
+      setError(null);
+    } catch {
+      setError('Failed to load data export history. Please try again.');
     } finally {
-      setLoading(false);
+      if (isRefresh) {
+        setRefreshing(false);
+      } else {
+        setLoadingHistory(false);
+      }
     }
   };
+
+  useEffect(() => {
+    loadHistory();
+  }, []);
+
+  const hasInProgressJob = useMemo(
+    () => history.some((item) => item.status === 'PENDING' || item.status === 'PROCESSING'),
+    [history],
+  );
+
+  const latest = history[0] ?? null;
+
+  useEffect(() => {
+    if (!hasInProgressJob) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      loadHistory(true);
+    }, 5000);
+
+    return () => clearInterval(timer);
+  }, [hasInProgressJob]);
+
+  const handleRequestExport = async () => {
+    setRequestingExport(true);
+    try {
+      await dataExportApi.requestExport();
+      await loadHistory(true);
+    } catch {
+      setError('Unable to request a new archive right now. Please try again shortly.');
+    } finally {
+      setRequestingExport(false);
+    }
+  };
+
+  const handleRedownload = async (item: DataExportHistoryItem) => {
+    if (!item.canRedownload) {
+      return;
+    }
+
+    setActionLoadingId(item.id);
+    try {
+      const response = await dataExportApi.redownload(item.id);
+      window.open(response.downloadUrl, '_blank', 'noopener,noreferrer');
+      setError(null);
+    } catch {
+      setError('Download link is no longer valid. Request a new link from this row.');
+      await loadHistory(true);
+    } finally {
+      setActionLoadingId(null);
+    }
+  };
+
+  const formatStatus = (status: DataExportStatus) => {
+    switch (status) {
+      case 'PENDING':
+        return 'Pending';
+      case 'PROCESSING':
+        return 'Processing';
+      case 'READY':
+        return 'Complete';
+      case 'FAILED':
+        return 'Failed';
+      case 'EXPIRED':
+        return 'Expired';
+      default:
+        return status;
+    }
+  };
+
+  const statusBadgeClass: Record<DataExportStatus, string> = {
+    PENDING: 'bg-amber-100 text-amber-800',
+    PROCESSING: 'bg-blue-100 text-blue-800',
+    READY: 'bg-green-100 text-green-800',
+    FAILED: 'bg-red-100 text-red-800',
+    EXPIRED: 'bg-slate-200 text-slate-700',
+  };
+
+  const statusIcon = (status: DataExportStatus) => {
+    switch (status) {
+      case 'READY':
+        return <CheckCircle2 size={15} className="text-green-600" />;
+      case 'FAILED':
+        return <XCircle size={15} className="text-red-500" />;
+      case 'PENDING':
+      case 'PROCESSING':
+        return <Clock3 size={15} className="text-amber-600" />;
+      case 'EXPIRED':
+      default:
+        return <AlertCircle size={15} className="text-slate-500" />;
+    }
+  };
+
+  const retentionMessage = (item: DataExportHistoryItem) => {
+    if (item.status === 'READY' && item.expiresAt) {
+      return `Download expires ${new Date(item.expiresAt).toLocaleString()}.`;
+    }
+    if (item.status === 'EXPIRED') {
+      return 'Secure link expired. Request a new export link.';
+    }
+    if (item.status === 'FAILED') {
+      return 'Generation failed. Request a new export to retry.';
+    }
+    return 'Archive retained for 24 hours once complete.';
+  };
+
+  if (loadingHistory) {
+    return (
+      <div className="max-w-4xl p-8 bg-white rounded-2xl border border-slate-200">
+        <p className="text-sm text-slate-500">Loading export history...</p>
+      </div>
+    );
+  }
+
+  if (error && history.length === 0) {
+    return (
+      <ErrorState
+        title="Unable to load exports"
+        error={error}
+        description="We could not fetch your export history."
+        onRetry={() => loadHistory()}
+      />
+    );
+  }
 
   return (
     <div className="max-w-4xl p-8 bg-white rounded-2xl border border-slate-200">
@@ -44,63 +173,107 @@ export default function DataExportRequest() {
         </p>
       </header>
 
-      {/* GDPR Info Box */}
       <div className="flex gap-4 p-4 mb-8 bg-slate-50 rounded-xl border border-slate-100">
         <ShieldCheck className="text-indigo-600 w-6 h-6 shrink-0" />
         <div>
           <h4 className="font-semibold text-slate-800 text-sm">Privacy & Portability</h4>
           <p className="text-xs text-slate-600 leading-relaxed mt-1">
-            To comply with GDPR, we provide your data in JSON (for machines) and CSV (for humans) formats. 
+            To comply with GDPR, we provide your data in JSON (for machines) and CSV (for humans) formats.
             Once your file is ready, you have 24 hours to download it before the link expires.
           </p>
         </div>
       </div>
 
-      {/* Main Action Area */}
-      <div className="bg-white border rounded-xl p-6">
-        {!exportReq || exportReq.status === 'EXPIRED' ? (
-          <div className="text-center py-4">
-            <button
-              onClick={handleRequest}
-              disabled={loading}
-              className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-6 rounded-lg transition-all disabled:bg-slate-300"
-            >
-              {loading ? 'Initiating...' : 'Generate New Archive'}
-            </button>
-            <p className="text-[11px] text-slate-400 mt-3 italic">
-              You can request an export once every 7 days.
-            </p>
-          </div>
-        ) : (
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <div className={`p-3 rounded-full ${exportReq.status === 'READY' ? 'bg-green-100' : 'bg-amber-100'}`}>
-                {exportReq.status === 'READY' ? <Download className="text-green-600" /> : <Clock className="text-amber-600 animate-pulse" />}
-              </div>
-              <div>
-                <h4 className="font-medium text-slate-900">
-                  {exportReq.status === 'READY' ? 'Your data is ready' : 'Preparing your data...'}
-                </h4>
-                <p className="text-sm text-slate-500">
-                  Requested on {new Date(exportReq.createdAt).toLocaleDateString()}
-                </p>
-              </div>
-            </div>
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 className="text-base font-semibold text-slate-900">Export Requests</h2>
+        <button
+          type="button"
+          onClick={() => loadHistory(true)}
+          disabled={refreshing}
+          className="inline-flex items-center gap-2 text-sm px-3 py-2 border rounded-lg text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+        >
+          <RotateCw size={14} className={refreshing ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
 
-            {exportReq.status === 'READY' && (
-              <a
-                href={`/api/data-export/download/${exportReq.id}?userId=${exportReq.userId}&token=...`} // Use the signed logic here
-                className="bg-slate-900 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-slate-800 transition"
-              >
-                Download (.zip)
-              </a>
-            )}
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-white border rounded-xl p-6">
+        <div className="text-center py-3 border-b border-slate-100 mb-4">
+          <button
+            onClick={handleRequestExport}
+            disabled={requestingExport || hasInProgressJob}
+            className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-6 rounded-lg transition-all disabled:bg-slate-300"
+          >
+            {requestingExport ? 'Initiating...' : 'Generate New Archive'}
+          </button>
+          <p className="text-[11px] text-slate-400 mt-3 italic">
+            You can request an export once every 7 days.
+          </p>
+          {hasInProgressJob && (
+            <p className="text-xs text-amber-700 mt-2">
+              An export is currently running. Refresh to see updated status.
+            </p>
+          )}
+        </div>
+
+        {history.length === 0 ? (
+          <p className="text-sm text-slate-500">No export requests yet.</p>
+        ) : (
+          <div className="space-y-3">
+            {history.map((item) => (
+              <div key={item.id} className="rounded-lg border border-slate-100 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      {statusIcon(item.status)}
+                      <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${statusBadgeClass[item.status]}`}>
+                        {formatStatus(item.status)}
+                      </span>
+                    </div>
+                    <p className="text-sm font-medium text-slate-900">
+                      Requested {new Date(item.createdAt).toLocaleString()}
+                    </p>
+                    <p className="text-xs text-slate-500 mt-1">{retentionMessage(item)}</p>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    {item.canRedownload && (
+                      <button
+                        type="button"
+                        onClick={() => handleRedownload(item)}
+                        disabled={actionLoadingId === item.id}
+                        className="inline-flex items-center gap-1.5 rounded-md bg-slate-900 px-3 py-2 text-xs font-medium text-white hover:bg-slate-800 disabled:opacity-60"
+                      >
+                        <Download size={14} />
+                        {actionLoadingId === item.id ? 'Preparing...' : 'Re-download'}
+                      </button>
+                    )}
+
+                    {item.canRequestNewLink && (
+                      <button
+                        type="button"
+                        onClick={handleRequestExport}
+                        disabled={requestingExport}
+                        className="rounded-md border border-slate-300 px-3 py-2 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+                      >
+                        Request New Link
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
           </div>
         )}
       </div>
 
-      {/* Error State */}
-      {exportReq?.status === 'FAILED' && (
+      {latest?.status === 'FAILED' && (
         <div className="mt-4 flex items-center gap-2 text-red-600 text-sm">
           <AlertCircle size={16} />
           <span>Something went wrong. Please try again in a few minutes.</span>

--- a/xconfess-frontend/app/components/common/ErrorState.tsx
+++ b/xconfess-frontend/app/components/common/ErrorState.tsx
@@ -5,7 +5,7 @@ import RetryButton from './RetryButton';
 
 interface ErrorStateProps {
   error?: string;
-  onRetry?: () => Promise<void>;
+  onRetry?: () => void | Promise<void>;
   title?: string;
   description?: string;
   showIcon?: boolean;

--- a/xconfess-frontend/app/lib/api/client.ts
+++ b/xconfess-frontend/app/lib/api/client.ts
@@ -106,3 +106,41 @@ apiClient.interceptors.response.use(
 
 export default apiClient;
 export { AxiosError };
+
+export type DataExportStatus = "PENDING" | "PROCESSING" | "READY" | "FAILED" | "EXPIRED";
+
+export interface DataExportHistoryItem {
+	id: string;
+	status: DataExportStatus;
+	createdAt: string;
+	expiresAt: number | null;
+	canRedownload: boolean;
+	canRequestNewLink: boolean;
+	downloadUrl: string | null;
+}
+
+export interface DataExportHistoryResponse {
+	latest: DataExportHistoryItem | null;
+	history: DataExportHistoryItem[];
+}
+
+export const dataExportApi = {
+	async getHistory() {
+		const response = await apiClient.get<DataExportHistoryResponse>("/data-export/history");
+		return response.data;
+	},
+
+	async requestExport() {
+		const response = await apiClient.post<{ requestId: string; status: string }>(
+			"/data-export/request",
+		);
+		return response.data;
+	},
+
+	async redownload(requestId: string) {
+		const response = await apiClient.post<{ downloadUrl: string }>(
+			`/data-export/${requestId}/redownload`,
+		);
+		return response.data;
+	},
+};


### PR DESCRIPTION
Closes #425

---

What changed
Updated xconfess-frontend/app/(dashboard)/settings/data-export/DataExportRequest.tsx

Replaced single-request UI with a history list of export requests.
Added status badges for PENDING, PROCESSING, READY (shown as Complete), FAILED, EXPIRED.
Added actions per record:
Re-download only when a valid secure link is available.
Request New Link when record is expired.
Added top-level Refresh action.
Added inline retention/expiry messaging per row.
Added polling while there are active jobs, and reload on refresh (state persists by re-fetching server history).
Updated xconfess-frontend/app/lib/api/client.ts

Added typed data-export API helper:
getHistory()
requestExport()
redownload(requestId)
Added data-export response/type definitions.
Updated xconfess-frontend/app/components/common/ErrorState.tsx

Relaxed retry callback type to () => void | Promise<void> to support sync/async retry handlers cleanly.
Updated xconfess-backend/src/data-export/data-export.controller.ts

Added authenticated endpoints:
POST /data-export/request
GET /data-export/history
POST /data-export/:id/redownload
Kept existing signed download endpoint behavior intact.
Updated xconfess-backend/src/data-export/data-export.service.ts

Added history DTO/types and mapping logic.
Added logic to compute expiry window and validity.
Added:
getExportHistory(userId, limit?)
getLatestExport(userId)
getRedownloadLink(requestId, userId)
Ensures re-download links are only returned when still valid.
Validation
Checked lints for all touched files: no linter errors reported.