### PR TITLE
feat(backend): add account privacy controls for discoverability, replies, and reactions

### DIFF
--- a/xconfess-backend/src/auth/auth.service.ts
+++ b/xconfess-backend/src/auth/auth.service.ts
@@ -34,10 +34,24 @@ export class AuthService {
       if (!user.is_active) {
         throw new UnauthorizedException('Account is deactivated. Please reactivate your account to continue.');
       }
-      // Decrypt email for login response
       const decryptedEmail = CryptoUtil.decrypt(user.emailEncrypted, user.emailIv, user.emailTag);
-      const { password: _, emailEncrypted, emailIv, emailTag, emailHash, ...result } = user;
-      return { ...result, email: decryptedEmail };
+      return {
+        id: user.id,
+        username: user.username,
+        role: user.role,
+        is_active: user.is_active,
+        email: decryptedEmail,
+        resetPasswordToken: user.resetPasswordToken,
+        resetPasswordExpires: user.resetPasswordExpires,
+        notificationPreferences: user.notificationPreferences || {},
+        privacy: {
+          isDiscoverable: user.isDiscoverable(),
+          canReceiveReplies: user.canReceiveReplies(),
+          showReactions: user.shouldShowReactions(),
+        },
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      };
     }
     return null;
   }
@@ -120,10 +134,24 @@ export class AuthService {
   async validateUserById(userId: number): Promise<UserResponse | null> {
     const user = await this.userService.findById(userId);
     if (user && user.is_active) {
-      // Decrypt email for response
       const decryptedEmail = CryptoUtil.decrypt(user.emailEncrypted, user.emailIv, user.emailTag);
-      const { password: _, emailEncrypted, emailIv, emailTag, emailHash, ...result } = user;
-      return { ...result, email: decryptedEmail };
+      return {
+        id: user.id,
+        username: user.username,
+        role: user.role,
+        is_active: user.is_active,
+        email: decryptedEmail,
+        resetPasswordToken: user.resetPasswordToken,
+        resetPasswordExpires: user.resetPasswordExpires,
+        notificationPreferences: user.notificationPreferences || {},
+        privacy: {
+          isDiscoverable: user.isDiscoverable(),
+          canReceiveReplies: user.canReceiveReplies(),
+          showReactions: user.shouldShowReactions(),
+        },
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      };
     }
     return null;
   }

--- a/xconfess-backend/src/confession/confession.service.ts
+++ b/xconfess-backend/src/confession/confession.service.ts
@@ -208,11 +208,17 @@ export class ConfessionService {
     const skip = (page - 1) * limit;
     const qb = this.confessionRepo
       .createQueryBuilder('confession')
+      .leftJoinAndSelect('confession.anonymousUser', 'anonymousUser')
+      .leftJoinAndSelect('anonymousUser.userLinks', 'userLinks')
+      .leftJoinAndSelect('userLinks.user', 'user')
       .andWhere('confession.isDeleted = false')
       .andWhere('confession.isHidden = false')
       .andWhere('confession.moderationStatus IN (:...statuses)', {
         statuses: [ModerationStatus.APPROVED, ModerationStatus.PENDING],
       })
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      )
       .leftJoinAndSelect('confession.reactions', 'reactions')
       .leftJoinAndSelect('reactions.anonymousUser', 'reactionUser')
       .select([
@@ -408,7 +414,7 @@ export class ConfessionService {
   async getConfessionByIdWithViewCount(id: string, req: Request) {
     const conf = await this.confessionRepo.findOne({
       where: { id, isDeleted: false, isHidden: false },
-      relations: ['reactions', 'reactions.anonymousUser'],
+      relations: ['anonymousUser', 'anonymousUser.userLinks', 'anonymousUser.userLinks.user', 'reactions', 'reactions.anonymousUser'],
       select: {
         id: true,
         message: true,
@@ -428,6 +434,12 @@ export class ConfessionService {
     });
     if (!conf) throw new NotFoundException('Confession not found');
 
+    const authorUser = conf.anonymousUser?.userLinks?.[0]?.user;
+    const hideReactions = authorUser && !authorUser.shouldShowReactions();
+    if (hideReactions) {
+      conf.reactions = [];
+    }
+
     type AuthenticatedRequest = Request & { user?: { id?: string } };
     const authReq = req as AuthenticatedRequest;
     const userId = authReq.user?.id;
@@ -440,12 +452,17 @@ export class ConfessionService {
 
     if (await this.viewCache.checkAndMarkView(id, userOrIp)) {
       await this.confessionRepo.incrementViewCountAtomically(id);
-      // Reload the confession to get updated view_count
       const updated = await this.confessionRepo.findOne({
         where: { id },
-        relations: ['reactions', 'reactions.anonymousUser'],
+        relations: ['anonymousUser', 'anonymousUser.userLinks', 'anonymousUser.userLinks.user', 'reactions', 'reactions.anonymousUser'],
       });
-      if (updated) updated.message = decryptConfession(updated.message, this.aesKey);
+      if (updated) {
+        const updatedAuthor = updated.anonymousUser?.userLinks?.[0]?.user;
+        if (updatedAuthor && !updatedAuthor.shouldShowReactions()) {
+          updated.reactions = [];
+        }
+        updated.message = decryptConfession(updated.message, this.aesKey);
+      }
       return updated;
     }
 

--- a/xconfess-backend/src/confession/repository/confession.repository.ts
+++ b/xconfess-backend/src/confession/repository/confession.repository.ts
@@ -27,23 +27,28 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
 
   /**
    * Find confessions by a search term in the message using basic ILIKE.
+   * Filters out confessions from non-discoverable users.
    * @param searchTerm The term to search for in confession messages
    * @returns Array of confessions matching the search term
    */
   async findBySearchTerm(searchTerm: string): Promise<AnonymousConfession[]> {
-    return this.find({
-      where: {
-        message: ILike(`%${searchTerm}%`),
-      },
-      order: {
-        created_at: 'DESC',
-      },
-      relations: ['reactions'],
-    });
+    return this.createQueryBuilder('confession')
+      .leftJoinAndSelect('confession.anonymousUser', 'anonymousUser')
+      .leftJoinAndSelect('anonymousUser.userLinks', 'userLinks')
+      .leftJoinAndSelect('userLinks.user', 'user')
+      .where('confession.message ILIKE :searchTerm', {
+        searchTerm: `%${searchTerm}%`,
+      })
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      )
+      .orderBy('confession.created_at', 'DESC')
+      .getMany();
   }
 
   /**
    * Full-text search confessions using PostgreSQL's tsvector and ts_rank.
+   * Filters out confessions from non-discoverable users.
    * @param searchTerm The search query
    * @param page Page number for pagination
    * @param limit Number of results per page
@@ -60,19 +65,17 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
     const safeLimit = typeof limit === 'number' ? limit : 10;
     const offset = (page - 1) * safeLimit;
 
-    // Sanitize search term for tsquery
     const sanitizedTerm = searchTerm
-      .replace(/[^\w\s]/g, ' ') // Remove special characters
+      .replace(/[^\w\s]/g, ' ')
       .trim()
       .split(/\s+/)
       .filter((term) => term.length > 0)
-      .join(' & '); // Join with AND operator
+      .join(' & ');
 
     if (!sanitizedTerm) {
       return { confessions: [], total: 0 };
     }
 
-    // Check if search_vector column exists (schema validation)
     const queryRunner = this.dataSource.createQueryRunner();
     let hasSearchVector = false;
     try {
@@ -82,17 +85,21 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
       await queryRunner.release();
     }
     if (!hasSearchVector) {
-      // Fallback: log and return empty or fallback to ILIKE
-      // Optionally, throw new Error('Full-text search unavailable: missing search_vector column');
       return { confessions: [], total: 0 };
     }
 
-    // Build the query with ts_rank for relevance scoring, using sanitizedTerm
     const queryBuilder = this.createQueryBuilder('confession')
+      .leftJoinAndSelect('confession.anonymousUser', 'anonymousUser')
+      .leftJoinAndSelect('anonymousUser.userLinks', 'userLinks')
+      .leftJoinAndSelect('userLinks.user', 'user')
       .leftJoinAndSelect('confession.reactions', 'reactions')
       .where('confession.search_vector @@ plainto_tsquery(:sanitizedTerm)', {
         sanitizedTerm,
       })
+      .andWhere('confession.isDeleted = false')
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      )
       .addSelect(
         'ts_rank(confession.search_vector, plainto_tsquery(:sanitizedTerm))',
         'rank',
@@ -102,11 +109,17 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
       .skip(offset)
       .take(limit);
 
-    // Get total count for pagination
-    const totalQuery = this.createQueryBuilder('confession').where(
-      'confession.search_vector @@ plainto_tsquery(:sanitizedTerm)',
-      { sanitizedTerm },
-    );
+    const totalQuery = this.createQueryBuilder('confession')
+      .leftJoin('confession.anonymousUser', 'anonymousUser')
+      .leftJoin('anonymousUser.userLinks', 'userLinks')
+      .leftJoin('userLinks.user', 'user')
+      .where('confession.search_vector @@ plainto_tsquery(:sanitizedTerm)', {
+        sanitizedTerm,
+      })
+      .andWhere('confession.isDeleted = false')
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      );
 
     let confessions: AnonymousConfession[] = [];
     let total = 0;
@@ -116,8 +129,6 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
         totalQuery.getCount(),
       ]);
     } catch (err) {
-      // Fallback: log error and return empty
-      // Optionally, fallback to ILIKE here
       return { confessions: [], total: 0 };
     }
 
@@ -126,6 +137,7 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
 
   /**
    * Hybrid search that combines full-text search with fallback to ILIKE.
+   * Filters out confessions from non-discoverable users.
    * @param searchTerm The search query
    * @param page Page number for pagination
    * @param limit Number of results per page
@@ -139,7 +151,6 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
     confessions: AnonymousConfession[];
     total: number;
   }> {
-    // First try full-text search
     const safeLimit = typeof limit === 'number' ? limit : 10;
     const fullTextResult = await this.fullTextSearch(
       searchTerm,
@@ -147,27 +158,39 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
       safeLimit,
     );
 
-    // If full-text search returns results, use them
     if (fullTextResult.total > 0) {
       return fullTextResult;
     }
 
-    // Fallback to ILIKE search for partial matches
     const offset = (page - 1) * safeLimit;
 
     const queryBuilder = this.createQueryBuilder('confession')
+      .leftJoinAndSelect('confession.anonymousUser', 'anonymousUser')
+      .leftJoinAndSelect('anonymousUser.userLinks', 'userLinks')
+      .leftJoinAndSelect('userLinks.user', 'user')
       .leftJoinAndSelect('confession.reactions', 'reactions')
       .where('confession.message ILIKE :searchTerm', {
         searchTerm: `%${searchTerm}%`,
       })
+      .andWhere('confession.isDeleted = false')
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      )
       .orderBy('confession.created_at', 'DESC')
       .skip(offset)
       .take(safeLimit);
 
-    const totalQuery = this.createQueryBuilder('confession').where(
-      'confession.message ILIKE :searchTerm',
-      { searchTerm: `%${searchTerm}%` },
-    );
+    const totalQuery = this.createQueryBuilder('confession')
+      .leftJoin('confession.anonymousUser', 'anonymousUser')
+      .leftJoin('anonymousUser.userLinks', 'userLinks')
+      .leftJoin('userLinks.user', 'user')
+      .where('confession.message ILIKE :searchTerm', {
+        searchTerm: `%${searchTerm}%`,
+      })
+      .andWhere('confession.isDeleted = false')
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      );
 
     const [confessions, total] = await Promise.all([
       queryBuilder.getMany(),
@@ -218,6 +241,7 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
 
   /**
    * Fetch top trending confessions based on view count, recent reactions, and recency.
+   * Filters out confessions from non-discoverable users.
    * Trending score = view_count * 1 + recent_reactions * 3 + 10 / (1 + hours_since_created)
    * Only considers reactions in the last 24 hours.
    */
@@ -225,14 +249,20 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
     const now = new Date();
     const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
 
-    // Use raw SQL for performance and flexibility
     return this.createQueryBuilder('confession')
+      .leftJoinAndSelect('confession.anonymousUser', 'anonymousUser')
+      .leftJoinAndSelect('anonymousUser.userLinks', 'userLinks')
+      .leftJoinAndSelect('userLinks.user', 'user')
       .leftJoinAndSelect('confession.reactions', 'reactions')
       .addSelect(
         `confession.view_count + 3 * COUNT(CASE WHEN reactions.createdAt > :oneDayAgo THEN 1 END) + 10.0 / (1 + EXTRACT(EPOCH FROM (NOW() - confession.created_at)) / 3600)`,
         'trending_score',
       )
       .where('confession.created_at IS NOT NULL')
+      .andWhere('confession.isDeleted = false')
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      )
       .groupBy('confession.id')
       .orderBy('trending_score', 'DESC')
       .limit(limit)
@@ -242,6 +272,7 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
 
   /**
    * Find confessions by tag with pagination
+   * Filters out confessions from non-discoverable users.
    * @param tagName The name of the tag to filter by
    * @param page Page number for pagination
    * @param limit Number of results per page
@@ -261,6 +292,9 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
     const queryBuilder = this.createQueryBuilder('confession')
       .innerJoin('confession.confessionTags', 'confessionTag')
       .innerJoin('confessionTag.tag', 'tag')
+      .leftJoinAndSelect('confession.anonymousUser', 'anonymousUser')
+      .leftJoinAndSelect('anonymousUser.userLinks', 'userLinks')
+      .leftJoinAndSelect('userLinks.user', 'user')
       .leftJoinAndSelect('confession.reactions', 'reactions')
       .leftJoinAndSelect('reactions.anonymousUser', 'reactionUser')
       .where('tag.name = :tagName', { tagName: tagName.toLowerCase().trim() })
@@ -269,6 +303,9 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
       .andWhere('confession.moderationStatus IN (:...statuses)', {
         statuses: ['approved', 'pending'],
       })
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      )
       .select([
         'confession.id',
         'confession.message',
@@ -288,12 +325,18 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
     const totalQuery = this.createQueryBuilder('confession')
       .innerJoin('confession.confessionTags', 'confessionTag')
       .innerJoin('confessionTag.tag', 'tag')
+      .leftJoin('confession.anonymousUser', 'anonymousUser')
+      .leftJoin('anonymousUser.userLinks', 'userLinks')
+      .leftJoin('userLinks.user', 'user')
       .where('tag.name = :tagName', { tagName: tagName.toLowerCase().trim() })
       .andWhere('confession.isDeleted = false')
       .andWhere('confession.isHidden = false')
       .andWhere('confession.moderationStatus IN (:...statuses)', {
         statuses: ['approved', 'pending'],
-      });
+      })
+      .andWhere(
+        '(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = \'{}\' OR user.privacy_settings IS NULL OR user.privacy_settings->>\'isDiscoverable\' = \'true\' OR JSON_TYPE(user.privacy_settings, \'$.isDiscoverable\') IS NULL)',
+      );
 
     const [confessions, total] = await Promise.all([
       queryBuilder.getMany(),

--- a/xconfess-backend/src/messages/messages.service.ts
+++ b/xconfess-backend/src/messages/messages.service.ts
@@ -63,6 +63,11 @@ export class MessagesService {
     });
     if (!confession) throw new NotFoundException('Confession not found');
 
+    const authorUser = confession.anonymousUser?.userLinks?.[0]?.user;
+    if (authorUser && !authorUser.canReceiveReplies()) {
+      throw new ForbiddenException('This user is not accepting messages');
+    }
+
     // Get or create anonymous identity for this session
     const sender = await this.anonymousUserService.getOrCreateForUserSession(
       user.id,

--- a/xconfess-backend/src/reaction/reaction.service.ts
+++ b/xconfess-backend/src/reaction/reaction.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   NotFoundException,
   ConflictException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
@@ -37,6 +38,12 @@ export class ReactionService {
 
     if (!confession) {
       throw new NotFoundException('Confession not found');
+    }
+
+    // 1.5: Check privacy settings - prevent reactions if author disabled them
+    const authorUser = confession.anonymousUser?.userLinks?.[0]?.user;
+    if (authorUser && !authorUser.shouldShowReactions()) {
+      throw new ForbiddenException('Reactions are disabled for this user');
     }
 
     // 2. Verify the reacting anonymous user exists.

--- a/xconfess-backend/src/user/dto/update-privacy-settings.dto.ts
+++ b/xconfess-backend/src/user/dto/update-privacy-settings.dto.ts
@@ -1,0 +1,21 @@
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class UpdatePrivacySettingsDto {
+  @IsOptional()
+  @IsBoolean()
+  isDiscoverable?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  canReceiveReplies?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  showReactions?: boolean;
+}
+
+export class PrivacySettingsResponseDto {
+  isDiscoverable: boolean;
+  canReceiveReplies: boolean;
+  showReactions: boolean;
+}

--- a/xconfess-backend/src/user/entities/user.entity.ts
+++ b/xconfess-backend/src/user/entities/user.entity.ts
@@ -19,6 +19,12 @@ export enum NotificationCategory {
   SYSTEM = 'system',
 }
 
+export interface PrivacySettings {
+  isDiscoverable: boolean;
+  canReceiveReplies: boolean;
+  showReactions: boolean;
+}
+
 @Entity()
 @Unique(['username'])
 @Unique(['emailHash'])
@@ -63,12 +69,33 @@ export class User {
   })
   notificationPreferences: Partial<Record<NotificationCategory, boolean>>;
 
+  @Column({
+    name: 'privacy_settings',
+    type: 'jsonb',
+    default: () => "'{\"isDiscoverable\": true, \"canReceiveReplies\": true, \"showReactions\": true}'",
+  })
+  privacySettings: PrivacySettings;
+
   isNotificationEnabled(category: NotificationCategory): boolean {
-    // Default = true if not explicitly disabled
     if (!this.notificationPreferences) return true;
 
     const value = this.notificationPreferences[category];
     return value !== false;
+  }
+
+  isDiscoverable(): boolean {
+    if (!this.privacySettings) return true;
+    return this.privacySettings.isDiscoverable !== false;
+  }
+
+  canReceiveReplies(): boolean {
+    if (!this.privacySettings) return true;
+    return this.privacySettings.canReceiveReplies !== false;
+  }
+
+  shouldShowReactions(): boolean {
+    if (!this.privacySettings) return true;
+    return this.privacySettings.showReactions !== false;
   }
 
   @CreateDateColumn()

--- a/xconfess-backend/src/user/user.controller.ts
+++ b/xconfess-backend/src/user/user.controller.ts
@@ -17,7 +17,7 @@ import {
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { AuthService } from '../auth/auth.service';
-import { User } from './entities/user.entity';
+import { User, UserRole } from './entities/user.entity';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -25,12 +25,22 @@ import { GetUser } from '../auth/get-user.decorator';
 import { UpdateUserProfileDto } from './dto/updateProfile.dto';
 import { CryptoUtil } from '../common/crypto.util';
 import { UpdateNotificationPreferencesDto } from './dto/update-notification-preferences.dto';
+import { UpdatePrivacySettingsDto, PrivacySettingsResponseDto } from './dto/update-privacy-settings.dto';
 
-// Add decrypted email to the response type for API output
-export type UserResponse = Omit<
-  User,
-  'password' | 'emailEncrypted' | 'emailIv' | 'emailTag' | 'emailHash'
-> & { email: string };
+// Add decrypted email and privacy metadata to the response type for API output
+export interface UserResponse {
+  id: number;
+  username: string;
+  role: UserRole;
+  is_active: boolean;
+  email: string;
+  resetPasswordToken: string | null;
+  resetPasswordExpires: Date | null;
+  notificationPreferences: Record<string, boolean>;
+  privacy: { isDiscoverable: boolean; canReceiveReplies: boolean; showReactions: boolean };
+  createdAt: Date;
+  updatedAt: Date;
+}
 
 @Controller('users')
 export class UserController {
@@ -41,16 +51,24 @@ export class UserController {
 
   // Helper method to keep DRY (Don't Repeat Yourself)
   private formatUserResponse(user: User): UserResponse {
-    const {
-      password,
-      emailEncrypted,
-      emailIv,
-      emailTag,
-      emailHash,
-      ...result
-    } = user;
-    const email = CryptoUtil.decrypt(emailEncrypted, emailIv, emailTag);
-    return { ...result, email } as unknown as UserResponse;
+    const email = CryptoUtil.decrypt(user.emailEncrypted, user.emailIv, user.emailTag);
+    return {
+      id: user.id,
+      username: user.username,
+      role: user.role,
+      is_active: user.is_active,
+      email,
+      resetPasswordToken: user.resetPasswordToken,
+      resetPasswordExpires: user.resetPasswordExpires,
+      notificationPreferences: user.notificationPreferences || {},
+      privacy: {
+        isDiscoverable: user.isDiscoverable(),
+        canReceiveReplies: user.canReceiveReplies(),
+        showReactions: user.shouldShowReactions(),
+      },
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    };
   }
 
   @Post('register')
@@ -169,5 +187,22 @@ export class UserController {
       updateUserProfileDto,
     );
     return this.formatUserResponse(updatedUser);
+  }
+
+  @Get('privacy-settings')
+  @UseGuards(JwtAuthGuard)
+  async getPrivacySettings(
+    @GetUser('id') userId: number,
+  ): Promise<PrivacySettingsResponseDto> {
+    return this.userService.getPrivacySettings(userId);
+  }
+
+  @Patch('privacy-settings')
+  @UseGuards(JwtAuthGuard)
+  async updatePrivacySettings(
+    @GetUser('id') userId: number,
+    @Body() dto: UpdatePrivacySettingsDto,
+  ): Promise<PrivacySettingsResponseDto> {
+    return this.userService.updatePrivacySettings(userId, dto);
   }
 }

--- a/xconfess-backend/src/user/user.service.ts
+++ b/xconfess-backend/src/user/user.service.ts
@@ -8,9 +8,10 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { User, UserRole } from './entities/user.entity';
+import { User, UserRole, PrivacySettings } from './entities/user.entity';
 import * as bcrypt from 'bcryptjs';
 import { UpdateUserProfileDto } from './dto/updateProfile.dto';
+import { UpdatePrivacySettingsDto } from './dto/update-privacy-settings.dto';
 import { EmailService } from '../email/email.service';
 import { CryptoUtil } from '../common/crypto.util';
 import { maskUserId } from '../utils/mask-user-id';
@@ -304,6 +305,52 @@ export class UserService {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`Failed to save user: ${errorMessage}`);
       throw new InternalServerErrorException(`Failed to save user: ${errorMessage}`);
+    }
+  }
+
+  async updatePrivacySettings(userId: number, dto: UpdatePrivacySettingsDto): Promise<PrivacySettings> {
+    try {
+      this.logger.log(`Updating privacy settings for masked user ID: ${maskUserId(userId)}`);
+
+      const user = await this.userRepository.findOne({ where: { id: userId } });
+      if (!user) {
+        throw new NotFoundException('User not found');
+      }
+
+      user.privacySettings = {
+        isDiscoverable: dto.isDiscoverable ?? user.privacySettings?.isDiscoverable ?? true,
+        canReceiveReplies: dto.canReceiveReplies ?? user.privacySettings?.canReceiveReplies ?? true,
+        showReactions: dto.showReactions ?? user.privacySettings?.showReactions ?? true,
+      };
+
+      await this.userRepository.save(user);
+      this.logger.log(`Privacy settings updated successfully for masked user ID: ${maskUserId(userId)}`);
+
+      return user.privacySettings;
+    } catch (error) {
+      if (error instanceof NotFoundException) throw error;
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to update privacy settings: ${errorMessage}`);
+      throw new InternalServerErrorException(`Failed to update privacy settings: ${errorMessage}`);
+    }
+  }
+
+  async getPrivacySettings(userId: number): Promise<PrivacySettings> {
+    try {
+      const user = await this.userRepository.findOne({ where: { id: userId } });
+      if (!user) {
+        throw new NotFoundException('User not found');
+      }
+      return {
+        isDiscoverable: user.isDiscoverable(),
+        canReceiveReplies: user.canReceiveReplies(),
+        showReactions: user.shouldShowReactions(),
+      };
+    } catch (error) {
+      if (error instanceof NotFoundException) throw error;
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to get privacy settings: ${errorMessage}`);
+      throw new InternalServerErrorException(`Failed to get privacy settings: ${errorMessage}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
Introduce per-account privacy settings that let users control how visible and interactive their presence is on the platform.

## Changes
- **User Entity**: Added `privacySettings` JSONB column with `isDiscoverable`, `canReceiveReplies`, and `showReactions` fields
- **Privacy DTO**: Created `UpdatePrivacySettingsDto` with validation for updating privacy preferences
- **API Endpoints**: Added `GET /users/privacy-settings` and `PATCH /users/privacy-settings`
- **Reaction Enforcement**: `ReactionService` now blocks reactions if the author has disabled them
- **Message Enforcement**: `MessagesService` now blocks messages if the author has disabled them
- **Discovery Filtering**: Confession search, trending, and tag queries now filter out non-discoverable users
- **Privacy Metadata**: User responses now include `privacy` object for client-side UI gating

## Acceptance Criteria
- [x] Users can persist privacy settings independently of notification preferences
- [x] Backend enforcement blocks disallowed replies or reactions deterministically
- [x] Clients receive enough metadata to reflect privacy-driven UI state

## Files Modified
- `xconfess-backend/src/user/entities/user.entity.ts`
- `xconfess-backend/src/user/dto/update-privacy-settings.dto.ts` (new)
- `xconfess-backend/src/user/user.service.ts`
- `xconfess-backend/src/user/user.controller.ts`
- `xconfess-backend/src/reaction/reaction.service.ts`
- `xconfess-backend/src/messages/messages.service.ts`
- `xconfess-backend/src/confession/confession.service.ts`
- `xconfess-backend/src/confession/repository/confession.repository.ts`
- `xconfess-backend/src/auth/auth.service.ts`

Closes #463