### PR TITLE
docs: add release readiness checklist for #472

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -1,5 +1,7 @@
 # Failed Notification Jobs Dashboard - Deployment Checklist
 
+This checklist is specific to the failed notification jobs dashboard release flow. For cross-system release gates covering backend, frontend, contracts, rollback, and post-release verification, start with [docs/release-readiness-checklist.md](docs/release-readiness-checklist.md) and then use this document for the dashboard-specific checks below.
+
 ## Pre-Deployment Checklist
 
 ### Code Review

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ xconfess/
 
 ---
 
+## 🚀 Release Readiness
+
+Use the shared release checklist at [docs/release-readiness-checklist.md](docs/release-readiness-checklist.md) before promoting backend, frontend, or contract changes.
+
+Key supporting references:
+
+- [DEPLOYMENT_CHECKLIST.md](DEPLOYMENT_CHECKLIST.md) for frontend-heavy deployment verification details
+- [docs/SOROBAN_SETUP.md](docs/SOROBAN_SETUP.md) for Soroban environment setup and contract interaction help
+- [maintainer/issues/125-docs-contract-release-and-upgrade-runbook.md](maintainer/issues/125-docs-contract-release-and-upgrade-runbook.md) for contract release and rollback guidance
+
+---
+
 ## ⚙️ Installation
 
 ### Prerequisites

--- a/docs/release-readiness-checklist.md
+++ b/docs/release-readiness-checklist.md
@@ -1,0 +1,109 @@
+# Release Readiness Checklist
+
+Use this checklist before any staging or production release that affects the backend, frontend, contracts, or shared operations flow.
+
+## Release Scope
+
+- [ ] Record the release owner, target environment, and planned release window.
+- [ ] Link the pull request, issue, or release notes bundle that defines the intended changes.
+- [ ] Confirm which subsystems changed: `backend`, `frontend`, `contracts`, `docs`, or `ops`.
+- [ ] Confirm the rollback owner and the communication channel to use if the release needs to pause or revert.
+
+## Pre-Release Gates
+
+### Repository And CI
+
+- [ ] Run dependency install from the repo root: `npm ci`
+- [ ] Review the latest CI results for `.github/workflows/ci.yml`.
+- [ ] Confirm no unresolved blockers remain in code review or release notes.
+- [ ] Verify any required environment variable or secret changes are prepared before deployment.
+
+### Backend Readiness
+
+- [ ] Build the backend: `npm run build --workspace=xconfess-backend`
+- [ ] Lint the backend: `npm run lint --workspace=xconfess-backend`
+- [ ] Run backend unit tests: `npm run test --workspace=xconfess-backend`
+- [ ] Run backend e2e tests required for the release: `npm run test:e2e --workspace=xconfess-backend`
+- [ ] Review schema, migration, and configuration changes in `xconfess-backend`.
+- [ ] Confirm API docs or route contracts changed only in ways that downstream consumers can tolerate.
+- [ ] Verify websocket, cache, queue, and background-job changes include an operational verification step if they were touched.
+
+### Frontend Readiness
+
+- [ ] Build the frontend with the intended API base URL: `NEXT_PUBLIC_API_URL=http://localhost:5000 npm run build --workspace=xconfess-frontend`
+- [ ] Lint the frontend: `npm run lint --workspace=xconfess-frontend`
+- [ ] Run frontend tests: `npm run test --workspace=xconfess-frontend`
+- [ ] Smoke-check the primary user journeys affected by the release.
+- [ ] Verify auth, dashboard navigation, and any changed admin flows against the backend contract.
+- [ ] Check responsive behavior for changed pages on desktop and mobile-sized viewports.
+
+### Contract Readiness
+
+- [ ] Review `maintainer/issues/125-docs-contract-release-and-upgrade-runbook.md` before any contract release or upgrade.
+- [ ] Run contract tests: `./scripts/test-contracts.sh`
+- [ ] Build the contract artifacts: `./scripts/build-contracts.sh`
+- [ ] Verify the expected WASM artifacts exist under `xconfess-contracts/target/wasm32v1-none/release/`.
+- [ ] Record the SHA-256 hash for each artifact being promoted.
+- [ ] Confirm the target network, deployer identity, and funding state before deployment.
+- [ ] Verify any backend or frontend config that depends on new contract IDs is ready to update in the same release window.
+
+## Deployment Plan
+
+### Staging Or Canary
+
+- [ ] Deploy to staging or the smallest safe audience first.
+- [ ] For GitHub Actions driven deployment, run `.github/workflows/cd.yml` with the correct environment and `run_build` setting.
+- [ ] Apply backend changes before frontend changes when the frontend depends on newly released API behavior.
+- [ ] Deploy contracts before enabling code that references new contract IDs or event shapes.
+- [ ] Capture deployment artifacts, logs, and resulting version identifiers in the release notes.
+
+### Manual Coordination Points
+
+- [ ] Update contract deployment records if new contract IDs were issued.
+- [ ] Update runtime configuration for backend and frontend services after deployment artifacts are promoted.
+- [ ] Confirm operators know whether the release contains migrations, cache invalidation needs, queue draining, or websocket behavior changes.
+
+## Verification After Deploy
+
+### Backend Verification
+
+- [ ] Confirm the backend starts cleanly and serves the expected environment.
+- [ ] Verify health-critical API routes and any changed endpoints.
+- [ ] Check logs for migration failures, queue crashes, cache issues, or authorization errors.
+- [ ] Verify background workers, realtime events, and scheduled jobs if the release touched them.
+
+### Frontend Verification
+
+- [ ] Load the deployed frontend and confirm the app boots without console or hydration errors.
+- [ ] Validate the main release path end to end against the deployed backend.
+- [ ] Confirm auth, navigation, and affected dashboards or forms work in the target environment.
+- [ ] Re-check one mobile-sized layout for every user-facing page changed in the release.
+
+### Contract Verification
+
+- [ ] If contracts were deployed, confirm deploy commands completed successfully and contract IDs were recorded.
+- [ ] Run contract smoke checks using the promoted IDs and target network.
+- [ ] Verify downstream consumers can read the expected on-chain data or events.
+- [ ] Confirm no unexpected error codes or payload-shape changes surfaced during verification.
+
+## Rollback Readiness
+
+- [ ] Define the exact rollback trigger for this release before starting deployment.
+- [ ] Keep the last known-good backend artifact, frontend artifact, and contract metadata available.
+- [ ] Confirm which changes are reversible immediately and which require operator intervention.
+- [ ] If a contract change is not directly reversible, document the mitigation path before release.
+- [ ] Prepare the communication message to send if rollback or release pause is required.
+
+## Post-Release Follow-Up
+
+- [ ] Monitor logs, alerts, and user reports during the agreed observation window.
+- [ ] Confirm post-release metrics remain within normal ranges for error rate, latency, and job health.
+- [ ] Update runbooks or deployment docs if the team had to improvise during the release.
+- [ ] Close the release with a short summary of what shipped, what was verified, and any follow-up actions.
+
+## Related References
+
+- `README.md`
+- `DEPLOYMENT_CHECKLIST.md`
+- `docs/SOROBAN_SETUP.md`
+- `maintainer/issues/125-docs-contract-release-and-upgrade-runbook.md`


### PR DESCRIPTION
Closes #472

## Summary
Add a shared repo-level release readiness checklist that operators can use before shipping backend, frontend, or contract changes.

## Problem
Release guidance was fragmented across the repo, which made it harder to coordinate cross-system releases, rollback planning, and post-release verification without relying on tribal knowledge.

## Scope
- Add `docs/release-readiness-checklist.md` with release gates for backend, frontend, contracts, deployment sequencing, rollback, and post-release follow-up
- Link the new checklist from `README.md`
- Clarify in `DEPLOYMENT_CHECKLIST.md` that it is a dashboard-specific checklist and should be used alongside the shared release readiness guide
- Reference the existing contract release guidance in `maintainer/issues/125-docs-contract-release-and-upgrade-runbook.md`

## Acceptance Criteria
- The checklist covers critical release gates for backend, frontend, and contracts
- Rollback, canary/staging, and post-release verification steps are explicitly documented
- Operators can use the document without needing hidden context from maintainers

## How To Test
1. Open `docs/release-readiness-checklist.md`
2. Walk through the checklist for a simulated release affecting backend, frontend, and contracts
3. Verify the README and deployment checklist both point to the shared release-readiness flow
4. Confirm rollback and post-release verification steps are concrete and actionable

## Notes
- Docs-only change
- No automated tests were run
