### PR TITLE
implemented add saved search presets and recent-query history

### DIFF
--- a/xconfess-backend/src/app.module.ts
+++ b/xconfess-backend/src/app.module.ts
@@ -9,6 +9,7 @@ import appConfig from './config/app.config';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfessionModule } from './confession/confession.module';
+import { SearchDiscoveryModule } from './search-discovery/search-discovery.module';
 import { ReactionModule } from './reaction/reaction.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { TerminusModule } from '@nestjs/terminus';
@@ -66,6 +67,7 @@ import { DatabaseModule } from './database/database.module';
     UserModule,
     AuthModule,
     ConfessionModule,
+    SearchDiscoveryModule,
     ReactionModule,
     MessagesModule,
     AdminModule,

--- a/xconfess-backend/src/confession/confession.controller.ts
+++ b/xconfess-backend/src/confession/confession.controller.ts
@@ -11,6 +11,7 @@ import {
   Delete,
   Req,
   Patch,
+  UseGuards,
 } from '@nestjs/common';
 import { Request } from 'express';
 import {
@@ -28,6 +29,8 @@ import { GetConfessionsByTagDto } from './dto/get-confessions-by-tag.dto';
 import { GetConfessionsDto } from './dto/get-confessions.dto';
 import { SearchConfessionDto } from './dto/search-confession.dto';
 import { UpdateConfessionDto } from './dto/update-confession.dto';
+import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
+import { SearchDiscoveryService } from '../search-discovery/search-discovery.service';
 
 @ApiTags('Confessions')
 @Controller('confessions')
@@ -37,7 +40,10 @@ export class ConfessionController {
     return this.getById(id, req);
   }
 
-  constructor(private readonly service: ConfessionService) {}
+  constructor(
+    private readonly service: ConfessionService,
+    private readonly searchDiscoveryService: SearchDiscoveryService,
+  ) {}
 
   @Post()
   @ApiOperation({ summary: 'Create a new anonymous confession' })
@@ -56,17 +62,27 @@ export class ConfessionController {
   }
 
   @Get('search')
+  @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({ summary: 'Search confessions (hybrid)' })
   @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
-  search(@Query() dto: SearchConfessionDto) {
-    return this.service.search(dto);
+  async search(@Query() dto: SearchConfessionDto, @Req() req: any) {
+    const result = await this.service.search(dto);
+    if (req.user) {
+      await this.searchDiscoveryService.recordSearch(req.user.id, dto);
+    }
+    return result;
   }
 
   @Get('search/fulltext')
+  @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({ summary: 'Full-text search confessions' })
   @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
-  fullTextSearch(@Query() dto: SearchConfessionDto) {
-    return this.service.fullTextSearch(dto);
+  async fullTextSearch(@Query() dto: SearchConfessionDto, @Req() req: any) {
+    const result = await this.service.fullTextSearch(dto);
+    if (req.user) {
+      await this.searchDiscoveryService.recordSearch(req.user.id, dto);
+    }
+    return result;
   }
 
   @Get('trending/top')

--- a/xconfess-backend/src/confession/confession.module.ts
+++ b/xconfess-backend/src/confession/confession.module.ts
@@ -20,6 +20,7 @@ import { AnonymousContextMiddleware } from '../middleware/anonymous-context.midd
 import { ModerationModule } from '../moderation/moderation.module';
 import { UserModule } from '../user/user.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { SearchDiscoveryModule } from '../search-discovery/search-discovery.module';
 // In-memory mock Redis for development without Redis server
 const REDIS_TOKEN = 'default_IORedisModuleConnectionToken';
 class MockRedis {
@@ -65,6 +66,7 @@ class MockRedis {
     ModerationModule,
     UserModule,
     StellarModule,
+    SearchDiscoveryModule,
   ],
   controllers: [ConfessionController],
   providers: [

--- a/xconfess-backend/src/search-discovery/dto/create-saved-search.dto.ts
+++ b/xconfess-backend/src/search-discovery/dto/create-saved-search.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, IsObject, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateSavedSearchDto {
+  @ApiProperty({ description: 'Name of the search preset', example: 'My Favorite Work Stress Search' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name: string;
+
+  @ApiProperty({ description: 'Filter object (same as SearchConfessionDto)' })
+  @IsObject()
+  @IsNotEmpty()
+  filters: any;
+}

--- a/xconfess-backend/src/search-discovery/entities/saved-search.entity.ts
+++ b/xconfess-backend/src/search-discovery/entities/saved-search.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+@Entity('saved_searches')
+@Index(['userId', 'name'], { unique: true })
+export class SavedSearch {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  userId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column()
+  name: string;
+
+  @Column({ type: 'jsonb' })
+  filters: any;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/xconfess-backend/src/search-discovery/entities/search-history.entity.ts
+++ b/xconfess-backend/src/search-discovery/entities/search-history.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+@Entity('search_history')
+@Index(['userId', 'queryHash'], { unique: true })
+export class SearchHistory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  userId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ nullable: true })
+  query: string;
+
+  @Column({ type: 'jsonb' })
+  filters: any;
+
+  @Column({ name: 'query_hash', length: 64 })
+  queryHash: string;
+
+  @UpdateDateColumn({ name: 'used_at' })
+  usedAt: Date;
+}

--- a/xconfess-backend/src/search-discovery/search-discovery.controller.ts
+++ b/xconfess-backend/src/search-discovery/search-discovery.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { SearchDiscoveryService } from './search-discovery.service';
+import { CreateSavedSearchDto } from './dto/create-saved-search.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@ApiTags('Search Discovery')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('confessions/search/discovery')
+export class SearchDiscoveryController {
+  constructor(private readonly service: SearchDiscoveryService) {}
+
+  @Post('presets')
+  @ApiOperation({ summary: 'Save a search preset' })
+  savePreset(@Req() req: any, @Body() dto: CreateSavedSearchDto) {
+    return this.service.savePreset(req.user.id, dto);
+  }
+
+  @Get('presets')
+  @ApiOperation({ summary: 'List saved search presets' })
+  listPresets(@Req() req: any) {
+    return this.service.listPresets(req.user.id);
+  }
+
+  @Delete('presets/:id')
+  @ApiOperation({ summary: 'Delete a search preset' })
+  deletePreset(@Req() req: any, @Param('id') id: string) {
+    return this.service.deletePreset(req.user.id, id);
+  }
+
+  @Get('history')
+  @ApiOperation({ summary: 'Get recent search history' })
+  getHistory(@Req() req: any) {
+    return this.service.getRecentSearches(req.user.id);
+  }
+}

--- a/xconfess-backend/src/search-discovery/search-discovery.module.ts
+++ b/xconfess-backend/src/search-discovery/search-discovery.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SearchDiscoveryService } from './search-discovery.service';
+import { SearchDiscoveryController } from './search-discovery.controller';
+import { SavedSearch } from './entities/saved-search.entity';
+import { SearchHistory } from './entities/search-history.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SavedSearch, SearchHistory])],
+  providers: [SearchDiscoveryService],
+  controllers: [SearchDiscoveryController],
+  exports: [SearchDiscoveryService],
+})
+export class SearchDiscoveryModule {}

--- a/xconfess-backend/src/search-discovery/search-discovery.service.spec.ts
+++ b/xconfess-backend/src/search-discovery/search-discovery.service.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SearchDiscoveryService } from './search-discovery.service';
+import { SavedSearch } from './entities/saved-search.entity';
+import { SearchHistory } from './entities/search-history.entity';
+
+describe('SearchDiscoveryService', () => {
+  let service: SearchDiscoveryService;
+  let savedSearchRepo: jest.Mocked<Repository<SavedSearch>>;
+  let searchHistoryRepo: jest.Mocked<Repository<SearchHistory>>;
+
+  beforeEach(async () => {
+    savedSearchRepo = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      delete: jest.fn(),
+    } as any;
+
+    searchHistoryRepo = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      count: jest.fn(),
+      find: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchDiscoveryService,
+        {
+          provide: getRepositoryToken(SavedSearch),
+          useValue: savedSearchRepo,
+        },
+        {
+          provide: getRepositoryToken(SearchHistory),
+          useValue: searchHistoryRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SearchDiscoveryService>(SearchDiscoveryService);
+  });
+
+  describe('savePreset', () => {
+    it('should save a new preset', async () => {
+      savedSearchRepo.findOne.mockResolvedValue(null);
+      savedSearchRepo.create.mockImplementation((x) => x as any);
+      savedSearchRepo.save.mockImplementation(async (x) => x as any);
+
+      const dto = { name: 'test', filters: { q: 'hello', gender: 'male' } };
+      const result = await service.savePreset(1, dto);
+
+      expect(result.name).toBe('test');
+      expect(result.filters).toEqual({ gender: 'male' }); // q is normalized out
+      expect(savedSearchRepo.create).toHaveBeenCalled();
+    });
+
+    it('should update existing preset', async () => {
+      const existing = { id: 'uuid', name: 'test', userId: 1, filters: {} };
+      savedSearchRepo.findOne.mockResolvedValue(existing as any);
+      savedSearchRepo.save.mockImplementation(async (x) => x as any);
+
+      const dto = { name: 'test', filters: { tags: ['tag1'] } };
+      const result = await service.savePreset(1, dto);
+
+      expect(result.filters).toEqual({ tags: ['tag1'] });
+      expect(savedSearchRepo.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recordSearch', () => {
+    it('should record a new search entry', async () => {
+      searchHistoryRepo.findOne.mockResolvedValue(null);
+      searchHistoryRepo.create.mockImplementation((x) => x as any);
+      searchHistoryRepo.save.mockResolvedValue({} as any);
+      searchHistoryRepo.count.mockResolvedValue(1);
+
+      await service.recordSearch(1, { q: 'find me' });
+
+      expect(searchHistoryRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: 'find me',
+          filters: {},
+        }),
+      );
+    });
+
+    it('should update usedAt for existing search entry', async () => {
+      const existing = { id: 'uuid', query: 'find me', queryHash: '...' };
+      searchHistoryRepo.findOne.mockResolvedValue(existing as any);
+      searchHistoryRepo.save.mockResolvedValue(existing as any);
+      searchHistoryRepo.count.mockResolvedValue(1);
+
+      await service.recordSearch(1, { q: 'find me' });
+
+      expect(searchHistoryRepo.save).toHaveBeenCalledWith(existing);
+      expect(searchHistoryRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('should prune history if it exceeds 20 entries', async () => {
+      searchHistoryRepo.findOne.mockResolvedValue(null);
+      searchHistoryRepo.create.mockImplementation((x) => x as any);
+      searchHistoryRepo.save.mockResolvedValue({} as any);
+      searchHistoryRepo.count.mockResolvedValue(25);
+      const oldest = [{ id: 'old1' }, { id: 'old2' }];
+      searchHistoryRepo.find.mockResolvedValue(oldest as any);
+
+      await service.recordSearch(1, { q: 'new search' });
+
+      expect(searchHistoryRepo.remove).toHaveBeenCalledWith(oldest);
+    });
+  });
+});

--- a/xconfess-backend/src/search-discovery/search-discovery.service.ts
+++ b/xconfess-backend/src/search-discovery/search-discovery.service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { SavedSearch } from './entities/saved-search.entity';
+import { SearchHistory } from './entities/search-history.entity';
+import { CreateSavedSearchDto } from './dto/create-saved-search.dto';
+import { SearchConfessionDto } from '../confession/dto/search-confession.dto';
+
+@Injectable()
+export class SearchDiscoveryService {
+  constructor(
+    @InjectRepository(SavedSearch)
+    private savedSearchRepo: Repository<SavedSearch>,
+    @InjectRepository(SearchHistory)
+    private searchHistoryRepo: Repository<SearchHistory>,
+  ) {}
+
+  private normalizeFilters(dto: SearchConfessionDto): any {
+    const { q, page, limit, ...filters } = dto;
+    // Remove undefined/null values
+    return Object.fromEntries(
+      Object.entries(filters).filter(([_, v]) => v != null),
+    );
+  }
+
+  private generateQueryHash(q: string, filters: any): string {
+    const data = JSON.stringify(
+      { q, ...filters },
+      Object.keys({ q, ...filters }).sort(),
+    );
+    return crypto.createHash('sha256').update(data).digest('hex');
+  }
+
+  async savePreset(userId: number, dto: CreateSavedSearchDto) {
+    const filters = this.normalizeFilters(dto.filters as SearchConfessionDto);
+    let preset = await this.savedSearchRepo.findOne({
+      where: { userId, name: dto.name },
+    });
+
+    if (preset) {
+      preset.filters = filters;
+      return this.savedSearchRepo.save(preset);
+    }
+
+    preset = this.savedSearchRepo.create({
+      userId,
+      name: dto.name,
+      filters,
+    });
+    return this.savedSearchRepo.save(preset);
+  }
+
+  async listPresets(userId: number) {
+    return this.savedSearchRepo.find({
+      where: { userId },
+      order: { updatedAt: 'DESC' },
+    });
+  }
+
+  async deletePreset(userId: number, id: string) {
+    return this.savedSearchRepo.delete({ id, userId });
+  }
+
+  async recordSearch(userId: number, dto: SearchConfessionDto) {
+    const q = dto.q?.trim() || '';
+    const filters = this.normalizeFilters(dto);
+    const queryHash = this.generateQueryHash(q, filters);
+
+    // Update if exists (upsert)
+    const existing = await this.searchHistoryRepo.findOne({
+      where: { userId, queryHash },
+    });
+
+    if (existing) {
+      // usedAt will be updated automatically by @UpdateDateColumn
+      await this.searchHistoryRepo.save(existing);
+    } else {
+      const history = this.searchHistoryRepo.create({
+        userId,
+        query: q,
+        filters,
+        queryHash,
+      });
+      await this.searchHistoryRepo.save(history);
+    }
+
+    // Bound history to 20 entries
+    const count = await this.searchHistoryRepo.count({ where: { userId } });
+    if (count > 20) {
+      const oldest = await this.searchHistoryRepo.find({
+        where: { userId },
+        order: { usedAt: 'ASC' },
+        take: count - 20,
+      });
+      if (oldest.length > 0) {
+        await this.searchHistoryRepo.remove(oldest);
+      }
+    }
+  }
+
+  async getRecentSearches(userId: number) {
+    return this.searchHistoryRepo.find({
+      where: { userId },
+      order: { usedAt: 'DESC' },
+      take: 20,
+    });
+  }
+}

--- a/xconfess-frontend/app/api/confessions/search/route.ts
+++ b/xconfess-frontend/app/api/confessions/search/route.ts
@@ -44,9 +44,15 @@ export async function GET(request: Request) {
   const searchUrl = `${BASE_API_URL}/confessions/search?${backendParams}`;
 
   try {
+    const authHeader = request.headers.get("Authorization");
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (authHeader) {
+      headers["Authorization"] = authHeader;
+    }
+
     const res = await fetch(searchUrl, {
       method: "GET",
-      headers: { "Content-Type": "application/json" },
+      headers,
       next: { revalidate: 15 },
     });
 


### PR DESCRIPTION
I have completed the implementation of Saved Searches and Recent Query History.

Key Changes:
Search Presets: Authenticated users can now save, list, and delete named search configurations via POST/GET/DELETE /api/confessions/search/discovery/presets.
Query History: The system now automatically tracks search history for authenticated users, keeping the last 20 unique searches for quick recall.
Frontend Integration: Updated the Next.js API route to forward authorization headers, ensuring persistence works seamlessly when searching from the frontend.
Filter Normalization: Stored searches only include core filters, ensuring they remain relevant even if pagination or display settings change.
Verification:
I've added and verified unit tests for the search discovery logic:

bash
PASS  src/search-discovery/search-discovery.service.spec.ts
  SearchDiscoveryService
    savePreset
      ✓ should save a new preset
      ✓ should update existing preset
    recordSearch
      ✓ should record a new search entry
      ✓ should update usedAt for existing search entry
      ✓ should prune history if it exceeds 20 entries


closes  #433 