### PR TITLE
feat(frontend): add live admin reports queue with optimistic resolution states

### DIFF
--- a/xconfess-backend/src/admin/realtime/admin.gateway.ts
+++ b/xconfess-backend/src/admin/realtime/admin.gateway.ts
@@ -69,4 +69,12 @@ export class AdminGateway implements OnGatewayConnection, OnGatewayDisconnect {
   emitNewReport(payload: any) {
     this.server.emit('new-report', payload);
   }
+
+  emitReportUpdated(payload: any) {
+    this.server.emit('report-updated', payload);
+  }
+
+  emitReportsBulkUpdated(payload: any) {
+    this.server.emit('reports-bulk-updated', payload);
+  }
 }

--- a/xconfess-backend/src/admin/realtime/reports.events.listener.ts
+++ b/xconfess-backend/src/admin/realtime/reports.events.listener.ts
@@ -10,4 +10,14 @@ export class ReportsEventsListener {
   handleReportCreated(payload: any) {
     this.adminGateway.emitNewReport(payload);
   }
+
+  @OnEvent('report.updated')
+  handleReportUpdated(payload: any) {
+    this.adminGateway.emitReportUpdated(payload);
+  }
+
+  @OnEvent('reports.bulk.updated')
+  handleReportsBulkUpdated(payload: any) {
+    this.adminGateway.emitReportsBulkUpdated(payload);
+  }
 }

--- a/xconfess-backend/src/admin/services/admin.service.ts
+++ b/xconfess-backend/src/admin/services/admin.service.ts
@@ -14,6 +14,7 @@ import { ModerationTemplateService } from '../../comment/moderation-template.ser
 import { AuditAction } from '../entities/audit-log.entity';
 import { Request } from 'express';
 import { decryptConfession } from '../../utils/confession-encryption';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UserAnonymousUser } from '../../user/entities/user-anonymous-link.entity';
 import { ConfigService } from '@nestjs/config';
 
@@ -46,6 +47,7 @@ export class AdminService {
     private readonly moderationService: ModerationService,
     private readonly moderationTemplateService: ModerationTemplateService,
     private readonly configService: ConfigService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   private get aesKey(): string {
@@ -158,6 +160,8 @@ export class AdminService {
       request,
     );
 
+    this.eventEmitter.emit('report.updated', saved);
+
     return saved;
   }
 
@@ -189,6 +193,8 @@ export class AdminService {
       notes,
       request,
     );
+
+    this.eventEmitter.emit('report.updated', saved);
 
     return saved;
   }
@@ -226,6 +232,8 @@ export class AdminService {
       notes,
       request,
     );
+
+    this.eventEmitter.emit('reports.bulk.updated', reports);
 
     return reports.length;
   }

--- a/xconfess-frontend/app/(dashboard)/admin/layout.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/layout.tsx
@@ -1,16 +1,16 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, useState } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
-import Link from 'next/link';
-import { io, Socket } from 'socket.io-client';
-import { useQueryClient } from '@tanstack/react-query';
-import { AUTH_TOKEN_KEY, USER_DATA_KEY } from '@/app/lib/api/constants';
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import Link from "next/link";
+import { io, Socket } from "socket.io-client";
+import { useQueryClient } from "@tanstack/react-query";
+import { AUTH_TOKEN_KEY, USER_DATA_KEY } from "@/app/lib/api/constants";
 
 function isMockAdminEnabled(): boolean {
-  if (process.env.NEXT_PUBLIC_ADMIN_MOCK === 'true') return true;
-  if (typeof window === 'undefined') return false;
-  return localStorage.getItem('adminMock') === 'true';
+  if (process.env.NEXT_PUBLIC_ADMIN_MOCK === "true") return true;
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem("adminMock") === "true";
 }
 
 export default function AdminLayout({
@@ -26,11 +26,11 @@ export default function AdminLayout({
 
   const navItems = useMemo(
     () => [
-      { href: '/admin/dashboard', label: 'Dashboard' },
-      { href: '/admin/reports', label: 'Reports' },
-      { href: '/admin/users', label: 'Users' },
-      { href: '/admin/notifications', label: 'Notifications' },
-      { href: '/admin/audit-logs', label: 'Audit Logs' },
+      { href: "/admin/dashboard", label: "Dashboard" },
+      { href: "/admin/reports", label: "Reports" },
+      { href: "/admin/users", label: "Users" },
+      { href: "/admin/notifications", label: "Notifications" },
+      { href: "/admin/audit-logs", label: "Audit Logs" },
     ],
     [],
   );
@@ -44,36 +44,39 @@ export default function AdminLayout({
         USER_DATA_KEY,
         JSON.stringify({
           id: 1,
-          username: 'demo-admin',
+          username: "demo-admin",
           isAdmin: true,
           is_active: true,
         }),
       );
-      localStorage.setItem(AUTH_TOKEN_KEY, 'mock');
+      localStorage.setItem(AUTH_TOKEN_KEY, "mock");
       return;
     }
 
     // Check if user is admin
     const userStr = localStorage.getItem(USER_DATA_KEY);
     if (!userStr) {
-      router.replace('/login');
+      router.replace("/login");
       return;
     }
 
     try {
       const user = JSON.parse(userStr);
       if (!user?.isAdmin) {
-        router.replace('/');
+        router.replace("/");
       }
     } catch {
-      router.replace('/login');
+      router.replace("/login");
     }
   }, [router]);
 
   useEffect(() => {
     // Real-time notifications for new reports (admins only)
     if (isMockAdminEnabled()) return;
-    const token = typeof window !== 'undefined' ? localStorage.getItem(AUTH_TOKEN_KEY) : null;
+    const token =
+      typeof window !== "undefined"
+        ? localStorage.getItem(AUTH_TOKEN_KEY)
+        : null;
     if (!token) return;
 
     const baseUrl = process.env.NEXT_PUBLIC_API_URL;
@@ -81,18 +84,58 @@ export default function AdminLayout({
 
     const socket: Socket = io(`${baseUrl}/admin`, {
       auth: { token },
-      transports: ['websocket'],
+      transports: ["websocket"],
     });
 
-    socket.on('connect', () => {
+    socket.on("connect", () => {
       // reset counter on connect
       setNewReportsCount(0);
     });
 
-    socket.on('new-report', () => {
+    socket.on("new-report", () => {
       setNewReportsCount((c) => c + 1);
       // refresh report list queries
-      queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+      queryClient.invalidateQueries({ queryKey: ["admin-reports"] });
+    });
+
+    socket.on("report-updated", (updatedReport: any) => {
+      // Reconcile optimistic state or just invalidate
+      queryClient.setQueriesData(
+        { queryKey: ["admin-reports"] },
+        (old: any) => {
+          if (!old?.reports) return old;
+          const newReports = old.reports.map((r: any) =>
+            r.id === updatedReport.id
+              ? {
+                  ...r,
+                  status: updatedReport.status,
+                  resolvedAt: updatedReport.resolvedAt,
+                }
+              : r,
+          );
+          return { ...old, reports: newReports };
+        },
+      );
+    });
+
+    socket.on("reports-bulk-updated", (updatedReports: any[]) => {
+      const updateMap = new Map(updatedReports.map((r) => [r.id, r]));
+      queryClient.setQueriesData(
+        { queryKey: ["admin-reports"] },
+        (old: any) => {
+          if (!old?.reports) return old;
+          const newReports = old.reports.map((r: any) =>
+            updateMap.has(r.id)
+              ? {
+                  ...r,
+                  status: updateMap.get(r.id).status,
+                  resolvedAt: updateMap.get(r.id).resolvedAt,
+                }
+              : r,
+          );
+          return { ...old, reports: newReports };
+        },
+      );
     });
 
     return () => {
@@ -114,7 +157,9 @@ export default function AdminLayout({
             <span className="text-xl leading-none">☰</span>
           </button>
           <div className="flex items-center gap-2">
-            <span className="font-semibold text-gray-900 dark:text-white">Admin</span>
+            <span className="font-semibold text-gray-900 dark:text-white">
+              Admin
+            </span>
             {isMockAdminEnabled() && (
               <span className="text-[10px] uppercase tracking-wide px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-200">
                 mock
@@ -168,26 +213,28 @@ export default function AdminLayout({
             <nav className="space-y-1">
               {navItems.map((item) => {
                 const active =
-                  pathname === item.href || (pathname?.startsWith(item.href + '/') ?? false);
+                  pathname === item.href ||
+                  (pathname?.startsWith(item.href + "/") ?? false);
                 return (
                   <Link
                     key={item.href}
                     href={item.href}
                     onClick={() => setMobileOpen(false)}
                     className={[
-                      'block rounded-md px-3 py-2 text-sm font-medium',
+                      "block rounded-md px-3 py-2 text-sm font-medium",
                       active
-                        ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-200'
-                        : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800',
-                    ].join(' ')}
+                        ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-200"
+                        : "text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800",
+                    ].join(" ")}
                   >
                     <span className="flex items-center justify-between">
                       <span>{item.label}</span>
-                      {item.href === '/admin/reports' && newReportsCount > 0 && (
-                        <span className="ml-3 text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200">
-                          {newReportsCount}
-                        </span>
-                      )}
+                      {item.href === "/admin/reports" &&
+                        newReportsCount > 0 && (
+                          <span className="ml-3 text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200">
+                            {newReportsCount}
+                          </span>
+                        )}
                     </span>
                   </Link>
                 );
@@ -228,21 +275,22 @@ export default function AdminLayout({
           <nav className="p-3 space-y-1">
             {navItems.map((item) => {
               const active =
-                pathname === item.href || (pathname?.startsWith(item.href + '/') ?? false);
+                pathname === item.href ||
+                (pathname?.startsWith(item.href + "/") ?? false);
               return (
                 <Link
                   key={item.href}
                   href={item.href}
                   className={[
-                    'block rounded-md px-3 py-2 text-sm font-medium',
+                    "block rounded-md px-3 py-2 text-sm font-medium",
                     active
-                      ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-200'
-                      : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800',
-                  ].join(' ')}
+                      ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-200"
+                      : "text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800",
+                  ].join(" ")}
                 >
                   <span className="flex items-center justify-between">
                     <span>{item.label}</span>
-                    {item.href === '/admin/reports' && newReportsCount > 0 && (
+                    {item.href === "/admin/reports" && newReportsCount > 0 && (
                       <span className="ml-3 text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200">
                         {newReportsCount}
                       </span>

--- a/xconfess-frontend/app/components/admin/ReportList.tsx
+++ b/xconfess-frontend/app/components/admin/ReportList.tsx
@@ -1,28 +1,35 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { adminApi, Report } from '@/app/lib/api/admin';
-import ReportDetail from './ReportDetail';
-import { exportToCSV } from '@/app/lib/utils/csvExport';
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi, Report } from "@/app/lib/api/admin";
+import ReportDetail from "./ReportDetail";
+import { exportToCSV } from "@/app/lib/utils/csvExport";
 
 export default function ReportList() {
   const [selectedReport, setSelectedReport] = useState<string | null>(null);
-  const [statusFilter, setStatusFilter] = useState<string>('all');
-  const [typeFilter, setTypeFilter] = useState<string>('all');
-  const [startDate, setStartDate] = useState<string>('');
-  const [endDate, setEndDate] = useState<string>('');
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [startDate, setStartDate] = useState<string>("");
+  const [endDate, setEndDate] = useState<string>("");
   const [page, setPage] = useState(1);
   const limit = 20;
 
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery({
-    queryKey: ['admin-reports', statusFilter, typeFilter, startDate, endDate, page],
+    queryKey: [
+      "admin-reports",
+      statusFilter,
+      typeFilter,
+      startDate,
+      endDate,
+      page,
+    ],
     queryFn: () =>
       adminApi.getReports({
-        status: statusFilter !== 'all' ? statusFilter : undefined,
-        type: typeFilter !== 'all' ? typeFilter : undefined,
+        status: statusFilter !== "all" ? statusFilter : undefined,
+        type: typeFilter !== "all" ? typeFilter : undefined,
         startDate: startDate ? new Date(startDate).toISOString() : undefined,
         endDate: endDate ? new Date(endDate).toISOString() : undefined,
         limit,
@@ -33,8 +40,33 @@ export default function ReportList() {
   const resolveMutation = useMutation({
     mutationFn: ({ id, notes }: { id: string; notes?: string }) =>
       adminApi.resolveReport(id, notes),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey: ["admin-reports"] });
+      const previousData = queryClient.getQueryData(["admin-reports"]);
+      queryClient.setQueriesData(
+        { queryKey: ["admin-reports"] },
+        (old: any) => {
+          if (!old?.reports) return old;
+          return {
+            ...old,
+            reports: old.reports.map((r: Report) =>
+              r.id === id ? { ...r, status: "resolved" } : r,
+            ),
+          };
+        },
+      );
+      return { previousData };
+    },
+    onError: (err, newReport, context) => {
+      if (context?.previousData) {
+        queryClient.setQueriesData(
+          { queryKey: ["admin-reports"] },
+          context.previousData,
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-reports"] });
       setSelectedReport(null);
     },
   });
@@ -42,8 +74,33 @@ export default function ReportList() {
   const dismissMutation = useMutation({
     mutationFn: ({ id, notes }: { id: string; notes?: string }) =>
       adminApi.dismissReport(id, notes),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey: ["admin-reports"] });
+      const previousData = queryClient.getQueryData(["admin-reports"]);
+      queryClient.setQueriesData(
+        { queryKey: ["admin-reports"] },
+        (old: any) => {
+          if (!old?.reports) return old;
+          return {
+            ...old,
+            reports: old.reports.map((r: Report) =>
+              r.id === id ? { ...r, status: "dismissed" } : r,
+            ),
+          };
+        },
+      );
+      return { previousData };
+    },
+    onError: (err, newReport, context) => {
+      if (context?.previousData) {
+        queryClient.setQueriesData(
+          { queryKey: ["admin-reports"] },
+          context.previousData,
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-reports"] });
       setSelectedReport(null);
     },
   });
@@ -51,8 +108,33 @@ export default function ReportList() {
   const bulkResolveMutation = useMutation({
     mutationFn: ({ ids, notes }: { ids: string[]; notes?: string }) =>
       adminApi.bulkResolveReports(ids, notes),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+    onMutate: async ({ ids }) => {
+      await queryClient.cancelQueries({ queryKey: ["admin-reports"] });
+      const previousData = queryClient.getQueryData(["admin-reports"]);
+      queryClient.setQueriesData(
+        { queryKey: ["admin-reports"] },
+        (old: any) => {
+          if (!old?.reports) return old;
+          return {
+            ...old,
+            reports: old.reports.map((r: Report) =>
+              ids.includes(r.id) ? { ...r, status: "resolved" } : r,
+            ),
+          };
+        },
+      );
+      return { previousData };
+    },
+    onError: (err, variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueriesData(
+          { queryKey: ["admin-reports"] },
+          context.previousData,
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-reports"] });
     },
   });
 
@@ -77,7 +159,9 @@ export default function ReportList() {
   };
 
   if (isLoading) {
-    return <div className="text-center py-8 text-gray-500">Loading reports...</div>;
+    return (
+      <div className="text-center py-8 text-gray-500">Loading reports...</div>
+    );
   }
 
   const reports = data?.reports || [];
@@ -91,8 +175,12 @@ export default function ReportList() {
         <ReportDetail
           report={report}
           onBack={() => setSelectedReport(null)}
-          onResolve={(notes) => resolveMutation.mutate({ id: report.id, notes })}
-          onDismiss={(notes) => dismissMutation.mutate({ id: report.id, notes })}
+          onResolve={(notes) =>
+            resolveMutation.mutate({ id: report.id, notes })
+          }
+          onDismiss={(notes) =>
+            dismissMutation.mutate({ id: report.id, notes })
+          }
         />
       );
     }
@@ -138,7 +226,9 @@ export default function ReportList() {
               <option value="spam">Spam</option>
               <option value="harassment">Harassment</option>
               <option value="hate_speech">Hate Speech</option>
-              <option value="inappropriate_content">Inappropriate Content</option>
+              <option value="inappropriate_content">
+                Inappropriate Content
+              </option>
               <option value="copyright">Copyright</option>
               <option value="other">Other</option>
             </select>
@@ -178,12 +268,17 @@ export default function ReportList() {
                   id: r.id,
                   type: r.type,
                   status: r.status,
-                  reporter: r.reporter?.username || 'Anonymous',
-                  reason: r.reason || '',
+                  reporter: r.reporter?.username || "Anonymous",
+                  reason: r.reason || "",
                   createdAt: new Date(r.createdAt).toLocaleString(),
-                  resolvedAt: r.resolvedAt ? new Date(r.resolvedAt).toLocaleString() : '',
+                  resolvedAt: r.resolvedAt
+                    ? new Date(r.resolvedAt).toLocaleString()
+                    : "",
                 }));
-                exportToCSV(exportData, `reports-${new Date().toISOString().split('T')[0]}.csv`);
+                exportToCSV(
+                  exportData,
+                  `reports-${new Date().toISOString().split("T")[0]}.csv`,
+                );
               }}
               className="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 text-sm"
             >
@@ -238,7 +333,10 @@ export default function ReportList() {
           </thead>
           <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             {reports.map((report: Report) => (
-              <tr key={report.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+              <tr
+                key={report.id}
+                className="hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
                 <td className="px-6 py-4 whitespace-nowrap">
                   <input
                     type="checkbox"
@@ -253,18 +351,18 @@ export default function ReportList() {
                 <td className="px-6 py-4 whitespace-nowrap">
                   <span
                     className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                      report.status === 'pending'
-                        ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100'
-                        : report.status === 'resolved'
-                        ? 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100'
-                        : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200'
+                      report.status === "pending"
+                        ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100"
+                        : report.status === "resolved"
+                          ? "bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100"
+                          : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200"
                     }`}
                   >
                     {report.status}
                   </span>
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                  {report.reporter?.username || 'Anonymous'}
+                  {report.reporter?.username || "Anonymous"}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                   {new Date(report.createdAt).toLocaleDateString()}
@@ -287,7 +385,8 @@ export default function ReportList() {
       {totalPages > 1 && (
         <div className="flex items-center justify-between">
           <div className="text-sm text-gray-700 dark:text-gray-300">
-            Showing {(page - 1) * limit + 1} to {Math.min(page * limit, total)} of {total} results
+            Showing {(page - 1) * limit + 1} to {Math.min(page * limit, total)}{" "}
+            of {total} results
           </div>
           <div className="flex gap-2">
             <button


### PR DESCRIPTION
## Description
This PR resolves #460 by introducing a real-time admin reports queue with optimistic resolution states to the frontend and backend.

### Changes Made:
- **Backend**: 
  - Updated `AdminGateway` to broadcast `report-updated` and `reports-bulk-updated` WebSocket events.
  - Added `ReportsEventsListener` to forward events seamlessly from the application event bus.
  - Injected `EventEmitter2` into `AdminService`'s resolution methods to trigger these broadcasts.
- **Frontend**:
  - Implemented React Query `onMutate`, `onError`, and `onSettled` in `ReportList.tsx` for immediate optimistic UI updates during resolution, dismissal, or bulk processing.
  - Added WebSocket event listeners in `admin/layout.tsx` to automatically keep the local cache synchronized with the live server state without manual polling.

### Motivation:
Admins needed immediate feedback when resolving reports and live synchronization across multiple concurrent sessions to prevent duplicate mitigation efforts. This enhances the UX by masking latency while preserving strict data accuracy.
