### PR TITLE
feat(frontend): surface wallet network mismatch and signer readiness warnings

### DIFF
--- a/xconfess-frontend/app/components/confession/AnchorButton.tsx
+++ b/xconfess-frontend/app/components/confession/AnchorButton.tsx
@@ -29,8 +29,15 @@ export const AnchorButton: React.FC<AnchorButtonProps> = ({
   onAnchorSuccess,
   className,
 }) => {
-  const { isAvailable, isConnected, connect, anchor, isLoading } =
-    useStellarWallet();
+  const {
+    isAvailable,
+    isConnected,
+    isReady,
+    readinessError,
+    connect,
+    anchor,
+    isLoading,
+  } = useStellarWallet();
   const [isAnchoring, setIsAnchoring] = useState(false);
   const [txHash, setTxHash] = useState<string | null>(stellarTxHash);
   const [error, setError] = useState<string | null>(null);
@@ -64,20 +71,23 @@ export const AnchorButton: React.FC<AnchorButtonProps> = ({
 
       if (result.success && result.txHash) {
         // Call backend to store the anchor data
-        const response = await fetch(`/api/confessions/${confessionId}/anchor`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
+        const response = await fetch(
+          `/api/confessions/${confessionId}/anchor`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              stellarTxHash: result.txHash,
+            }),
           },
-          body: JSON.stringify({
-            stellarTxHash: result.txHash,
-          }),
-        });
+        );
 
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}));
           throw new Error(
-            errorData.message || "Failed to save anchor data to server"
+            errorData.message || "Failed to save anchor data to server",
           );
         }
 
@@ -119,7 +129,10 @@ export const AnchorButton: React.FC<AnchorButtonProps> = ({
   if (!isAvailable) {
     return (
       <div
-        className={cn("flex items-center gap-1 text-xs text-zinc-500", className)}
+        className={cn(
+          "flex items-center gap-1 text-xs text-zinc-500",
+          className,
+        )}
         title="Install Freighter wallet to anchor confessions"
       >
         <Anchor className="h-3 w-3" />
@@ -134,9 +147,13 @@ export const AnchorButton: React.FC<AnchorButtonProps> = ({
         variant="outline"
         size="sm"
         onClick={handleAnchor}
-        disabled={isAnchoring || isLoading}
+        disabled={isAnchoring || isLoading || (isConnected && !isReady)}
         className="h-7 px-2 text-xs"
-        title="Anchor this confession on Stellar blockchain"
+        title={
+          isConnected && !isReady
+            ? readinessError || "Wallet not ready"
+            : "Anchor this confession on Stellar blockchain"
+        }
       >
         {isAnchoring || isLoading ? (
           <>
@@ -155,6 +172,17 @@ export const AnchorButton: React.FC<AnchorButtonProps> = ({
           <AlertCircle className="h-3 w-3" />
           <span className="truncate max-w-[150px]" title={error}>
             {error}
+          </span>
+        </div>
+      )}
+      {isConnected && !isReady && !error && (
+        <div className="flex items-center gap-1 text-xs text-orange-400 mt-1">
+          <AlertCircle className="h-3 w-3" />
+          <span
+            className="truncate max-w-[200px]"
+            title={readinessError || "Wallet not ready"}
+          >
+            {readinessError}
           </span>
         </div>
       )}

--- a/xconfess-frontend/app/components/confession/TipButton.tsx
+++ b/xconfess-frontend/app/components/confession/TipButton.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { sendTip, verifyTip, getTipStats, type TipStats } from "@/lib/services/tipping.service";
+import {
+  sendTip,
+  verifyTip,
+  getTipStats,
+  type TipStats,
+} from "@/lib/services/tipping.service";
 import { useWallet } from "@/lib/hooks/useWallet";
 
 interface TipButtonProps {
@@ -22,7 +27,8 @@ export const TipButton = ({
   const [success, setSuccess] = useState(false);
   const [pendingTxHash, setPendingTxHash] = useState<string | null>(null);
   const [stats, setStats] = useState<TipStats | null>(initialStats || null);
-  const { publicKey, isConnected, connect } = useWallet();
+  const { publicKey, isConnected, isReady, readinessError, connect } =
+    useWallet();
 
   // Fetch stats on mount and when confession changes
   useEffect(() => {
@@ -60,7 +66,7 @@ export const TipButton = ({
       if (!verifyResult.success) {
         throw new Error(
           verifyResult.error ||
-            "Verification is still pending. Please retry in a moment."
+            "Verification is still pending. Please retry in a moment.",
         );
       }
       setPendingTxHash(null);
@@ -76,7 +82,9 @@ export const TipButton = ({
 
   const handleTip = async () => {
     if (!recipientAddress) {
-      setError("Recipient address not available. The confession creator needs to provide their Stellar address.");
+      setError(
+        "Recipient address not available. The confession creator needs to provide their Stellar address.",
+      );
       return;
     }
 
@@ -115,7 +123,7 @@ export const TipButton = ({
         setPendingTxHash(result.txHash);
         throw new Error(
           verifyResult.error ||
-            "Tip was sent on-chain, but verification is pending. Retry verification without resending."
+            "Tip was sent on-chain, but verification is pending. Retry verification without resending.",
         );
       }
 
@@ -145,7 +153,11 @@ export const TipButton = ({
         disabled={!recipientAddress}
         className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all min-w-[44px] min-h-[44px] justify-center touch-manipulation"
         aria-label="Tip confession"
-        title={!recipientAddress ? "Recipient address not available" : "Tip this confession"}
+        title={
+          !recipientAddress
+            ? "Recipient address not available"
+            : "Tip this confession"
+        }
       >
         <span className="text-lg">💰</span>
         {tipCount > 0 && (
@@ -173,7 +185,9 @@ export const TipButton = ({
 
           {!isConnected && (
             <div className="mb-4 p-3 bg-yellow-900/30 border border-yellow-700 rounded text-sm text-yellow-200">
-              <p className="mb-2">Please connect your Freighter wallet to send tips.</p>
+              <p className="mb-2">
+                Please connect your Freighter wallet to send tips.
+              </p>
               <button
                 type="button"
                 onClick={handleConnectWallet}
@@ -183,9 +197,10 @@ export const TipButton = ({
               </button>
             </div>
           )}
-          {isConnected && !publicKey && (
+          {isConnected && !isReady && (
             <div className="mb-4 p-3 bg-amber-900/30 border border-amber-700 rounded text-sm text-amber-100">
-              Wallet signer is unavailable. Unlock Freighter and try again.
+              {readinessError ||
+                "Wallet is not ready. Please check connection and network."}
             </div>
           )}
 
@@ -203,9 +218,7 @@ export const TipButton = ({
                 className="w-full px-3 py-2 bg-zinc-900 border border-zinc-700 rounded text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
                 placeholder="0.1"
               />
-              <p className="text-xs text-gray-400 mt-1">
-                Minimum: 0.1 XLM
-              </p>
+              <p className="text-xs text-gray-400 mt-1">Minimum: 0.1 XLM</p>
             </div>
 
             {error && (
@@ -235,14 +248,19 @@ export const TipButton = ({
 
             <button
               onClick={handleTip}
-              disabled={isSending || !isConnected || !publicKey || !!pendingTxHash}
+              disabled={
+                isSending ||
+                (isConnected && !isReady) ||
+                !publicKey ||
+                !!pendingTxHash
+              }
               className="w-full px-4 py-2 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 disabled:opacity-50 disabled:cursor-not-allowed rounded font-medium text-white transition-all"
             >
               {isSending
                 ? "Sending..."
                 : pendingTxHash
-                ? "Verification pending"
-                : `Send ${tipAmount} XLM Tip`}
+                  ? "Verification pending"
+                  : `Send ${tipAmount} XLM Tip`}
             </button>
 
             {stats && (

--- a/xconfess-frontend/app/lib/hooks/useStellarWallet.ts
+++ b/xconfess-frontend/app/lib/hooks/useStellarWallet.ts
@@ -12,8 +12,11 @@ export interface StellarWalletState {
   isAvailable: boolean;
   isConnected: boolean;
   publicKey: string | null;
+  network: string | null;
   isLoading: boolean;
   error: string | null;
+  isReady: boolean;
+  readinessError: string | null;
 }
 
 export function useStellarWallet() {
@@ -21,9 +24,48 @@ export function useStellarWallet() {
     isAvailable: false,
     isConnected: false,
     publicKey: null,
+    network: null,
     isLoading: true,
     error: null,
+    isReady: false,
+    readinessError: null,
   });
+
+  const updateReadiness = (
+    currentState: Partial<StellarWalletState>,
+  ): Partial<StellarWalletState> => {
+    if (!currentState.isConnected) {
+      return { isReady: false, readinessError: null };
+    }
+
+    const expected = process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet";
+    const actual = (currentState.network || "").toUpperCase();
+
+    let isNetworkMatch = false;
+    if (expected === "mainnet") {
+      isNetworkMatch = ["PUBLIC", "PUBLIC_NETWORK", "MAINNET"].includes(actual);
+    } else {
+      isNetworkMatch = ["TESTNET", "TESTNET_SOROBAN"].includes(actual);
+    }
+
+    if (!isNetworkMatch) {
+      const displayExpected = expected === "mainnet" ? "Mainnet" : "Testnet";
+      return {
+        isReady: false,
+        readinessError: `Wallet on wrong network. Please switch to ${displayExpected}.`,
+      };
+    }
+
+    if (!currentState.publicKey) {
+      return {
+        isReady: false,
+        readinessError:
+          "Wallet signer is unavailable. Unlock Freighter and try again.",
+      };
+    }
+
+    return { isReady: true, readinessError: null };
+  };
 
   useEffect(() => {
     const checkWallet = async () => {
@@ -47,7 +89,8 @@ export function useStellarWallet() {
         setState((prev) => ({
           ...prev,
           isLoading: false,
-          error: "Freighter wallet not found. Please install Freighter extension.",
+          error:
+            "Freighter wallet not found. Please install Freighter extension.",
         }));
         return;
       }
@@ -62,13 +105,26 @@ export function useStellarWallet() {
         return;
       }
 
-      setState((prev) => ({
-        ...prev,
-        isConnected: true,
-        publicKey,
-        isLoading: false,
-        error: null,
-      }));
+      let networkStr = "TESTNET_SOROBAN";
+      if (
+        (window as any).freighter &&
+        typeof (window as any).freighter.getNetwork === "function"
+      ) {
+        networkStr = await (window as any).freighter.getNetwork();
+      }
+
+      setState((prev) => {
+        const nextState = {
+          ...prev,
+          isConnected: true,
+          publicKey,
+          network: networkStr,
+          isLoading: false,
+          error: null,
+        };
+        const readiness = updateReadiness(nextState);
+        return { ...nextState, ...readiness } as StellarWalletState;
+      });
     } catch (error: any) {
       setState((prev) => ({
         ...prev,
@@ -79,7 +135,9 @@ export function useStellarWallet() {
   }, []);
 
   const anchor = useCallback(
-    async (content: string): Promise<{ success: boolean; txHash?: string; error?: string }> => {
+    async (
+      content: string,
+    ): Promise<{ success: boolean; txHash?: string; error?: string }> => {
       if (!state.isConnected || !state.publicKey) {
         setState((prev) => ({
           ...prev,
@@ -88,6 +146,18 @@ export function useStellarWallet() {
         return {
           success: false,
           error: "Wallet not connected",
+        };
+      }
+
+      if (!state.isReady) {
+        const err = state.readinessError || "Wallet not ready";
+        setState((prev) => ({
+          ...prev,
+          error: err,
+        }));
+        return {
+          success: false,
+          error: err,
         };
       }
 
@@ -119,7 +189,7 @@ export function useStellarWallet() {
         };
       }
     },
-    [state.isConnected, state.publicKey]
+    [state.isConnected, state.publicKey, state.isReady, state.readinessError],
   );
 
   return {

--- a/xconfess-frontend/components/wallet/WalletButton.tsx
+++ b/xconfess-frontend/components/wallet/WalletButton.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import { useContext, useState } from 'react';
-import { WalletContext } from '@/lib/providers/WalletProvider';
+import { useContext, useState } from "react";
+import { WalletContext } from "@/lib/providers/WalletProvider";
 
 interface WalletButtonProps {
   className?: string;
@@ -18,29 +18,29 @@ const truncateAddress = (address: string, chars = 6): string => {
  * Get network display name and color
  */
 const getNetworkInfo = (
-  network: string
+  network: string,
 ): { name: string; color: string; bgColor: string } => {
   switch (network.toUpperCase()) {
-    case 'TESTNET_SOROBAN':
-    case 'TESTNET':
+    case "TESTNET_SOROBAN":
+    case "TESTNET":
       return {
-        name: 'Testnet',
-        color: '#FF6B6B',
-        bgColor: 'rgba(255, 107, 107, 0.1)',
+        name: "Testnet",
+        color: "#FF6B6B",
+        bgColor: "rgba(255, 107, 107, 0.1)",
       };
-    case 'PUBLIC_NETWORK':
-    case 'MAINNET':
-    case 'PUBLIC':
+    case "PUBLIC_NETWORK":
+    case "MAINNET":
+    case "PUBLIC":
       return {
-        name: 'Mainnet',
-        color: '#51CF66',
-        bgColor: 'rgba(81, 207, 102, 0.1)',
+        name: "Mainnet",
+        color: "#51CF66",
+        bgColor: "rgba(81, 207, 102, 0.1)",
       };
     default:
       return {
         name: network,
-        color: '#748FFC',
-        bgColor: 'rgba(116, 143, 252, 0.1)',
+        color: "#748FFC",
+        bgColor: "rgba(116, 143, 252, 0.1)",
       };
   }
 };
@@ -49,7 +49,9 @@ const getNetworkInfo = (
  * Wallet Button Component
  * Displays wallet connection status and allows connect/disconnect
  */
-export const WalletButton: React.FC<WalletButtonProps> = ({ className = '' }) => {
+export const WalletButton: React.FC<WalletButtonProps> = ({
+  className = "",
+}) => {
   const wallet = useContext(WalletContext);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -57,14 +59,24 @@ export const WalletButton: React.FC<WalletButtonProps> = ({ className = '' }) =>
     return null;
   }
 
-  const { publicKey, network, isConnected, isLoading, error, connect, disconnect } = wallet;
+  const {
+    publicKey,
+    network,
+    isConnected,
+    isLoading,
+    error,
+    isReady,
+    readinessError,
+    connect,
+    disconnect,
+  } = wallet;
   const networkInfo = getNetworkInfo(network);
 
   const handleConnect = async () => {
     try {
       await connect();
     } catch (err) {
-      console.error('Failed to connect wallet:', err);
+      console.error("Failed to connect wallet:", err);
     }
   };
 
@@ -77,7 +89,7 @@ export const WalletButton: React.FC<WalletButtonProps> = ({ className = '' }) =>
     if (publicKey) {
       navigator.clipboard.writeText(publicKey);
       // Optional: Show toast notification
-      console.log('Public key copied to clipboard');
+      console.log("Public key copied to clipboard");
     }
   };
 
@@ -103,10 +115,34 @@ export const WalletButton: React.FC<WalletButtonProps> = ({ className = '' }) =>
           className="px-4 py-2 rounded-lg bg-red-100 text-red-700 hover:bg-red-200 transition font-medium text-sm border border-red-300"
           title={error}
         >
-          ⚠️ {error.includes('not installed') ? 'Install Wallet' : 'Connect Wallet'}
+          ⚠️{" "}
+          {error.includes("not installed")
+            ? "Install Wallet"
+            : "Connect Wallet"}
         </button>
         <div className="absolute hidden group-hover:block bg-red-900 text-white text-xs rounded py-1 px-2 whitespace-nowrap z-50 bottom-full mb-2">
           {error}
+        </div>
+      </div>
+    );
+  }
+
+  // Connected but not ready state (e.g. wrong network or no signer)
+  if (isConnected && !isReady) {
+    return (
+      <div className={`relative group ${className}`}>
+        <button
+          onClick={handleDisconnect}
+          className="px-4 py-2 rounded-lg bg-orange-100 text-orange-800 hover:bg-orange-200 transition font-medium text-sm border border-orange-300 flex items-center gap-2"
+          title={readinessError || "Action Required"}
+        >
+          ⚠️{" "}
+          {readinessError?.includes("network")
+            ? "Network Mismatch"
+            : "Action Required"}
+        </button>
+        <div className="absolute hidden group-hover:block bg-orange-900 text-white text-xs rounded py-1 px-2 whitespace-nowrap z-50 bottom-full mb-2">
+          {readinessError} (Click to disconnect)
         </div>
       </div>
     );
@@ -126,12 +162,17 @@ export const WalletButton: React.FC<WalletButtonProps> = ({ className = '' }) =>
           <span className="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
           {truncateAddress(publicKey)}
           <svg
-            className={`w-4 h-4 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
+            className={`w-4 h-4 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 14l-7 7m0 0l-7-7m7 7V3"
+            />
           </svg>
         </button>
 
@@ -144,19 +185,29 @@ export const WalletButton: React.FC<WalletButtonProps> = ({ className = '' }) =>
           >
             {/* Network Info */}
             <div className="p-4 border-b border-gray-200">
-              <div className="text-xs text-gray-500 font-semibold mb-2">NETWORK</div>
+              <div className="text-xs text-gray-500 font-semibold mb-2">
+                NETWORK
+              </div>
               <div
                 className="px-3 py-2 rounded-lg flex items-center gap-2 text-sm font-medium"
-                style={{ backgroundColor: networkInfo.bgColor, color: networkInfo.color }}
+                style={{
+                  backgroundColor: networkInfo.bgColor,
+                  color: networkInfo.color,
+                }}
               >
-                <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: networkInfo.color }}></span>
+                <span
+                  className="inline-block w-2 h-2 rounded-full"
+                  style={{ backgroundColor: networkInfo.color }}
+                ></span>
                 {networkInfo.name}
               </div>
             </div>
 
             {/* Public Key Section */}
             <div className="p-4 border-b border-gray-200">
-              <div className="text-xs text-gray-500 font-semibold mb-2">PUBLIC KEY</div>
+              <div className="text-xs text-gray-500 font-semibold mb-2">
+                PUBLIC KEY
+              </div>
               <div className="flex items-center gap-2">
                 <code className="flex-1 text-xs bg-gray-100 p-2 rounded font-mono text-gray-700 break-all">
                   {publicKey}

--- a/xconfess-frontend/lib/hooks/useWallet.ts
+++ b/xconfess-frontend/lib/hooks/useWallet.ts
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { usePathname, useSearchParams } from 'next/navigation';
-import * as WalletService from '../services/wallet.service';
+import { useState, useCallback, useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import * as WalletService from "../services/wallet.service";
 
 export interface WalletState {
   publicKey: string | null;
-  network: 'TESTNET_SOROBAN' | 'PUBLIC_NETWORK' | string;
+  network: "TESTNET_SOROBAN" | "PUBLIC_NETWORK" | string;
   isConnected: boolean;
   isLoading: boolean;
   error: string | null;
@@ -14,6 +14,8 @@ export interface WalletState {
 }
 
 export interface UseWalletReturn extends WalletState {
+  isReady: boolean;
+  readinessError: string | null;
   connect: () => Promise<void>;
   disconnect: () => void;
   signTransaction: (xdr: string) => Promise<string>;
@@ -22,8 +24,8 @@ export interface UseWalletReturn extends WalletState {
   clearError: () => void;
 }
 
-const WALLET_STORAGE_KEY = 'xconfess_wallet_session';
-const NETWORK_STORAGE_KEY = 'xconfess_network';
+const WALLET_STORAGE_KEY = "xconfess_wallet_session";
+const NETWORK_STORAGE_KEY = "xconfess_network";
 
 /**
  * Custom hook for managing wallet connection and state
@@ -32,7 +34,7 @@ const NETWORK_STORAGE_KEY = 'xconfess_network';
 export const useWallet = (): UseWalletReturn => {
   const [state, setState] = useState<WalletState>({
     publicKey: null,
-    network: 'TESTNET_SOROBAN',
+    network: "TESTNET_SOROBAN",
     isConnected: false,
     isLoading: false,
     error: null,
@@ -45,7 +47,10 @@ export const useWallet = (): UseWalletReturn => {
    * Store session in localStorage
    */
   const storeSession = useCallback((publicKey: string, network: string) => {
-    localStorage.setItem(WALLET_STORAGE_KEY, JSON.stringify({ publicKey, network }));
+    localStorage.setItem(
+      WALLET_STORAGE_KEY,
+      JSON.stringify({ publicKey, network }),
+    );
     localStorage.setItem(NETWORK_STORAGE_KEY, network);
   }, []);
 
@@ -59,7 +64,10 @@ export const useWallet = (): UseWalletReturn => {
   /**
    * Get stored session from localStorage
    */
-  const getStoredSession = useCallback((): { publicKey: string; network: string } | null => {
+  const getStoredSession = useCallback((): {
+    publicKey: string;
+    network: string;
+  } | null => {
     try {
       const stored = localStorage.getItem(WALLET_STORAGE_KEY);
       return stored ? JSON.parse(stored) : null;
@@ -93,7 +101,7 @@ export const useWallet = (): UseWalletReturn => {
             ...prev,
             publicKey: null,
             isConnected: false,
-            error: 'Wallet disconnected. Please reconnect.',
+            error: "Wallet disconnected. Please reconnect.",
           }));
           clearSession();
         } else if (walletInfo.publicKey !== state.publicKey) {
@@ -125,7 +133,7 @@ export const useWallet = (): UseWalletReturn => {
         setState((prev) => ({
           ...prev,
           isLoading: false,
-          error: 'Freighter wallet is not installed',
+          error: "Freighter wallet is not installed",
         }));
         return;
       }
@@ -156,7 +164,7 @@ export const useWallet = (): UseWalletReturn => {
             network: stored.network,
             isConnected: false,
             isLoading: false,
-            error: 'Wallet disconnected. Please reconnect.',
+            error: "Wallet disconnected. Please reconnect.",
           }));
         } else {
           setState((prev) => ({
@@ -168,7 +176,7 @@ export const useWallet = (): UseWalletReturn => {
       }
     } catch (error) {
       const errorMessage =
-        error instanceof Error ? error.message : 'Failed to initialize wallet';
+        error instanceof Error ? error.message : "Failed to initialize wallet";
       setState((prev) => ({
         ...prev,
         isLoading: false,
@@ -198,7 +206,7 @@ export const useWallet = (): UseWalletReturn => {
       storeSession(walletInfo.publicKey, walletInfo.network);
     } catch (error) {
       const errorMessage =
-        error instanceof Error ? error.message : 'Failed to connect wallet';
+        error instanceof Error ? error.message : "Failed to connect wallet";
       setState((prev) => ({
         ...prev,
         isLoading: false,
@@ -226,7 +234,7 @@ export const useWallet = (): UseWalletReturn => {
       clearSession();
     } catch (error) {
       const errorMessage =
-        error instanceof Error ? error.message : 'Failed to disconnect wallet';
+        error instanceof Error ? error.message : "Failed to disconnect wallet";
       setState((prev) => ({
         ...prev,
         error: errorMessage,
@@ -248,7 +256,7 @@ export const useWallet = (): UseWalletReturn => {
       return signedXDR;
     } catch (error) {
       const errorMessage =
-        error instanceof Error ? error.message : 'Failed to sign transaction';
+        error instanceof Error ? error.message : "Failed to sign transaction";
       setState((prev) => ({
         ...prev,
         isLoading: false,
@@ -282,7 +290,9 @@ export const useWallet = (): UseWalletReturn => {
       }
     } catch (error) {
       const errorMessage =
-        error instanceof Error ? error.message : 'Failed to check wallet connection';
+        error instanceof Error
+          ? error.message
+          : "Failed to check wallet connection";
       setState((prev) => ({
         ...prev,
         error: errorMessage,
@@ -311,8 +321,47 @@ export const useWallet = (): UseWalletReturn => {
     }));
   }, []);
 
+  /**
+   * Compute wallet readiness state continuously based on current app configuration
+   */
+  const getReadinessState = () => {
+    if (!state.isConnected) return { isReady: false, readinessError: null };
+
+    const expected = process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet";
+    const actual = (state.network || "").toUpperCase();
+
+    let isNetworkMatch = false;
+    if (expected === "mainnet") {
+      isNetworkMatch = ["PUBLIC", "PUBLIC_NETWORK", "MAINNET"].includes(actual);
+    } else {
+      isNetworkMatch = ["TESTNET", "TESTNET_SOROBAN"].includes(actual);
+    }
+
+    if (!isNetworkMatch) {
+      const displayExpected = expected === "mainnet" ? "Mainnet" : "Testnet";
+      return {
+        isReady: false,
+        readinessError: `Wallet on wrong network. Please switch to ${displayExpected}.`,
+      };
+    }
+
+    if (!state.publicKey) {
+      return {
+        isReady: false,
+        readinessError:
+          "Wallet signer is unavailable. Unlock Freighter and try again.",
+      };
+    }
+
+    return { isReady: true, readinessError: null };
+  };
+
+  const { isReady, readinessError } = getReadinessState();
+
   return {
     ...state,
+    isReady,
+    readinessError,
     connect,
     disconnect,
     signTransaction,


### PR DESCRIPTION
## Description
This PR resolves #443 by surfacing preemptive wallet health/readiness warnings for actions requiring a connected Freighter signer on the correct network.

### Changes Made:
- **Global Wallet State**:
  - Updated `useWallet.ts` and `useStellarWallet.ts` to compute a unified `isReady` boolean and `readinessError` string.
  - Continuously validates that the injected Freighter `network` matches `NEXT_PUBLIC_STELLAR_NETWORK`.
- **UI Components**:
  - Modified `WalletButton.tsx` to dynamically display an amber alert dropdown indicating network mismatches or unavailable signer states.
  - Updated `AnchorButton.tsx` and `TipButton.tsx` to preemptively disable actions (Anchor / Send Tip) and present actionable error messages *before* the transaction requests fail.

### Motivation:
Wallet failures previously appeared as generic transaction errors when the root cause was a mismatched network or an active but locked extension. Checking readiness explicitly improves UX by guiding users directly to the proper corrective action.
