### PR TITLE
implemented add draft revision history edit conflict

### DIFF
--- a/xconfess-backend/src/confession-draft/confession-draft.controller.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.controller.ts
@@ -46,7 +46,7 @@ export class ConfessionDraftController {
     @Param('id') id: string,
     @Body() dto: UpdateConfessionDraftDto,
   ) {
-    return this.service.updateDraft(userId, id, dto.content);
+    return this.service.updateDraft(userId, id, dto);
   }
 
   @Delete(':id')

--- a/xconfess-backend/src/confession-draft/confession-draft.service.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.service.spec.ts
@@ -1,20 +1,22 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
 import { ConfessionDraftService } from './confession-draft.service';
 import {
   ConfessionDraft,
   ConfessionDraftStatus,
 } from './entities/confession-draft.entity';
 import { ConfessionService } from '../confession/confession.service';
+import { encryptConfession } from '../utils/confession-encryption';
+
+const AES_KEY = '12345678901234567890123456789012';
 
 describe('ConfessionDraftService', () => {
   let service: ConfessionDraftService;
   let repo: jest.Mocked<Repository<ConfessionDraft>>;
 
   beforeEach(async () => {
-    process.env.CONFESSION_AES_KEY = '12345678901234567890123456789012';
-
     repo = {
       count: jest.fn(),
       create: jest.fn(),
@@ -29,6 +31,15 @@ describe('ConfessionDraftService', () => {
         ConfessionDraftService,
         { provide: getRepositoryToken(ConfessionDraft), useValue: repo },
         { provide: ConfessionService, useValue: { create: jest.fn() } },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'app.confessionAesKey') return AES_KEY;
+              return null;
+            }),
+          },
+        },
         {
           provide: DataSource,
           useValue: {
@@ -60,5 +71,85 @@ describe('ConfessionDraftService', () => {
 
     const res = await service.createDraft(1, 'hello');
     expect(res.content).toBe('hello');
+  });
+
+  describe('updateDraft', () => {
+    it('successfully updates and saves revision when version matches', async () => {
+      const draft = {
+        id: 'draft1',
+        userId: 1,
+        content: encryptConfession('old content', AES_KEY),
+        version: 1,
+        revisions: [],
+        status: ConfessionDraftStatus.DRAFT,
+      } as any;
+
+      repo.findOne.mockResolvedValue(draft);
+      repo.save.mockImplementation(async (x: any) => ({
+        ...x,
+        version: x.version + 1,
+      }));
+
+      const res = await service.updateDraft(1, 'draft1', {
+        content: 'new content',
+        version: 1,
+      });
+
+      expect(res.content).toBe('new content');
+      expect(res.revisions).toHaveLength(1);
+      expect(res.revisions[0].content).toBe('old content');
+      expect(res.revisions[0].version).toBe(1);
+    });
+
+    it('throws ConflictException when version mismatch', async () => {
+      const draft = {
+        id: 'draft1',
+        userId: 1,
+        content: encryptConfession('server content', AES_KEY),
+        version: 2,
+        revisions: [],
+        status: ConfessionDraftStatus.DRAFT,
+      } as any;
+
+      repo.findOne.mockResolvedValue(draft);
+
+      await expect(
+        service.updateDraft(1, 'draft1', {
+          content: 'stale client content',
+          version: 1,
+        }),
+      ).rejects.toThrow('Conflict detected');
+    });
+
+    it('bounds revision history to 10 entries', async () => {
+      const oldRevisions = Array(10)
+        .fill(null)
+        .map((_, i) => ({
+          content: encryptConfession(`rev-${i}`, AES_KEY),
+          version: i,
+          createdAt: new Date(),
+        }));
+
+      const draft = {
+        id: 'draft1',
+        userId: 1,
+        content: encryptConfession('current', AES_KEY),
+        version: 10,
+        revisions: [...oldRevisions],
+        status: ConfessionDraftStatus.DRAFT,
+      } as any;
+
+      repo.findOne.mockResolvedValue(draft);
+      repo.save.mockImplementation(async (x: any) => x);
+
+      const res = await service.updateDraft(1, 'draft1', {
+        content: 'newest',
+        version: 10,
+      });
+
+      expect(res.revisions).toHaveLength(10);
+      expect(res.revisions[0].content).toBe('current');
+      expect(res.revisions[9].content).toBe('rev-8');
+    });
   });
 });

--- a/xconfess-backend/src/confession-draft/confession-draft.service.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -22,6 +23,7 @@ import {
   decryptConfession,
 } from '../utils/confession-encryption';
 import { ConfessionService } from '../confession/confession.service';
+import { UpdateConfessionDraftDto } from './dto/update-confession-draft.dto';
 import { DateTime } from 'luxon';
 
 const MAX_DRAFTS_PER_USER = 50;
@@ -62,6 +64,10 @@ export class ConfessionDraftService {
     return {
       ...draft,
       content: decryptConfession(draft.content, this.aesKey),
+      revisions: (draft.revisions || []).map((rev) => ({
+        ...rev,
+        content: decryptConfession(rev.content, this.aesKey),
+      })),
     };
   }
 
@@ -117,7 +123,11 @@ export class ConfessionDraftService {
     return this.sanitizeForResponse(draft);
   }
 
-  async updateDraft(userId: number, id: string, content?: string) {
+  async updateDraft(
+    userId: number,
+    id: string,
+    dto: UpdateConfessionDraftDto,
+  ) {
     const draft = await this.draftRepo.findOne({ where: { id } });
     if (!draft) throw new NotFoundException('Draft not found');
     if (draft.userId !== userId) throw new ForbiddenException();
@@ -126,8 +136,23 @@ export class ConfessionDraftService {
       throw new BadRequestException('Cannot edit a posted draft');
     }
 
-    if (typeof content === 'string') {
-      draft.content = encryptConfession(content, this.aesKey);
+    if (draft.version !== dto.version) {
+      throw new ConflictException({
+        message: 'Conflict detected: draft has been modified by another session',
+        currentDraft: this.sanitizeForResponse(draft),
+      });
+    }
+
+    if (typeof dto.content === 'string') {
+      // Store current content in revision history before updating
+      const revision = {
+        content: draft.content,
+        version: draft.version,
+        createdAt: new Date(),
+      };
+
+      draft.revisions = [revision, ...(draft.revisions || [])].slice(0, 10);
+      draft.content = encryptConfession(dto.content, this.aesKey);
     }
 
     const saved = await this.draftRepo.save(draft);

--- a/xconfess-backend/src/confession-draft/dto/update-confession-draft.dto.ts
+++ b/xconfess-backend/src/confession-draft/dto/update-confession-draft.dto.ts
@@ -1,6 +1,10 @@
 import { PartialType, PickType } from '@nestjs/mapped-types';
+import { IsNumber } from 'class-validator';
 import { CreateConfessionDraftDto } from './create-confession-draft.dto';
 
 export class UpdateConfessionDraftDto extends PartialType(
   PickType(CreateConfessionDraftDto, ['content'] as const),
-) {}
+) {
+  @IsNumber()
+  version: number;
+}

--- a/xconfess-backend/src/confession-draft/entities/confession-draft.entity.ts
+++ b/xconfess-backend/src/confession-draft/entities/confession-draft.entity.ts
@@ -7,6 +7,7 @@ import {
   Index,
   ManyToOne,
   JoinColumn,
+  VersionColumn,
 } from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 
@@ -58,4 +59,10 @@ export class ConfessionDraft {
 
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
+
+  @VersionColumn()
+  version: number;
+
+  @Column({ type: 'jsonb', default: [] })
+  revisions: { content: string; version: number; createdAt: Date }[];
 }

--- a/xconfess-backend/src/moderation/ai-moderation.service.ts
+++ b/xconfess-backend/src/moderation/ai-moderation.service.ts
@@ -160,8 +160,8 @@ export class AiModerationService {
         details.sexual = result.category_scores.sexual;
       }
 
-      const scores = Object.values(result.category_scores);
-      const maxScore = Math.max(...scores);
+      const scores = Object.values(result.category_scores) as number[];
+      const maxScore = scores.length > 0 ? Math.max(...scores) : 0;
 
       return {
         score: maxScore,


### PR DESCRIPTION
I have completed the implementation of Draft Revisions and Conflict Detection for confession drafts.

Key Features:
Optimistic Concurrency: Updates now require a version number. If the version in the database has changed (e.g., edited in another tab), the update is rejected with a 409 Conflict error.
Conflict Metadata: The conflict response includes the current server version and content, allowing for easy reconciliation.
Bounded History: The last 10 revisions of each draft are automatically stored and encrypted in the database.
Revision Recovery: Historical revisions are decrypted and returned in the API response for comparison or recovery.
Verification:
I added 3 new unit tests to confession-draft.service.spec.ts covering:

Successful versioned updates.
Conflict detection on version mismatch.
Pruning of history once the 10-revision limit is reached.
All tests passed successfully:

bash
PASS  src/confession-draft/confession-draft.service.spec.ts
  ConfessionDraftService
    ✓ createDraft encrypts content and returns decrypted content
    updateDraft
      ✓ successfully updates and saves revision when version matches
      ✓ throws ConflictException when version mismatch
      ✓ bounds revision history to 10 entries

Closes #453 