### PR TITLE
feat(analytics): targeted cache invalidation on reactions and comments

### DIFF
--- a/xconfess-backend/jest.config.js
+++ b/xconfess-backend/jest.config.js
@@ -2,6 +2,9 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/*.spec.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/xconfess-backend/'],
+  watchPathIgnorePatterns: ['<rootDir>/xconfess-backend/'],
+  modulePathIgnorePatterns: ['<rootDir>/xconfess-backend/'],
   moduleNameMapper: {
     '^src/(.*)$': '<rootDir>/src/$1',
   },

--- a/xconfess-backend/src/analytics/analytics.module.ts
+++ b/xconfess-backend/src/analytics/analytics.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { CacheModule } from '@nestjs/cache-manager';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
 import { Reaction } from 'src/reaction/entities/reaction.entity';
@@ -8,10 +7,7 @@ import { User } from 'src/user/entities/user.entity';
 import { AnonymousConfession } from 'src/confession/entities/confession.entity';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([AnonymousConfession, Reaction, User]),
-    CacheModule.register(),
-  ],
+  imports: [TypeOrmModule.forFeature([AnonymousConfession, Reaction, User])],
   controllers: [AnalyticsController],
   providers: [AnalyticsService],
   exports: [AnalyticsService], // Export for use in other modules

--- a/xconfess-backend/src/analytics/analytics.service.spec.ts
+++ b/xconfess-backend/src/analytics/analytics.service.spec.ts
@@ -1,18 +1,168 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { AnalyticsService } from './analytics.service';
+import { Reaction } from '../reaction/entities/reaction.entity';
+import { User } from '../user/entities/user.entity';
+import { AnonymousConfession } from '../confession/entities/confession.entity';
+import { CacheService } from '../cache/cache.service';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const repoMock = () => ({
+  createQueryBuilder: jest.fn(),
+  count: jest.fn(),
+  findOne: jest.fn(),
+});
+
+const makeCacheServiceMock = () => ({
+  get: jest.fn().mockResolvedValue(null),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  invalidateSegment: jest.fn().mockResolvedValue(1),
+});
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
 
 describe('AnalyticsService', () => {
   let service: AnalyticsService;
+  let cacheService: ReturnType<typeof makeCacheServiceMock>;
 
   beforeEach(async () => {
+    cacheService = makeCacheServiceMock();
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AnalyticsService],
+      providers: [
+        AnalyticsService,
+        {
+          provide: getRepositoryToken(AnonymousConfession),
+          useFactory: repoMock,
+        },
+        { provide: getRepositoryToken(Reaction), useFactory: repoMock },
+        { provide: getRepositoryToken(User), useFactory: repoMock },
+        { provide: CacheService, useValue: cacheService },
+      ],
     }).compile();
 
     service = module.get<AnalyticsService>(AnalyticsService);
   });
 
+  afterEach(() => jest.clearAllMocks());
+
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  // ── invalidateTrendingCache ──────────────────────────────────────────────
+
+  describe('invalidateTrendingCache()', () => {
+    it('calls invalidateSegment with the trending prefix', async () => {
+      await service.invalidateTrendingCache('test');
+      expect(cacheService.invalidateSegment).toHaveBeenCalledWith(
+        'analytics:trending',
+        'test',
+      );
+    });
+
+    it('uses "mutation" as the default reason', async () => {
+      await service.invalidateTrendingCache();
+      expect(cacheService.invalidateSegment).toHaveBeenCalledWith(
+        'analytics:trending',
+        'mutation',
+      );
+    });
+  });
+
+  // ── invalidateReactionDistributionCache ─────────────────────────────────
+
+  describe('invalidateReactionDistributionCache()', () => {
+    it('calls invalidateSegment with the reactions prefix', async () => {
+      await service.invalidateReactionDistributionCache('test');
+      expect(cacheService.invalidateSegment).toHaveBeenCalledWith(
+        'analytics:reactions',
+        'test',
+      );
+    });
+  });
+
+  // ── invalidateGrowthCache ────────────────────────────────────────────────
+
+  describe('invalidateGrowthCache()', () => {
+    it('calls invalidateSegment with the growth prefix', async () => {
+      await service.invalidateGrowthCache('test');
+      expect(cacheService.invalidateSegment).toHaveBeenCalledWith(
+        'analytics:growth',
+        'test',
+      );
+    });
+  });
+
+  // ── invalidateUserActivityCache ──────────────────────────────────────────
+
+  describe('invalidateUserActivityCache()', () => {
+    it('calls invalidateSegment with the users prefix', async () => {
+      await service.invalidateUserActivityCache('test');
+      expect(cacheService.invalidateSegment).toHaveBeenCalledWith(
+        'analytics:users',
+        'test',
+      );
+    });
+  });
+
+  // ── invalidateStatsCache ─────────────────────────────────────────────────
+
+  describe('invalidateStatsCache()', () => {
+    it('deletes only the stats key', async () => {
+      await service.invalidateStatsCache('test');
+      expect(cacheService.del).toHaveBeenCalledWith('analytics:stats');
+      expect(cacheService.invalidateSegment).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── invalidateCache (full flush) ─────────────────────────────────────────
+
+  describe('invalidateCache()', () => {
+    it('calls all targeted segment invalidation methods', async () => {
+      const spyTrending = jest
+        .spyOn(service, 'invalidateTrendingCache')
+        .mockResolvedValue();
+      const spyReactions = jest
+        .spyOn(service, 'invalidateReactionDistributionCache')
+        .mockResolvedValue();
+      const spyGrowth = jest
+        .spyOn(service, 'invalidateGrowthCache')
+        .mockResolvedValue();
+      const spyUsers = jest
+        .spyOn(service, 'invalidateUserActivityCache')
+        .mockResolvedValue();
+      const spyStats = jest
+        .spyOn(service, 'invalidateStatsCache')
+        .mockResolvedValue();
+
+      await service.invalidateCache();
+
+      expect(spyTrending).toHaveBeenCalledWith('full-flush');
+      expect(spyReactions).toHaveBeenCalledWith('full-flush');
+      expect(spyGrowth).toHaveBeenCalledWith('full-flush');
+      expect(spyUsers).toHaveBeenCalledWith('full-flush');
+      expect(spyStats).toHaveBeenCalledWith('full-flush');
+    });
+
+    it('does NOT call invalidateSegment for keys outside the analytics namespace', async () => {
+      jest.spyOn(service, 'invalidateTrendingCache').mockResolvedValue();
+      jest
+        .spyOn(service, 'invalidateReactionDistributionCache')
+        .mockResolvedValue();
+      jest.spyOn(service, 'invalidateGrowthCache').mockResolvedValue();
+      jest.spyOn(service, 'invalidateUserActivityCache').mockResolvedValue();
+      jest.spyOn(service, 'invalidateStatsCache').mockResolvedValue();
+
+      await service.invalidateCache();
+
+      // invalidateSegment should never be called with prefixes outside analytics:*
+      const calls = cacheService.invalidateSegment.mock.calls;
+      calls.forEach(([prefix]) => {
+        expect(prefix).toMatch(/^analytics:/);
+      });
+    });
   });
 });

--- a/xconfess-backend/src/analytics/analytics.service.ts
+++ b/xconfess-backend/src/analytics/analytics.service.ts
@@ -1,15 +1,15 @@
 // src/analytics/analytics.service.ts
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan } from 'typeorm';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Cache } from 'cache-manager';
+import { Repository } from 'typeorm';
 import { Reaction } from 'src/reaction/entities/reaction.entity';
 import { User } from 'src/user/entities/user.entity';
 import { AnonymousConfession } from 'src/confession/entities/confession.entity';
+import { CacheService } from 'src/cache/cache.service';
 
 @Injectable()
 export class AnalyticsService {
+  private readonly logger = new Logger(AnalyticsService.name);
   private readonly CACHE_TTL = 900; // 15 minutes in seconds
 
   constructor(
@@ -19,15 +19,14 @@ export class AnalyticsService {
     private reactionRepository: Repository<Reaction>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
-    @Inject(CACHE_MANAGER)
-    private cacheManager: Cache,
+    private readonly cacheService: CacheService,
   ) {}
 
   async getTrendingConfessions(days: number = 7) {
     const cacheKey = `analytics:trending:${days}d`;
 
     // Try to get from cache
-    const cached = await this.cacheManager.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -57,7 +56,7 @@ export class AnalyticsService {
     }));
 
     // Cache the result
-    await this.cacheManager.set(cacheKey, result, this.CACHE_TTL);
+    await this.cacheService.set(cacheKey, result, this.CACHE_TTL);
 
     return result;
   }
@@ -65,7 +64,7 @@ export class AnalyticsService {
   async getReactionDistribution(days: number = 7) {
     const cacheKey = `analytics:reactions:${days}d`;
 
-    const cached = await this.cacheManager.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -96,7 +95,7 @@ export class AnalyticsService {
       period: `${days} days`,
     };
 
-    await this.cacheManager.set(cacheKey, result, this.CACHE_TTL);
+    await this.cacheService.set(cacheKey, result, this.CACHE_TTL);
 
     return result;
   }
@@ -104,7 +103,7 @@ export class AnalyticsService {
   async getDailyActiveUsers(days: number = 7) {
     const cacheKey = `analytics:users:${days}d`;
 
-    const cached = await this.cacheManager.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -151,7 +150,7 @@ export class AnalyticsService {
           activityMap.size || 0,
     };
 
-    await this.cacheManager.set(cacheKey, result, this.CACHE_TTL);
+    await this.cacheService.set(cacheKey, result, this.CACHE_TTL);
 
     return result;
   }
@@ -159,7 +158,7 @@ export class AnalyticsService {
   async getPlatformStats() {
     const cacheKey = 'analytics:stats';
 
-    const cached = await this.cacheManager.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -198,7 +197,7 @@ export class AnalyticsService {
       lastUpdated: new Date(),
     };
 
-    await this.cacheManager.set(cacheKey, result, this.CACHE_TTL);
+    await this.cacheService.set(cacheKey, result, this.CACHE_TTL);
 
     return result;
   }
@@ -206,7 +205,7 @@ export class AnalyticsService {
   async getConfessionGrowth(days: number = 7) {
     const cacheKey = `analytics:growth:${days}d`;
 
-    const cached = await this.cacheManager.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -240,7 +239,7 @@ export class AnalyticsService {
       trend: this.calculateTrend(dailyGrowth),
     };
 
-    await this.cacheManager.set(cacheKey, result, this.CACHE_TTL);
+    await this.cacheService.set(cacheKey, result, this.CACHE_TTL);
 
     return result;
   }
@@ -266,20 +265,56 @@ export class AnalyticsService {
     return 'stable';
   }
 
-  // Method to invalidate all analytics caches
-  async invalidateCache() {
-    const keys = [
-      'analytics:trending:7d',
-      'analytics:trending:30d',
-      'analytics:reactions:7d',
-      'analytics:reactions:30d',
-      'analytics:users:7d',
-      'analytics:users:30d',
-      'analytics:stats',
-      'analytics:growth:7d',
-      'analytics:growth:30d',
-    ];
+  // ─── Targeted cache invalidation ───────────────────────────────────────────
+  //
+  // Each method invalidates only the segment that is affected by a given type
+  // of mutation. Callers should prefer these over the full-flush invalidateCache().
+  // All methods are fire-and-forget safe (errors are absorbed and logged by
+  // CacheService.invalidateSegment).
 
-    await Promise.all(keys.map((key) => this.cacheManager.del(key)));
+  async invalidateTrendingCache(reason = 'mutation'): Promise<void> {
+    this.logger.log(
+      `Invalidating trending analytics cache (reason: ${reason})`,
+    );
+    await this.cacheService.invalidateSegment('analytics:trending', reason);
+  }
+
+  async invalidateReactionDistributionCache(
+    reason = 'mutation',
+  ): Promise<void> {
+    this.logger.log(
+      `Invalidating reaction distribution cache (reason: ${reason})`,
+    );
+    await this.cacheService.invalidateSegment('analytics:reactions', reason);
+  }
+
+  async invalidateGrowthCache(reason = 'mutation'): Promise<void> {
+    this.logger.log(`Invalidating growth metrics cache (reason: ${reason})`);
+    await this.cacheService.invalidateSegment('analytics:growth', reason);
+  }
+
+  async invalidateUserActivityCache(reason = 'mutation'): Promise<void> {
+    this.logger.log(`Invalidating user activity cache (reason: ${reason})`);
+    await this.cacheService.invalidateSegment('analytics:users', reason);
+  }
+
+  async invalidateStatsCache(reason = 'mutation'): Promise<void> {
+    this.logger.log(`Invalidating platform stats cache (reason: ${reason})`);
+    await this.cacheService.del('analytics:stats');
+  }
+
+  /**
+   * Full-flush fallback retained for backward compatibility and admin use.
+   * Prefer the targeted methods above for routine mutation-driven invalidation.
+   */
+  async invalidateCache(): Promise<void> {
+    this.logger.warn('Full analytics cache flush requested');
+    await Promise.all([
+      this.invalidateTrendingCache('full-flush'),
+      this.invalidateReactionDistributionCache('full-flush'),
+      this.invalidateGrowthCache('full-flush'),
+      this.invalidateUserActivityCache('full-flush'),
+      this.invalidateStatsCache('full-flush'),
+    ]);
   }
 }

--- a/xconfess-backend/src/cache/cache.service.ts
+++ b/xconfess-backend/src/cache/cache.service.ts
@@ -6,7 +6,7 @@ import { Cache } from 'cache-manager';
 export class CacheService {
   private readonly logger = new Logger(CacheService.name);
 
-  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) { }
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 
   async get<T>(key: string): Promise<T | null> {
     try {
@@ -26,7 +26,9 @@ export class CacheService {
   async set<T>(key: string, value: T, ttl?: number): Promise<void> {
     try {
       await this.cacheManager.set(key, value, ttl);
-      this.logger.debug(`Cache SET for key: ${key} (TTL: ${ttl || 'default'}s)`);
+      this.logger.debug(
+        `Cache SET for key: ${key} (TTL: ${ttl || 'default'}s)`,
+      );
     } catch (error) {
       this.logger.error(`Cache set error for key ${key}:`, error);
     }
@@ -48,12 +50,58 @@ export class CacheService {
       if (store && store.keys) {
         const keys = await store.keys(`${pattern}*`);
         if (keys && keys.length > 0) {
-          await Promise.all(keys.map((key: string) => this.cacheManager.del(key)));
-          this.logger.debug(`Cache DEL pattern: ${pattern}* (${keys.length} keys)`);
+          await Promise.all(
+            keys.map((key: string) => this.cacheManager.del(key)),
+          );
+          this.logger.debug(
+            `Cache DEL pattern: ${pattern}* (${keys.length} keys)`,
+          );
         }
       }
     } catch (error) {
       this.logger.error(`Cache delete pattern error for ${pattern}:`, error);
+    }
+  }
+
+  /**
+   * Invalidates all keys matching a given prefix and emits a structured log
+   * entry so cache churn can be observed (e.g. by a log aggregator).
+   *
+   * @param prefix - The key prefix to match (e.g. "analytics:trending").
+   *                 A trailing wildcard is appended automatically.
+   * @param reason - Human-readable reason for the invalidation, used only
+   *                 for observability logging.
+   * @returns The number of keys that were evicted.
+   */
+  async invalidateSegment(prefix: string, reason: string): Promise<number> {
+    const startMs = Date.now();
+    try {
+      const manager = this.cacheManager as any;
+      const store = manager.store || (manager.stores && manager.stores[0]);
+      if (store && typeof store.keys === 'function') {
+        const keys: string[] = await store.keys(`${prefix}*`);
+        if (keys.length > 0) {
+          await Promise.all(keys.map((key) => this.cacheManager.del(key)));
+          this.logger.log(
+            `Cache segment invalidated: prefix="${prefix}*", evicted=${keys.length}, reason="${reason}", elapsed=${Date.now() - startMs}ms`,
+          );
+          return keys.length;
+        }
+        this.logger.debug(
+          `Cache segment invalidate noop: prefix="${prefix}*", reason="${reason}" (no matching keys)`,
+        );
+        return 0;
+      }
+      this.logger.warn(
+        `Cache store does not support key enumeration; segment invalidation skipped for prefix="${prefix}"`,
+      );
+      return 0;
+    } catch (error) {
+      this.logger.error(
+        `Cache invalidateSegment error for prefix "${prefix}" (reason="${reason}"):`,
+        error,
+      );
+      return 0;
     }
   }
 

--- a/xconfess-backend/src/comment/comment.module.ts
+++ b/xconfess-backend/src/comment/comment.module.ts
@@ -7,15 +7,13 @@ import { AnonymousContextMiddleware } from '../middleware/anonymous-context.midd
 import { ModerationComment } from './entities/moderation-comment.entity';
 import { NotificationModule } from '../notification/notification.module';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
+import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([
-      Comment,
-      ModerationComment,
-      OutboxEvent,
-    ]),
+    TypeOrmModule.forFeature([Comment, ModerationComment, OutboxEvent]),
     NotificationModule,
+    AnalyticsModule,
   ],
   controllers: [CommentController],
   providers: [CommentService],
@@ -23,8 +21,6 @@ import { OutboxEvent } from '../common/entities/outbox-event.entity';
 })
 export class CommentModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer
-      .apply(AnonymousContextMiddleware)
-      .forRoutes('comments');
+    consumer.apply(AnonymousContextMiddleware).forRoutes('comments');
   }
 }

--- a/xconfess-backend/src/comment/comment.service.spec.ts
+++ b/xconfess-backend/src/comment/comment.service.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unused-vars, @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository, UpdateResult } from 'typeorm';
+import { DataSource, Repository, UpdateResult } from 'typeorm';
 import { CommentService } from './comment.service';
 import { Comment } from './entities/comment.entity';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
@@ -11,6 +11,8 @@ import {
   ModerationComment,
   ModerationStatus,
 } from './entities/moderation-comment.entity';
+import { OutboxEvent } from '../common/entities/outbox-event.entity';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 describe('CommentService (soft‑delete)', () => {
   let service: CommentService;
@@ -20,18 +22,31 @@ describe('CommentService (soft‑delete)', () => {
   let queue: jest.Mocked<NotificationQueue>;
 
   beforeEach(async () => {
+    // Pre-create mocks so the DataSource transaction mock can delegate to them.
+    const commentRepoMock = {
+      createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+    };
+    const moderationRepoMock = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+    };
+    const outboxRepoMock = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CommentService,
         {
           provide: getRepositoryToken(Comment),
-          useValue: {
-            createQueryBuilder: jest.fn(),
-            findOne: jest.fn(),
-            create: jest.fn(),
-            save: jest.fn(),
-            update: jest.fn(),
-          },
+          useValue: commentRepoMock,
         },
         {
           provide: getRepositoryToken(AnonymousConfession),
@@ -41,15 +56,36 @@ describe('CommentService (soft‑delete)', () => {
         },
         {
           provide: getRepositoryToken(ModerationComment),
-          useValue: {
-            create: jest.fn(),
-            save: jest.fn(),
-            findOne: jest.fn(),
-          },
+          useValue: moderationRepoMock,
         },
         {
           provide: NotificationQueue,
           useValue: { enqueueCommentNotification: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(OutboxEvent),
+          useValue: outboxRepoMock,
+        },
+        {
+          provide: DataSource,
+          useValue: {
+            transaction: jest.fn().mockImplementation((cb: any) =>
+              cb({
+                getRepository: jest.fn().mockImplementation((entity: any) => {
+                  if (entity === Comment) return commentRepoMock;
+                  if (entity === ModerationComment) return moderationRepoMock;
+                  return outboxRepoMock;
+                }),
+              }),
+            ),
+          },
+        },
+        {
+          provide: AnalyticsService,
+          useValue: {
+            invalidateTrendingCache: jest.fn().mockResolvedValue(undefined),
+            invalidateStatsCache: jest.fn().mockResolvedValue(undefined),
+          },
         },
       ],
     }).compile();
@@ -87,7 +123,7 @@ describe('CommentService (soft‑delete)', () => {
     const fakeUser = { id: 'anon1' } as any;
     const goodComment = {
       id: 42,
-      anonymousUser: { id: 11 },
+      anonymousUser: { id: 'anon1' },
       isDeleted: false,
     } as any;
 
@@ -111,7 +147,7 @@ describe('CommentService (soft‑delete)', () => {
     it(`throws BadRequestException if user doesn’t own comment`, async () => {
       commentRepo.findOne.mockResolvedValue({
         id: 42,
-        user: { id: 77 },
+        anonymousUser: { id: 77 },
         isDeleted: false,
       } as any);
       await expect(service.delete(42, fakeUser)).rejects.toThrow(
@@ -122,6 +158,7 @@ describe('CommentService (soft‑delete)', () => {
 
   describe(`create()`, () => {
     const fakeUser = { id: 5 } as any;
+    const fakeAnonUser = { id: 'anon1' } as any;
     const fakeConf = {
       id: 'c1',
       anonymousUser: { email: 'a@b.com' },
@@ -140,31 +177,39 @@ describe('CommentService (soft‑delete)', () => {
         service.create('hey', fakeAnonUser, 'c1', 'anonCtx'),
       ).rejects.toThrow(NotFoundException);
 
-      confessionRepo.findOne.mockResolvedValue({
-        ...fakeConf,
-        isDeleted: true,
-      });
+      // When the DB filters out deleted confessions (isDeleted: false in WHERE),
+      // it returns null — simulate the same by returning null here.
+      confessionRepo.findOne.mockResolvedValue(null);
       await expect(
         service.create('hey', fakeAnonUser, 'c1', 'anonCtx'),
       ).rejects.toThrow(NotFoundException);
     });
 
     it(`creates comment and moderation entry`, async () => {
+      const savedComment = {
+        id: 101,
+        content: 'hey',
+        anonymousUser: fakeAnonUser,
+        confession: fakeConf,
+      } as any;
       confessionRepo.findOne.mockResolvedValue(fakeConf);
-      commentRepo.create.mockReturnValue(fakeComment);
-      commentRepo.save.mockResolvedValue(fakeComment);
-      moderationRepo.create.mockReturnValue({ commentId: 101, status: ModerationStatus.PENDING } as any);
+      commentRepo.create.mockReturnValue(savedComment);
+      commentRepo.save.mockResolvedValue(savedComment);
+      moderationRepo.create.mockReturnValue({
+        commentId: 101,
+        status: ModerationStatus.PENDING,
+      } as any);
       moderationRepo.save.mockResolvedValue({} as any);
 
       const result = await service.create('hey', fakeAnonUser, 'c1', 'anonCtx');
       expect(commentRepo.create).toHaveBeenCalledWith({
         content: 'hey',
-        anonymousUser: fakeUser,
+        anonymousUser: fakeAnonUser,
         confession: fakeConf,
         anonymousContextId: 'anonCtx',
       });
       expect(moderationRepo.save).toHaveBeenCalled();
-      expect(result).toBe(fakeComment);
+      expect(result).toBe(savedComment);
     });
   });
 });
@@ -177,18 +222,30 @@ describe('CommentService (moderation)', () => {
   let queue: jest.Mocked<NotificationQueue>;
 
   beforeEach(async () => {
+    const commentRepoMock = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+    };
+    const moderationRepoMock = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+    const outboxRepoMock = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CommentService,
         {
           provide: getRepositoryToken(Comment),
-          useValue: {
-            find: jest.fn(),
-            findOne: jest.fn(),
-            create: jest.fn(),
-            save: jest.fn(),
-            update: jest.fn(),
-          },
+          useValue: commentRepoMock,
         },
         {
           provide: getRepositoryToken(AnonymousConfession),
@@ -196,11 +253,36 @@ describe('CommentService (moderation)', () => {
         },
         {
           provide: getRepositoryToken(ModerationComment),
-          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn() },
+          useValue: moderationRepoMock,
         },
         {
           provide: NotificationQueue,
           useValue: { enqueueCommentNotification: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(OutboxEvent),
+          useValue: outboxRepoMock,
+        },
+        {
+          provide: DataSource,
+          useValue: {
+            transaction: jest.fn().mockImplementation((cb: any) =>
+              cb({
+                getRepository: jest.fn().mockImplementation((entity: any) => {
+                  if (entity === Comment) return commentRepoMock;
+                  if (entity === ModerationComment) return moderationRepoMock;
+                  return outboxRepoMock;
+                }),
+              }),
+            ),
+          },
+        },
+        {
+          provide: AnalyticsService,
+          useValue: {
+            invalidateTrendingCache: jest.fn().mockResolvedValue(undefined),
+            invalidateStatsCache: jest.fn().mockResolvedValue(undefined),
+          },
         },
       ],
     }).compile();
@@ -308,6 +390,288 @@ describe('CommentService (moderation)', () => {
         }),
       );
       expect(moderationRepo.save).toHaveBeenCalled();
+    });
+  });
+});
+
+// ─── Analytics cache invalidation ────────────────────────────────────────────
+
+describe('CommentService – analytics cache invalidation', () => {
+  let service: CommentService;
+  let analyticsService: jest.Mocked<
+    Pick<AnalyticsService, 'invalidateTrendingCache' | 'invalidateStatsCache'>
+  >;
+  let moderationRepo: jest.Mocked<Repository<ModerationComment>>;
+  let commentRepo: jest.Mocked<Repository<Comment>>;
+
+  const makeProviders = (analyticsValue: any, dataSourceValue?: any) => [
+    CommentService,
+    {
+      provide: getRepositoryToken(Comment),
+      useValue: {
+        findOne: jest.fn(),
+        create: jest.fn(),
+        save: jest.fn(),
+        update: jest.fn(),
+      },
+    },
+    {
+      provide: getRepositoryToken(AnonymousConfession),
+      useValue: {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'c1',
+          anonymousUser: null,
+          isDeleted: false,
+        }),
+      },
+    },
+    {
+      provide: getRepositoryToken(ModerationComment),
+      useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn() },
+    },
+    {
+      provide: getRepositoryToken(OutboxEvent),
+      useValue: { create: jest.fn(), save: jest.fn(), findOne: jest.fn() },
+    },
+    {
+      provide: NotificationQueue,
+      useValue: { enqueueCommentNotification: jest.fn() },
+    },
+    {
+      provide: DataSource,
+      useValue: dataSourceValue ?? {
+        transaction: jest.fn().mockImplementation((cb: any) =>
+          cb({
+            getRepository: jest.fn().mockReturnValue({
+              create: jest.fn().mockReturnValue({ id: 101, content: 'hey' }),
+              save: jest.fn().mockResolvedValue({ id: 101, content: 'hey' }),
+              findOne: jest.fn().mockResolvedValue(null),
+            }),
+          }),
+        ),
+      },
+    },
+    { provide: AnalyticsService, useValue: analyticsValue },
+  ];
+
+  beforeEach(() => {
+    analyticsService = {
+      invalidateTrendingCache: jest.fn().mockResolvedValue(undefined),
+      invalidateStatsCache: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('create()', () => {
+    it('invalidates trending cache after a comment is saved', async () => {
+      const module = await Test.createTestingModule({
+        providers: makeProviders(analyticsService),
+      }).compile();
+
+      service = module.get(CommentService);
+
+      await service.create('hello', { id: 'anon1' } as any, 'c1', 'ctx1');
+      await Promise.resolve(); // settle fire-and-forget
+      expect(analyticsService.invalidateTrendingCache).toHaveBeenCalledWith(
+        'comment-created',
+      );
+    });
+  });
+
+  describe('delete()', () => {
+    it('invalidates trending cache after a soft-delete', async () => {
+      const commentRepoValue = {
+        findOne: jest.fn().mockResolvedValue({
+          id: 1,
+          anonymousUser: { id: 'anon1' },
+          isDeleted: false,
+        }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          CommentService,
+          { provide: getRepositoryToken(Comment), useValue: commentRepoValue },
+          {
+            provide: getRepositoryToken(AnonymousConfession),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(ModerationComment),
+            useValue: {
+              findOne: jest.fn(),
+              create: jest.fn(),
+              save: jest.fn(),
+            },
+          },
+          {
+            provide: getRepositoryToken(OutboxEvent),
+            useValue: { create: jest.fn(), save: jest.fn() },
+          },
+          {
+            provide: NotificationQueue,
+            useValue: { enqueueCommentNotification: jest.fn() },
+          },
+          { provide: DataSource, useValue: { transaction: jest.fn() } },
+          { provide: AnalyticsService, useValue: analyticsService },
+        ],
+      }).compile();
+
+      service = module.get(CommentService);
+      await service.delete(1, { id: 'anon1' } as any);
+      await Promise.resolve();
+      expect(analyticsService.invalidateTrendingCache).toHaveBeenCalledWith(
+        'comment-deleted',
+      );
+    });
+  });
+
+  describe('moderateComment()', () => {
+    const moderator = { id: 99 } as any;
+
+    it('invalidates trending cache after approval', async () => {
+      const modEntry = {
+        comment: { id: 10 },
+        status: ModerationStatus.PENDING,
+      } as any;
+      const modRepoValue = {
+        findOne: jest.fn().mockResolvedValue(modEntry),
+        save: jest.fn().mockResolvedValue({
+          ...modEntry,
+          status: ModerationStatus.APPROVED,
+        }),
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          CommentService,
+          {
+            provide: getRepositoryToken(Comment),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(AnonymousConfession),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(ModerationComment),
+            useValue: modRepoValue,
+          },
+          {
+            provide: getRepositoryToken(OutboxEvent),
+            useValue: { create: jest.fn(), save: jest.fn() },
+          },
+          {
+            provide: NotificationQueue,
+            useValue: { enqueueCommentNotification: jest.fn() },
+          },
+          { provide: DataSource, useValue: { transaction: jest.fn() } },
+          { provide: AnalyticsService, useValue: analyticsService },
+        ],
+      }).compile();
+
+      service = module.get(CommentService);
+      await service.moderateComment(10, ModerationStatus.APPROVED, moderator);
+      await Promise.resolve();
+      expect(analyticsService.invalidateTrendingCache).toHaveBeenCalledWith(
+        `comment-moderated:${ModerationStatus.APPROVED}`,
+      );
+      expect(analyticsService.invalidateStatsCache).toHaveBeenCalledWith(
+        `comment-moderated:${ModerationStatus.APPROVED}`,
+      );
+    });
+
+    it('invalidates caches after rejection', async () => {
+      const modEntry = {
+        comment: { id: 11 },
+        status: ModerationStatus.PENDING,
+      } as any;
+      const modRepoValue = {
+        findOne: jest.fn().mockResolvedValue(modEntry),
+        save: jest.fn().mockResolvedValue({
+          ...modEntry,
+          status: ModerationStatus.REJECTED,
+        }),
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          CommentService,
+          {
+            provide: getRepositoryToken(Comment),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(AnonymousConfession),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(ModerationComment),
+            useValue: modRepoValue,
+          },
+          {
+            provide: getRepositoryToken(OutboxEvent),
+            useValue: { create: jest.fn(), save: jest.fn() },
+          },
+          {
+            provide: NotificationQueue,
+            useValue: { enqueueCommentNotification: jest.fn() },
+          },
+          { provide: DataSource, useValue: { transaction: jest.fn() } },
+          { provide: AnalyticsService, useValue: analyticsService },
+        ],
+      }).compile();
+
+      service = module.get(CommentService);
+      await service.moderateComment(11, ModerationStatus.REJECTED, moderator);
+      await Promise.resolve();
+      expect(analyticsService.invalidateTrendingCache).toHaveBeenCalledWith(
+        `comment-moderated:${ModerationStatus.REJECTED}`,
+      );
+    });
+
+    it('does NOT call analytics invalidation when moderation entry is not found', async () => {
+      const modRepoValue = {
+        findOne: jest.fn().mockResolvedValue(null),
+        save: jest.fn(),
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          CommentService,
+          {
+            provide: getRepositoryToken(Comment),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(AnonymousConfession),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(ModerationComment),
+            useValue: modRepoValue,
+          },
+          {
+            provide: getRepositoryToken(OutboxEvent),
+            useValue: { create: jest.fn(), save: jest.fn() },
+          },
+          {
+            provide: NotificationQueue,
+            useValue: { enqueueCommentNotification: jest.fn() },
+          },
+          { provide: DataSource, useValue: { transaction: jest.fn() } },
+          { provide: AnalyticsService, useValue: analyticsService },
+        ],
+      }).compile();
+
+      service = module.get(CommentService);
+      await expect(
+        service.moderateComment(99, ModerationStatus.APPROVED, moderator),
+      ).rejects.toThrow(NotFoundException);
+      expect(analyticsService.invalidateTrendingCache).not.toHaveBeenCalled();
+      expect(analyticsService.invalidateStatsCache).not.toHaveBeenCalled();
     });
   });
 });

--- a/xconfess-backend/src/comment/comment.service.ts
+++ b/xconfess-backend/src/comment/comment.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
@@ -14,10 +15,16 @@ import {
   ModerationStatus,
 } from './entities/moderation-comment.entity';
 import { AnonymousUser } from '../user/entities/anonymous-user.entity';
-import { OutboxEvent, OutboxStatus } from '../common/entities/outbox-event.entity';
+import {
+  OutboxEvent,
+  OutboxStatus,
+} from '../common/entities/outbox-event.entity';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 @Injectable()
 export class CommentService {
+  private readonly logger = new Logger(CommentService.name);
+
   constructor(
     @InjectRepository(Comment)
     private commentRepo: Repository<Comment>,
@@ -29,7 +36,8 @@ export class CommentService {
     private outboxRepo: Repository<OutboxEvent>,
     private readonly notificationQueue: NotificationQueue,
     private readonly dataSource: DataSource,
-  ) { }
+    private readonly analyticsService: AnalyticsService,
+  ) {}
 
   async create(
     content: string,
@@ -40,68 +48,86 @@ export class CommentService {
   ): Promise<Comment> {
     const confession = await this.confessionRepo.findOne({
       where: { id: confessionId, isDeleted: false },
-      relations: ['anonymousUser', 'anonymousUser.userLinks', 'anonymousUser.userLinks.user'],
+      relations: [
+        'anonymousUser',
+        'anonymousUser.userLinks',
+        'anonymousUser.userLinks.user',
+      ],
     });
 
     if (!confession) {
       throw new NotFoundException('Confession not found');
     }
 
-    return this.dataSource.transaction(async (manager) => {
-      // ... (existing comment creation logic)
-      const commentRepo = manager.getRepository(Comment);
-      const moderationRepo = manager.getRepository(ModerationComment);
-      const outboxRepo = manager.getRepository(OutboxEvent);
+    return this.dataSource
+      .transaction(async (manager) => {
+        // ... (existing comment creation logic)
+        const commentRepo = manager.getRepository(Comment);
+        const moderationRepo = manager.getRepository(ModerationComment);
+        const outboxRepo = manager.getRepository(OutboxEvent);
 
-      const comment = commentRepo.create({
-        content,
-        anonymousUser: user,
-        confession,
-        anonymousContextId,
-      });
+        const comment = commentRepo.create({
+          content,
+          anonymousUser: user,
+          confession,
+          anonymousContextId,
+        });
 
-      if (parentId) {
-        const parentComment = new Comment();
-        parentComment.id = parentId;
-        comment.parent = parentComment;
-      }
+        if (parentId) {
+          const parentComment = new Comment();
+          parentComment.id = parentId;
+          comment.parent = parentComment;
+        }
 
-      const savedComment = await commentRepo.save(comment);
+        const savedComment = await commentRepo.save(comment);
 
-      // Add moderation entry
-      await moderationRepo.save(
-        moderationRepo.create({
-          comment: savedComment,
-          commentId: savedComment.id,
-          status: ModerationStatus.PENDING,
-        }),
-      );
-
-      // 4. Create Outbox Event for notification
-      const recipientEmail = this.getRecipientEmail(confession.anonymousUser);
-      if (recipientEmail) {
-        const payload = {
-          commentId: savedComment.id,
-          confessionId: confession.id,
-          recipientEmail,
-          commenterContextId: anonymousContextId,
-          commentPreview: content.substring(0, 100),
-        };
-
-        const idempotencyKey = `comment:${savedComment.id}`;
-
-        await outboxRepo.save(
-          outboxRepo.create({
-            type: 'comment_notification',
-            payload,
-            idempotencyKey,
-            status: OutboxStatus.PENDING,
+        // Add moderation entry
+        await moderationRepo.save(
+          moderationRepo.create({
+            comment: savedComment,
+            commentId: savedComment.id,
+            status: ModerationStatus.PENDING,
           }),
         );
-      }
 
-      return savedComment;
-    });
+        // 4. Create Outbox Event for notification
+        const recipientEmail = this.getRecipientEmail(confession.anonymousUser);
+        if (recipientEmail) {
+          const payload = {
+            commentId: savedComment.id,
+            confessionId: confession.id,
+            recipientEmail,
+            commenterContextId: anonymousContextId,
+            commentPreview: content.substring(0, 100),
+          };
+
+          const idempotencyKey = `comment:${savedComment.id}`;
+
+          await outboxRepo.save(
+            outboxRepo.create({
+              type: 'comment_notification',
+              payload,
+              idempotencyKey,
+              status: OutboxStatus.PENDING,
+            }),
+          );
+        }
+
+        return savedComment;
+      })
+      .then(async (result) => {
+        // Invalidate trending analytics after a new comment lands.
+        // Fire-and-forget: cache failures must not roll back the comment write.
+        this.analyticsService
+          .invalidateTrendingCache('comment-created')
+          .catch((err) =>
+            this.logger.error(
+              'Failed to invalidate trending cache after comment create',
+              err,
+            ),
+          );
+        return result;
+      });
   }
 
   private getRecipientEmail(anonymousUser: AnonymousUser): string | null {
@@ -166,6 +192,16 @@ export class CommentService {
     }
 
     await this.commentRepo.update(id, { isDeleted: true });
+
+    // A deleted comment changes visible engagement counts.
+    this.analyticsService
+      .invalidateTrendingCache('comment-deleted')
+      .catch((err) =>
+        this.logger.error(
+          'Failed to invalidate trending cache after comment delete',
+          err,
+        ),
+      );
   }
 
   async moderateComment(
@@ -188,6 +224,26 @@ export class CommentService {
     moderation.moderatedBy = moderator;
     moderation.moderatedById = moderator.id;
     await this.moderationCommentRepo.save(moderation);
+
+    // Moderation changes which comments are publicly visible, directly
+    // affecting trending scores and platform stats.
+    this.analyticsService
+      .invalidateTrendingCache(`comment-moderated:${status}`)
+      .catch((err) =>
+        this.logger.error(
+          'Failed to invalidate trending cache after moderation',
+          err,
+        ),
+      );
+    this.analyticsService
+      .invalidateStatsCache(`comment-moderated:${status}`)
+      .catch((err) =>
+        this.logger.error(
+          'Failed to invalidate stats cache after moderation',
+          err,
+        ),
+      );
+
     return { success: true, message: `Comment ${status}` };
   }
 }

--- a/xconfess-backend/src/config/email.config.ts
+++ b/xconfess-backend/src/config/email.config.ts
@@ -32,6 +32,63 @@ export interface EmailTemplateRegistry {
   };
 }
 
+/** Alias matching the name used in email.service.ts */
+export type TemplateRegistry = EmailTemplateRegistry;
+
+export interface TemplateRolloutPolicy {
+  activeVersion: string;
+  canaryVersion?: string;
+  canaryPercent?: number;
+}
+
+export interface TemplateRolloutMap {
+  [templateKey: string]: TemplateRolloutPolicy;
+}
+
+/**
+ * Resolve which template version to use for a given recipient.
+ * Uses the rolloutMap for explicit per-key overrides, then falls back
+ * to the registry's built-in rollout config.
+ */
+export function resolveTemplate(
+  registry: TemplateRegistry,
+  rolloutMap: TemplateRolloutMap,
+  templateKey: string,
+  _recipientEmail: string,
+): { template: EmailTemplateVersion; isCanary: boolean } {
+  const reg = registry[templateKey];
+  if (!reg) {
+    throw new Error(`Template "${templateKey}" not found in registry`);
+  }
+
+  // Prefer per-key rollout override from rolloutMap
+  const policy = rolloutMap[templateKey];
+  const canaryKey = policy?.canaryVersion ?? reg.rollout?.canaryVersion;
+  const canaryPct = policy?.canaryPercent ?? reg.rollout?.canaryWeight ?? 0;
+  const activeKey = policy?.activeVersion ?? reg.activeVersion;
+  const killSwitch = reg.rollout?.killSwitchEnabled ?? false;
+
+  const activeVersion = reg.versions[activeKey];
+  const canaryVersion = canaryKey ? reg.versions[canaryKey] : undefined;
+
+  if (
+    !killSwitch &&
+    canaryVersion &&
+    canaryVersion.lifecycleState === 'canary'
+  ) {
+    if (Math.random() * 100 < canaryPct) {
+      return { template: canaryVersion, isCanary: true };
+    }
+  }
+
+  if (!activeVersion) {
+    throw new Error(
+      `Active version "${activeKey}" not found for template "${templateKey}"`,
+    );
+  }
+  return { template: activeVersion, isCanary: false };
+}
+
 export interface MailConfig {
   host: string;
   port: number;
@@ -108,7 +165,10 @@ const templateRegistry: EmailTemplateRegistry = {
     },
     rollout: {
       canaryVersion: 'v2',
-      canaryWeight: parseInt(process.env.EMAIL_WELCOME_CANARY_WEIGHT || '0', 10),
+      canaryWeight: parseInt(
+        process.env.EMAIL_WELCOME_CANARY_WEIGHT || '0',
+        10,
+      ),
       killSwitchEnabled: false,
     },
   },
@@ -253,5 +313,8 @@ export const mailConfig = registerAs('mail', () => ({
 export const circuitBreakerConfig = registerAs('circuitBreaker', () => ({
   failureThreshold: parseInt(process.env.CB_FAILURE_THRESHOLD || '3', 10),
   cooldownSeconds: parseInt(process.env.CB_COOLDOWN_SECONDS || '60', 10),
-  probeSuccessThreshold: parseInt(process.env.CB_PROBE_SUCCESS_THRESHOLD || '2', 10),
+  probeSuccessThreshold: parseInt(
+    process.env.CB_PROBE_SUCCESS_THRESHOLD || '2',
+    10,
+  ),
 }));

--- a/xconfess-backend/src/reaction/reaction.module.ts
+++ b/xconfess-backend/src/reaction/reaction.module.ts
@@ -7,14 +7,21 @@ import { Reaction } from './entities/reaction.entity';
 import { ConfessionModule } from '../confession/confession.module';
 import { AnonymousUser } from '../user/entities/anonymous-user.entity';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
+import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
   imports: [
     forwardRef(() => ConfessionModule),
-    TypeOrmModule.forFeature([Reaction, AnonymousConfession, AnonymousUser, OutboxEvent]),
+    TypeOrmModule.forFeature([
+      Reaction,
+      AnonymousConfession,
+      AnonymousUser,
+      OutboxEvent,
+    ]),
+    AnalyticsModule,
   ],
   controllers: [ReactionController],
   providers: [ReactionService],
   exports: [ReactionService],
 })
-export class ReactionModule { }
+export class ReactionModule {}

--- a/xconfess-backend/src/reaction/reaction.service.spec.ts
+++ b/xconfess-backend/src/reaction/reaction.service.spec.ts
@@ -1,14 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { ReactionService } from './reaction.service';
 import { Reaction } from './entities/reaction.entity';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { AnonymousUser } from '../user/entities/anonymous-user.entity';
+import { OutboxEvent } from '../common/entities/outbox-event.entity';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 // ─── Factories ───────────────────────────────────────────────────────────────
 
-const makeConfession = (overrides: Partial<AnonymousConfession> = {}): AnonymousConfession =>
+const makeConfession = (
+  overrides: Partial<AnonymousConfession> = {},
+): AnonymousConfession =>
   ({
     id: 'conf-uuid-1',
     message: 'Test confession',
@@ -19,7 +24,9 @@ const makeConfession = (overrides: Partial<AnonymousConfession> = {}): Anonymous
     ...overrides,
   }) as AnonymousConfession;
 
-const makeAnonymousUser = (overrides: Partial<AnonymousUser> = {}): AnonymousUser =>
+const makeAnonymousUser = (
+  overrides: Partial<AnonymousUser> = {},
+): AnonymousUser =>
   ({
     id: 'anon-uuid-1',
     ...overrides,
@@ -51,14 +58,46 @@ describe('ReactionService', () => {
   let reactionRepo: ReturnType<typeof repoMock>;
   let confessionRepo: ReturnType<typeof repoMock>;
   let anonymousUserRepo: ReturnType<typeof repoMock>;
+  // inner manager repo shared so transaction-based calls can be asserted
+  let managerReactionRepo: ReturnType<typeof repoMock>;
+  let managerOutboxRepo: ReturnType<typeof repoMock>;
 
   beforeEach(async () => {
+    managerReactionRepo = repoMock();
+    managerOutboxRepo = repoMock();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReactionService,
         { provide: getRepositoryToken(Reaction), useFactory: repoMock },
-        { provide: getRepositoryToken(AnonymousConfession), useFactory: repoMock },
+        {
+          provide: getRepositoryToken(AnonymousConfession),
+          useFactory: repoMock,
+        },
         { provide: getRepositoryToken(AnonymousUser), useFactory: repoMock },
+        { provide: getRepositoryToken(OutboxEvent), useFactory: repoMock },
+        {
+          provide: DataSource,
+          useValue: {
+            transaction: jest.fn().mockImplementation((cb: any) =>
+              cb({
+                getRepository: jest.fn().mockImplementation((entity: any) => {
+                  if (entity === Reaction) return managerReactionRepo;
+                  return managerOutboxRepo;
+                }),
+              }),
+            ),
+          },
+        },
+        {
+          provide: AnalyticsService,
+          useValue: {
+            invalidateTrendingCache: jest.fn().mockResolvedValue(undefined),
+            invalidateReactionDistributionCache: jest
+              .fn()
+              .mockResolvedValue(undefined),
+          },
+        },
       ],
     }).compile();
 
@@ -86,27 +125,24 @@ describe('ReactionService', () => {
 
       confessionRepo.findOne.mockResolvedValue(confession);
       anonymousUserRepo.findOne.mockResolvedValue(user);
-      reactionRepo.findOne.mockResolvedValue(null);
-      reactionRepo.create.mockReturnValue(reaction);
-      reactionRepo.save.mockResolvedValue(reaction);
+      // Duplicate check and save are inside the transaction (manager repo)
+      managerReactionRepo.findOne.mockResolvedValue(null);
+      managerReactionRepo.create.mockReturnValue(reaction);
+      managerReactionRepo.save.mockResolvedValue(reaction);
 
       const result = await service.createReaction(dto);
 
-      // Confession loaded WITHOUT invalid relations
-      expect(confessionRepo.findOne).toHaveBeenCalledWith({
-        where: { id: dto.confessionId },
-      });
-      // No 'relations: [user]' or 'relations: [anonymousUser]' on confession lookup
-      expect(confessionRepo.findOne).not.toHaveBeenCalledWith(
-        expect.objectContaining({ relations: expect.anything() }),
+      // Confession loaded with relations for notification lookup
+      expect(confessionRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: dto.confessionId } }),
       );
 
-      expect(reactionRepo.create).toHaveBeenCalledWith({
+      expect(managerReactionRepo.create).toHaveBeenCalledWith({
         emoji: dto.emoji,
         confession,
         anonymousUser: user,
       });
-      expect(reactionRepo.save).toHaveBeenCalledWith(reaction);
+      expect(managerReactionRepo.save).toHaveBeenCalledWith(reaction);
       expect(result).toEqual(reaction);
     });
 
@@ -115,12 +151,12 @@ describe('ReactionService', () => {
 
       confessionRepo.findOne.mockResolvedValue(makeConfession());
       anonymousUserRepo.findOne.mockResolvedValue(makeAnonymousUser());
-      reactionRepo.findOne.mockResolvedValue(existing);
+      managerReactionRepo.findOne.mockResolvedValue(existing);
 
       const result = await service.createReaction(dto);
 
-      expect(reactionRepo.create).not.toHaveBeenCalled();
-      expect(reactionRepo.save).not.toHaveBeenCalled();
+      expect(managerReactionRepo.create).not.toHaveBeenCalled();
+      expect(managerReactionRepo.save).not.toHaveBeenCalled();
       expect(result).toBe(existing);
     });
 
@@ -130,12 +166,12 @@ describe('ReactionService', () => {
 
       confessionRepo.findOne.mockResolvedValue(makeConfession());
       anonymousUserRepo.findOne.mockResolvedValue(makeAnonymousUser());
-      reactionRepo.findOne.mockResolvedValue(existing);
-      reactionRepo.save.mockResolvedValue(updated);
+      managerReactionRepo.findOne.mockResolvedValue(existing);
+      managerReactionRepo.save.mockResolvedValue(updated);
 
       const result = await service.createReaction({ ...dto, emoji: '❤️' });
 
-      expect(reactionRepo.save).toHaveBeenCalledWith(
+      expect(managerReactionRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({ emoji: '❤️' }),
       );
       expect(result.emoji).toBe('❤️');
@@ -146,8 +182,12 @@ describe('ReactionService', () => {
     it('throws NotFoundException when confession does not exist', async () => {
       confessionRepo.findOne.mockResolvedValue(null);
 
-      await expect(service.createReaction(dto)).rejects.toThrow(NotFoundException);
-      await expect(service.createReaction(dto)).rejects.toThrow('Confession not found');
+      await expect(service.createReaction(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.createReaction(dto)).rejects.toThrow(
+        'Confession not found',
+      );
 
       // Must not proceed to user/reaction lookup
       expect(anonymousUserRepo.findOne).not.toHaveBeenCalled();
@@ -158,8 +198,12 @@ describe('ReactionService', () => {
       confessionRepo.findOne.mockResolvedValue(makeConfession());
       anonymousUserRepo.findOne.mockResolvedValue(null);
 
-      await expect(service.createReaction(dto)).rejects.toThrow(NotFoundException);
-      await expect(service.createReaction(dto)).rejects.toThrow('Anonymous user not found');
+      await expect(service.createReaction(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.createReaction(dto)).rejects.toThrow(
+        'Anonymous user not found',
+      );
 
       expect(reactionRepo.create).not.toHaveBeenCalled();
     });
@@ -178,9 +222,9 @@ describe('ReactionService', () => {
 
       confessionRepo.findOne.mockResolvedValue(confession);
       anonymousUserRepo.findOne.mockResolvedValue(makeAnonymousUser());
-      reactionRepo.findOne.mockResolvedValue(null);
-      reactionRepo.create.mockReturnValue(makeReaction());
-      reactionRepo.save.mockResolvedValue(makeReaction());
+      managerReactionRepo.findOne.mockResolvedValue(null);
+      managerReactionRepo.create.mockReturnValue(makeReaction());
+      managerReactionRepo.save.mockResolvedValue(makeReaction());
 
       await service.createReaction(dto);
 
@@ -194,19 +238,146 @@ describe('ReactionService', () => {
 
       confessionRepo.findOne.mockResolvedValue(confession);
       anonymousUserRepo.findOne.mockResolvedValue(user);
-      reactionRepo.findOne.mockResolvedValue(null);
-      reactionRepo.create.mockReturnValue(reaction);
-      reactionRepo.save.mockResolvedValue(reaction);
+      managerReactionRepo.findOne.mockResolvedValue(null);
+      managerReactionRepo.create.mockReturnValue(reaction);
+      managerReactionRepo.save.mockResolvedValue(reaction);
 
       await service.createReaction(dto);
 
       // Confirm create() was called with `anonymousUser`, NOT `user`
-      expect(reactionRepo.create).toHaveBeenCalledWith(
+      expect(managerReactionRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({ anonymousUser: user }),
       );
-      expect(reactionRepo.create).not.toHaveBeenCalledWith(
+      expect(managerReactionRepo.create).not.toHaveBeenCalledWith(
         expect.objectContaining({ user: expect.anything() }),
       );
     });
+  });
+});
+
+// ─── Analytics cache invalidation ────────────────────────────────────────────
+
+describe('ReactionService – analytics cache invalidation', () => {
+  let service: ReactionService;
+  let analyticsService: jest.Mocked<
+    Pick<
+      AnalyticsService,
+      'invalidateTrendingCache' | 'invalidateReactionDistributionCache'
+    >
+  >;
+
+  const makeManagerRepo = () => ({
+    findOne: jest.fn().mockResolvedValue(null),
+    create: jest.fn().mockReturnValue({ id: 'r1', emoji: '❤️' }),
+    save: jest.fn().mockResolvedValue({ id: 'r1', emoji: '❤️' }),
+  });
+
+  const confession = {
+    id: 'conf-1',
+    anonymousUser: null,
+  } as any;
+
+  const anonUser = { id: 'anon-1' } as any;
+
+  const dto = {
+    confessionId: 'conf-1',
+    anonymousUserId: 'anon-1',
+    emoji: '❤️',
+  };
+
+  beforeEach(async () => {
+    analyticsService = {
+      invalidateTrendingCache: jest.fn().mockResolvedValue(undefined),
+      invalidateReactionDistributionCache: jest
+        .fn()
+        .mockResolvedValue(undefined),
+    };
+
+    const managerRepo = makeManagerRepo();
+    const dataSourceMock = {
+      transaction: jest
+        .fn()
+        .mockImplementation((cb: any) =>
+          cb({ getRepository: jest.fn().mockReturnValue(managerRepo) }),
+        ),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReactionService,
+        {
+          provide: getRepositoryToken(Reaction),
+          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(AnonymousConfession),
+          useValue: { findOne: jest.fn().mockResolvedValue(confession) },
+        },
+        {
+          provide: getRepositoryToken(AnonymousUser),
+          useValue: { findOne: jest.fn().mockResolvedValue(anonUser) },
+        },
+        {
+          provide: getRepositoryToken(OutboxEvent),
+          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn() },
+        },
+        { provide: DataSource, useValue: dataSourceMock },
+        { provide: AnalyticsService, useValue: analyticsService },
+      ],
+    }).compile();
+
+    service = module.get<ReactionService>(ReactionService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('invalidates trending cache after a new reaction is persisted', async () => {
+    await service.createReaction(dto);
+    // Allow the fire-and-forget promises to settle
+    await Promise.resolve();
+    expect(analyticsService.invalidateTrendingCache).toHaveBeenCalledWith(
+      'reaction-mutation',
+    );
+  });
+
+  it('invalidates reaction distribution cache after a new reaction is persisted', async () => {
+    await service.createReaction(dto);
+    await Promise.resolve();
+    expect(
+      analyticsService.invalidateReactionDistributionCache,
+    ).toHaveBeenCalledWith('reaction-mutation');
+  });
+
+  it('does NOT call analytics invalidation when confession is not found', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReactionService,
+        {
+          provide: getRepositoryToken(Reaction),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(AnonymousConfession),
+          useValue: { findOne: jest.fn().mockResolvedValue(null) },
+        },
+        {
+          provide: getRepositoryToken(AnonymousUser),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(OutboxEvent),
+          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn() },
+        },
+        { provide: DataSource, useValue: { transaction: jest.fn() } },
+        { provide: AnalyticsService, useValue: analyticsService },
+      ],
+    }).compile();
+
+    const svc = module.get<ReactionService>(ReactionService);
+    await expect(svc.createReaction(dto)).rejects.toThrow(NotFoundException);
+    expect(analyticsService.invalidateTrendingCache).not.toHaveBeenCalled();
+    expect(
+      analyticsService.invalidateReactionDistributionCache,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/xconfess-backend/src/reaction/reaction.service.ts
+++ b/xconfess-backend/src/reaction/reaction.service.ts
@@ -10,7 +10,11 @@ import { CreateReactionDto } from './dto/create-reaction.dto';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { Reaction } from './entities/reaction.entity';
 import { AnonymousUser } from '../user/entities/anonymous-user.entity';
-import { OutboxEvent, OutboxStatus } from '../common/entities/outbox-event.entity';
+import {
+  OutboxEvent,
+  OutboxStatus,
+} from '../common/entities/outbox-event.entity';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 @Injectable()
 export class ReactionService {
@@ -26,13 +30,18 @@ export class ReactionService {
     @InjectRepository(OutboxEvent)
     private outboxRepo: Repository<OutboxEvent>,
     private readonly dataSource: DataSource,
-  ) { }
+    private readonly analyticsService: AnalyticsService,
+  ) {}
 
   async createReaction(dto: CreateReactionDto): Promise<Reaction> {
     // 1. Verify confession exists.
     const confession = await this.confessionRepo.findOne({
       where: { id: dto.confessionId },
-      relations: ['anonymousUser', 'anonymousUser.userLinks', 'anonymousUser.userLinks.user'],
+      relations: [
+        'anonymousUser',
+        'anonymousUser.userLinks',
+        'anonymousUser.userLinks.user',
+      ],
     });
 
     if (!confession) {
@@ -48,46 +57,79 @@ export class ReactionService {
       throw new NotFoundException('Anonymous user not found');
     }
 
-    return this.dataSource.transaction(async (manager) => {
-      const reactionRepo = manager.getRepository(Reaction);
-      const outboxRepo = manager.getRepository(OutboxEvent);
+    return this.dataSource
+      .transaction(async (manager) => {
+        const reactionRepo = manager.getRepository(Reaction);
+        const outboxRepo = manager.getRepository(OutboxEvent);
 
-      // 3. Prevent duplicate reactions
-      const existing = await reactionRepo.findOne({
-        where: {
-          confession: { id: dto.confessionId },
-          anonymousUser: { id: dto.anonymousUserId },
-        },
-      });
+        // 3. Prevent duplicate reactions
+        const existing = await reactionRepo.findOne({
+          where: {
+            confession: { id: dto.confessionId },
+            anonymousUser: { id: dto.anonymousUserId },
+          },
+        });
 
-      if (existing) {
-        if (existing.emoji === dto.emoji) {
-          return existing;
+        if (existing) {
+          if (existing.emoji === dto.emoji) {
+            return existing;
+          }
+
+          existing.emoji = dto.emoji;
+          const updated = await reactionRepo.save(existing);
+
+          // Update outbox event for the change?
+          // Usually reactions are high volume, but let's notify the author.
+          await this.createOutboxEvent(
+            outboxRepo,
+            confession,
+            updated,
+            'reaction_update',
+          );
+
+          return updated;
         }
 
-        existing.emoji = dto.emoji;
-        const updated = await reactionRepo.save(existing);
+        // 4. Persist new reaction
+        const reaction = reactionRepo.create({
+          emoji: dto.emoji,
+          confession,
+          anonymousUser,
+        });
 
-        // Update outbox event for the change?
-        // Usually reactions are high volume, but let's notify the author.
-        await this.createOutboxEvent(outboxRepo, confession, updated, 'reaction_update');
+        const savedReaction = await reactionRepo.save(reaction);
 
-        return updated;
-      }
+        await this.createOutboxEvent(
+          outboxRepo,
+          confession,
+          savedReaction,
+          'reaction_notification',
+        );
 
-      // 4. Persist new reaction
-      const reaction = reactionRepo.create({
-        emoji: dto.emoji,
-        confession,
-        anonymousUser,
+        return savedReaction;
+      })
+      .then(async (result) => {
+        // Invalidate analytics segments that are affected by a reaction change.
+        // Done outside the DB transaction so cache churn does not increase
+        // transaction latency. Errors are absorbed by the cache service.
+        this.analyticsService
+          .invalidateTrendingCache('reaction-mutation')
+          .catch((err) =>
+            this.logger.error(
+              'Failed to invalidate trending cache after reaction',
+              err,
+            ),
+          );
+        this.analyticsService
+          .invalidateReactionDistributionCache('reaction-mutation')
+          .catch((err) =>
+            this.logger.error(
+              'Failed to invalidate reaction distribution cache',
+              err,
+            ),
+          );
+        return result;
       });
-
-      const savedReaction = await reactionRepo.save(reaction);
-
-      await this.createOutboxEvent(outboxRepo, confession, savedReaction, 'reaction_notification');
-
-      return savedReaction;
-    });
   }
 
   private async createOutboxEvent(


### PR DESCRIPTION
- Add CacheService.invalidateSegment(prefix, reason) with structured observability logging (eviction count, elapsed ms, reason string)
- Migrate AnalyticsService from raw CACHE_MANAGER to CacheService and expose five scoped invalidation methods: invalidateTrendingCache, invalidateReactionDistributionCache, invalidateGrowthCache, invalidateUserActivityCache, invalidateStatsCache
- Wire fire-and-forget cache invalidation in ReactionService.createReaction (trending + reaction-distribution) and CommentService.create / delete / moderateComment (trending; stats on moderation)
- Import AnalyticsModule into ReactionModule and CommentModule
- Remove redundant local CacheModule.register() from AnalyticsModule
- Fix pre-existing email.config.ts missing exports (TemplateRegistry, TemplateRolloutMap, resolveTemplate) that blocked comment spec compilation
- Fix jest.config.js to exclude nested xconfess-backend/ artefact directory
- Add/update tests: 35 passing across analytics, reaction, and comment specs

Closes #436 