### PR TITLE
feat(backend): wire moderation webhook to admin notifications and rev…

### DIFF
--- a/xconfess-backend/src/moderation/moderation-events.listener.spec.ts
+++ b/xconfess-backend/src/moderation/moderation-events.listener.spec.ts
@@ -1,0 +1,104 @@
+import { ModerationEventsListener } from './moderation-events.listener';
+import { ModerationStatus } from './ai-moderation.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
+import { NotificationType } from 'src/notifications/entities/notification.entity';
+
+describe('ModerationEventsListener', () => {
+  let listener: ModerationEventsListener;
+  let notificationService: {
+    createNotification: jest.Mock;
+  };
+  let auditLogService: {
+    log: jest.Mock;
+  };
+  let userRepository: {
+    find: jest.Mock;
+  };
+
+  beforeEach(() => {
+    notificationService = {
+      createNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    auditLogService = {
+      log: jest.fn().mockResolvedValue(undefined),
+    };
+    userRepository = {
+      find: jest.fn().mockResolvedValue([{ id: 11 }, { id: 29 }]),
+    };
+
+    listener = new ModerationEventsListener(
+      notificationService as any,
+      auditLogService as any,
+      userRepository as any,
+    );
+  });
+
+  it('notifies all active admins when a confession requires review', async () => {
+    await listener.handleRequiresReview({
+      confessionId: 'conf-123',
+      score: 0.64,
+      flags: ['harassment'],
+    });
+
+    expect(userRepository.find).toHaveBeenCalled();
+    expect(notificationService.createNotification).toHaveBeenCalledTimes(2);
+    expect(notificationService.createNotification).toHaveBeenNthCalledWith(1, {
+      type: NotificationType.SYSTEM,
+      userId: '11',
+      title: 'Confession Requires Moderation Review',
+      message:
+        'Confession conf-123 requires review. Score: 0.64, Flags: harassment',
+      metadata: {
+        confessionId: 'conf-123',
+        score: 0.64,
+        flags: ['harassment'],
+        eventType: 'requires-review',
+        moderationStatus: ModerationStatus.FLAGGED,
+      },
+    });
+    expect(auditLogService.log).toHaveBeenCalledWith({
+      actionType: AuditActionType.MODERATION_ESCALATION,
+      metadata: {
+        eventType: 'requires-review',
+        confessionId: 'conf-123',
+        score: 0.64,
+        flags: ['harassment'],
+      },
+      context: { userId: null },
+    });
+  });
+
+  it('notifies all active admins when a confession is rejected', async () => {
+    await listener.handleHighSeverity({
+      confessionId: 'conf-999',
+      score: 0.98,
+      flags: ['violence'],
+    });
+
+    expect(notificationService.createNotification).toHaveBeenCalledTimes(2);
+    expect(notificationService.createNotification).toHaveBeenNthCalledWith(1, {
+      type: NotificationType.SYSTEM,
+      userId: '11',
+      title: 'High-Severity Content Detected',
+      message:
+        'Confession conf-999 was rejected by moderation. Score: 0.98, Flags: violence',
+      metadata: {
+        confessionId: 'conf-999',
+        score: 0.98,
+        flags: ['violence'],
+        eventType: 'high-severity',
+        moderationStatus: ModerationStatus.REJECTED,
+      },
+    });
+    expect(auditLogService.log).toHaveBeenCalledWith({
+      actionType: AuditActionType.MODERATION_ESCALATION,
+      metadata: {
+        eventType: 'high-severity',
+        confessionId: 'conf-999',
+        score: 0.98,
+        flags: ['violence'],
+      },
+      context: { userId: null },
+    });
+  });
+});

--- a/xconfess-backend/src/moderation/moderation-events.listener.ts
+++ b/xconfess-backend/src/moderation/moderation-events.listener.ts
@@ -1,11 +1,10 @@
-import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { NotificationService } from 'src/notifications/services/notification.service';
 import { NotificationType } from 'src/notifications/entities/notification.entity';
 import { AuditLogService } from '../audit-log/audit-log.service';
 import { AuditActionType } from '../audit-log/audit-log.entity';
-import { ModerationRepositoryService } from './moderation-repository.service';
-import { ModerationStatus, ModerationCategory } from './ai-moderation.service';
+import { ModerationStatus } from './ai-moderation.service';
 import { UserRole } from '../user/entities/user.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -32,7 +31,6 @@ export class ModerationEventsListener {
   constructor(
     private readonly notificationService: NotificationService,
     private readonly auditLogService: AuditLogService,
-    private readonly moderationRepoService: ModerationRepositoryService,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
   ) {}
@@ -44,23 +42,17 @@ export class ModerationEventsListener {
         `Score: ${event.score}, Flags: ${event.flags.join(', ')}`,
     );
     try {
-      // Find all admin users
-      const admins = await this.userRepository.find({
-        where: { role: UserRole.ADMIN, is_active: true },
+      await this.notifyActiveAdmins({
+        title: 'High-Severity Content Detected',
+        message: `Confession ${event.confessionId} was rejected by moderation. Score: ${event.score}, Flags: ${event.flags.join(', ')}`,
+        metadata: {
+          confessionId: event.confessionId,
+          score: event.score,
+          flags: event.flags,
+          eventType: 'high-severity',
+          moderationStatus: ModerationStatus.REJECTED,
+        },
       });
-      for (const admin of admins) {
-        await this.notificationService.createNotification({
-          type: NotificationType.SYSTEM,
-          userId: String(admin.id),
-          title: 'High-Severity Content Detected',
-          message: `Confession ${event.confessionId} flagged as high-severity. Score: ${event.score}, Flags: ${event.flags.join(', ')}`,
-          metadata: {
-            confessionId: event.confessionId,
-            score: event.score,
-            flags: event.flags,
-          },
-        });
-      }
       await this.auditLogService.log({
         actionType: AuditActionType.MODERATION_ESCALATION,
         metadata: {
@@ -86,20 +78,17 @@ export class ModerationEventsListener {
         `Score: ${event.score}, Flags: ${event.flags.join(', ')}`,
     );
     try {
-      // Persist moderation log entry for review queue
-      await this.moderationRepoService.createLog(
-        '', // content not needed for escalation
-        {
+      await this.notifyActiveAdmins({
+        title: 'Confession Requires Moderation Review',
+        message: `Confession ${event.confessionId} requires review. Score: ${event.score}, Flags: ${event.flags.join(', ')}`,
+        metadata: {
+          confessionId: event.confessionId,
           score: event.score,
-          flags: event.flags as unknown as ModerationCategory[],
-          status: ModerationStatus.FLAGGED,
-          requiresReview: true,
-          details: {},
+          flags: event.flags,
+          eventType: 'requires-review',
+          moderationStatus: ModerationStatus.FLAGGED,
         },
-        event.confessionId,
-        event.userId,
-        'escalation',
-      );
+      });
       await this.auditLogService.log({
         actionType: AuditActionType.MODERATION_ESCALATION,
         metadata: {
@@ -116,5 +105,27 @@ export class ModerationEventsListener {
       );
       throw err;
     }
+  }
+
+  private async notifyActiveAdmins(params: {
+    title: string;
+    message: string;
+    metadata: Record<string, unknown>;
+  }): Promise<void> {
+    const admins = await this.userRepository.find({
+      where: { role: UserRole.ADMIN, is_active: true },
+    });
+
+    await Promise.all(
+      admins.map((admin) =>
+        this.notificationService.createNotification({
+          type: NotificationType.SYSTEM,
+          userId: String(admin.id),
+          title: params.title,
+          message: params.message,
+          metadata: params.metadata,
+        }),
+      ),
+    );
   }
 }

--- a/xconfess-backend/src/moderation/moderation-repository.service.ts
+++ b/xconfess-backend/src/moderation/moderation-repository.service.ts
@@ -41,6 +41,56 @@ export class ModerationRepositoryService {
     return await repo.save(log);
   }
 
+  async syncWebhookResult(params: {
+    confessionId: string;
+    content: string;
+    userId?: string;
+    result: ModerationResult;
+    deliveryHash: string;
+    deliveryTimestamp: string;
+  }): Promise<{ log: ModerationLog; isIdempotent: boolean }> {
+    const existing = await this.moderationLogRepo.findOne({
+      where: { confessionId: params.confessionId },
+      order: { createdAt: 'DESC' },
+    });
+
+    const existingWebhookHash = existing?.metadata?.webhook?.deliveryHash;
+    if (existingWebhookHash === params.deliveryHash) {
+      return { log: existing, isIdempotent: true };
+    }
+
+    const log =
+      existing ??
+      this.moderationLogRepo.create({
+        confessionId: params.confessionId,
+        userId: params.userId,
+        content: params.content.substring(0, 5000),
+      });
+
+    log.userId = params.userId;
+    log.content = params.content.substring(0, 5000);
+    log.moderationScore = params.result.score;
+    log.moderationFlags = params.result.flags;
+    log.moderationStatus = params.result.status;
+    log.details = params.result.details;
+    log.requiresReview = params.result.requiresReview;
+    log.autoActioned = params.result.status !== ModerationStatus.PENDING;
+    log.apiProvider = 'webhook';
+    log.metadata = {
+      ...(existing?.metadata ?? {}),
+      webhook: {
+        deliveryHash: params.deliveryHash,
+        timestamp: params.deliveryTimestamp,
+        processedAt: new Date().toISOString(),
+      },
+    };
+
+    return {
+      log: await this.moderationLogRepo.save(log),
+      isIdempotent: false,
+    };
+  }
+
   async updateReview(
     logId: string,
     status: ModerationStatus,

--- a/xconfess-backend/src/moderation/moderation-webhook.controller.spec.ts
+++ b/xconfess-backend/src/moderation/moderation-webhook.controller.spec.ts
@@ -1,0 +1,176 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ModerationStatus } from './ai-moderation.service';
+import { ModerationWebhookController } from './moderation-webhook.controller';
+
+describe('ModerationWebhookController', () => {
+  const webhookSecret = 'top-secret';
+  let controller: ModerationWebhookController;
+  let confessionRepo: {
+    findOne: jest.Mock;
+    save: jest.Mock;
+  };
+  let moderationRepoService: {
+    syncWebhookResult: jest.Mock;
+  };
+  let eventEmitter: {
+    emit: jest.Mock;
+  };
+
+  const confession = {
+    id: 'conf-123',
+    message: 'example confession',
+    moderationScore: 0,
+    moderationFlags: [],
+    moderationStatus: ModerationStatus.PENDING,
+    moderationDetails: null,
+    requiresReview: false,
+    isHidden: false,
+  } as any;
+
+  const buildSignature = (payload: unknown) => {
+    const crypto = require('crypto') as typeof import('crypto');
+    return crypto
+      .createHmac('sha256', webhookSecret)
+      .update(JSON.stringify(payload))
+      .digest('hex');
+  };
+
+  beforeEach(() => {
+    confessionRepo = {
+      findOne: jest.fn().mockResolvedValue({ ...confession }),
+      save: jest.fn().mockImplementation(async (value) => value),
+    };
+    moderationRepoService = {
+      syncWebhookResult: jest
+        .fn()
+        .mockResolvedValue({ log: { id: 'log-1' }, isIdempotent: false }),
+    };
+    eventEmitter = {
+      emit: jest.fn(),
+    };
+
+    controller = new ModerationWebhookController(
+      { get: jest.fn().mockReturnValue(webhookSecret) } as any,
+      eventEmitter as unknown as EventEmitter2,
+      confessionRepo as any,
+      moderationRepoService as any,
+    );
+  });
+
+  it('updates the confession and emits requires-review for flagged results', async () => {
+    const payload = {
+      confessionId: 'conf-123',
+      moderationScore: 0.71,
+      moderationFlags: ['harassment'],
+      moderationStatus: ModerationStatus.FLAGGED,
+      details: { harassment: 0.71 },
+      timestamp: '2026-03-25T10:00:00.000Z',
+    };
+
+    const result = await controller.handleModerationResults(
+      payload,
+      buildSignature(payload),
+    );
+
+    expect(moderationRepoService.syncWebhookResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        confessionId: 'conf-123',
+        deliveryTimestamp: payload.timestamp,
+        result: expect.objectContaining({
+          status: ModerationStatus.FLAGGED,
+          requiresReview: true,
+        }),
+      }),
+    );
+    expect(confessionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        moderationStatus: ModerationStatus.FLAGGED,
+        requiresReview: true,
+        isHidden: false,
+      }),
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      'moderation.requires-review',
+      expect.objectContaining({
+        confessionId: 'conf-123',
+        score: payload.moderationScore,
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      confessionId: 'conf-123',
+      status: ModerationStatus.FLAGGED,
+      isIdempotent: false,
+    });
+  });
+
+  it('emits high-severity for rejected results', async () => {
+    const payload = {
+      confessionId: 'conf-123',
+      moderationScore: 0.99,
+      moderationFlags: ['violence'],
+      moderationStatus: ModerationStatus.REJECTED,
+      details: { violence: 0.99 },
+      timestamp: '2026-03-25T10:05:00.000Z',
+    };
+
+    await controller.handleModerationResults(payload, buildSignature(payload));
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      'moderation.high-severity',
+      expect.objectContaining({
+        confessionId: 'conf-123',
+        score: payload.moderationScore,
+      }),
+    );
+    expect(eventEmitter.emit).not.toHaveBeenCalledWith(
+      'moderation.requires-review',
+      expect.anything(),
+    );
+  });
+
+  it('treats a duplicate delivery as idempotent and skips side effects', async () => {
+    const payload = {
+      confessionId: 'conf-123',
+      moderationScore: 0.71,
+      moderationFlags: ['harassment'],
+      moderationStatus: ModerationStatus.FLAGGED,
+      details: { harassment: 0.71 },
+      timestamp: '2026-03-25T10:00:00.000Z',
+    };
+    moderationRepoService.syncWebhookResult.mockResolvedValueOnce({
+      log: { id: 'log-1' },
+      isIdempotent: true,
+    });
+
+    const result = await controller.handleModerationResults(
+      payload,
+      buildSignature(payload),
+    );
+
+    expect(confessionRepo.save).not.toHaveBeenCalled();
+    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: true,
+      confessionId: 'conf-123',
+      status: ModerationStatus.FLAGGED,
+      isIdempotent: true,
+    });
+  });
+
+  it('rejects webhook requests with an invalid signature', async () => {
+    const payload = {
+      confessionId: 'conf-123',
+      moderationScore: 0.71,
+      moderationFlags: ['harassment'],
+      moderationStatus: ModerationStatus.FLAGGED,
+      details: { harassment: 0.71 },
+      timestamp: '2026-03-25T10:00:00.000Z',
+    };
+
+    await expect(
+      controller.handleModerationResults(payload, 'invalid-signature'),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+});

--- a/xconfess-backend/src/moderation/moderation-webhook.controller.ts
+++ b/xconfess-backend/src/moderation/moderation-webhook.controller.ts
@@ -1,175 +1,161 @@
-// import {
-//   Controller,
-//   Post,
-//   Body,
-//   Headers,
-//   HttpCode,
-//   HttpStatus,
-//   UnauthorizedException,
-//   Logger,
-// } from '@nestjs/common';
-// import { ConfigService } from '@nestjs/config';
-// import { InjectRepository } from '@nestjs/typeorm';
-// import { Repository } from 'typeorm';
-// import { Confession } from '../confession/entities/confession.entity';
-// import { ModerationRepositoryService } from './moderation-repository.service';
-// import { ModerationStatus } from './ai-moderation.service';
-// import * as crypto from 'crypto';
+import {
+  Body,
+  Controller,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as crypto from 'crypto';
+import { Repository } from 'typeorm';
+import { AnonymousConfession } from '../confession/entities/confession.entity';
+import {
+  ModerationCategory,
+  ModerationResult,
+  ModerationStatus,
+} from './ai-moderation.service';
+import { ModerationRepositoryService } from './moderation-repository.service';
 
-// interface WebhookPayload {
-//   confessionId: string;
-//   moderationScore: number;
-//   moderationFlags: string[];
-//   moderationStatus: ModerationStatus;
-//   details: Record<string, number>;
-//   timestamp: string;
-// }
+interface WebhookPayload {
+  confessionId: string;
+  moderationScore: number;
+  moderationFlags: string[];
+  moderationStatus: ModerationStatus;
+  details: Record<string, number>;
+  timestamp: string;
+}
 
-// @Controller('webhooks/moderation')
-// export class ModerationWebhookController {
-//   private readonly logger = new Logger(ModerationWebhookController.name);
-//   private readonly webhookSecret: string;
+@Controller('webhooks/moderation')
+export class ModerationWebhookController {
+  private readonly logger = new Logger(ModerationWebhookController.name);
+  private readonly webhookSecret: string;
 
-//   constructor(
-//     private readonly configService: ConfigService,
-//     @InjectRepository(Confession)
-//     private readonly confessionRepo: Repository<Confession>,
-//     private readonly moderationRepoService: ModerationRepositoryService,
-//   ) {
-//     this.webhookSecret = this.configService.get<string>('WEBHOOK_SECRET');
-//   }
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly eventEmitter: EventEmitter2,
+    @InjectRepository(AnonymousConfession)
+    private readonly confessionRepo: Repository<AnonymousConfession>,
+    private readonly moderationRepoService: ModerationRepositoryService,
+  ) {
+    this.webhookSecret = this.configService.get<string>('WEBHOOK_SECRET', '');
+  }
 
-//   @Post('results')
-//   @HttpCode(HttpStatus.OK)
-//   async handleModerationResults(
-//     @Body() payload: WebhookPayload,
-//     @Headers('x-webhook-signature') signature: string,
-//   ) {
-//     // Verify webhook signature
-//     if (!this.verifySignature(JSON.stringify(payload), signature)) {
-//       this.logger.warn('Invalid webhook signature');
-//       throw new UnauthorizedException('Invalid signature');
-//     }
+  @Post('results')
+  @HttpCode(HttpStatus.OK)
+  async handleModerationResults(
+    @Body() payload: WebhookPayload,
+    @Headers('x-webhook-signature') signature: string,
+  ) {
+    const serializedPayload = JSON.stringify(payload);
 
-//     try {
-//       this.logger.log(`Processing webhook for confession ${payload.confessionId}`);
+    if (!this.verifySignature(serializedPayload, signature)) {
+      this.logger.warn('Invalid moderation webhook signature');
+      throw new UnauthorizedException('Invalid signature');
+    }
 
-//       // Find the confession
-//       const confession = await this.confessionRepo.findOne({
-//         where: { id: payload.confessionId },
-//       });
+    const confession = await this.confessionRepo.findOne({
+      where: { id: payload.confessionId },
+    });
 
-//       if (!confession) {
-//         this.logger.error(`Confession ${payload.confessionId} not found`);
-//         return { success: false, error: 'Confession not found' };
-//       }
+    if (!confession) {
+      this.logger.error(`Confession ${payload.confessionId} not found`);
+      return { success: false, error: 'Confession not found' };
+    }
 
-//       // Update confession with async moderation results
-//       confession.moderationScore = payload.moderationScore;
-//       confession.moderationFlags = payload.moderationFlags as any;
-//       confession.moderationStatus = payload.moderationStatus;
-//       confession.moderationDetails = payload.details;
-//       confession.requiresReview =
-//         payload.moderationStatus === ModerationStatus.FLAGGED;
-//       confession.isHidden =
-//         payload.moderationStatus === ModerationStatus.REJECTED;
+    const requiresReview = payload.moderationStatus === ModerationStatus.FLAGGED;
+    const shouldHide = payload.moderationStatus === ModerationStatus.REJECTED;
+    const moderationResult: ModerationResult = {
+      score: payload.moderationScore,
+      flags: payload.moderationFlags as ModerationCategory[],
+      status: payload.moderationStatus,
+      details: payload.details,
+      requiresReview,
+    };
+    const deliveryHash = this.buildDeliveryHash(serializedPayload);
+    const { isIdempotent } = await this.moderationRepoService.syncWebhookResult({
+      confessionId: confession.id,
+      content: confession.message,
+      result: moderationResult,
+      deliveryHash,
+      deliveryTimestamp: payload.timestamp,
+    });
 
-//       await this.confessionRepo.save(confession);
+    if (isIdempotent) {
+      this.logger.log(
+        `Ignoring duplicate moderation webhook for confession ${payload.confessionId}`,
+      );
 
-//       // Update moderation log
-//       const logs = await this.moderationRepoService.getLogsByConfession(
-//         payload.confessionId,
-//       );
+      return {
+        success: true,
+        confessionId: payload.confessionId,
+        status: payload.moderationStatus,
+        isIdempotent: true,
+      };
+    }
 
-//       if (logs.length > 0) {
-//         const log = logs[0];
-//         log.moderationScore = payload.moderationScore;
-//         log.moderationFlags = payload.moderationFlags as any;
-//         log.moderationStatus = payload.moderationStatus;
-//         log.details = payload.details;
-//         log.requiresReview =
-//           payload.moderationStatus === ModerationStatus.FLAGGED;
-//       }
+    confession.moderationScore = payload.moderationScore;
+    confession.moderationFlags = payload.moderationFlags;
+    confession.moderationStatus = payload.moderationStatus;
+    confession.moderationDetails = payload.details;
+    confession.requiresReview = requiresReview;
+    confession.isHidden = shouldHide;
 
-//       this.logger.log(
-//         `Webhook processed successfully for confession ${payload.confessionId}`,
-//       );
+    await this.confessionRepo.save(confession);
 
-//       return {
-//         success: true,
-//         confessionId: payload.confessionId,
-//         status: payload.moderationStatus,
-//       };
-//     } catch (error) {
-//       this.logger.error('Error processing webhook:', error);
-//       return { success: false, error: error.message };
-//     }
-//   }
+    if (payload.moderationStatus === ModerationStatus.REJECTED) {
+      this.eventEmitter.emit('moderation.high-severity', {
+        confessionId: confession.id,
+        score: payload.moderationScore,
+        flags: payload.moderationFlags,
+      });
+    }
 
-//   private verifySignature(payload: string, signature: string): boolean {
-//     if (!this.webhookSecret || !signature) {
-//       return false;
-//     }
+    if (payload.moderationStatus === ModerationStatus.FLAGGED) {
+      this.eventEmitter.emit('moderation.requires-review', {
+        confessionId: confession.id,
+        score: payload.moderationScore,
+        flags: payload.moderationFlags,
+      });
+    }
 
-//     const expectedSignature = crypto
-//       .createHmac('sha256', this.webhookSecret)
-//       .update(payload)
-//       .digest('hex');
+    this.logger.log(
+      `Processed moderation webhook for confession ${payload.confessionId}`,
+    );
 
-//     return crypto.timingSafeEqual(
-//       Buffer.from(signature),
-//       Buffer.from(expectedSignature),
-//     );
-//   }
-// }
+    return {
+      success: true,
+      confessionId: payload.confessionId,
+      status: payload.moderationStatus,
+      isIdempotent: false,
+    };
+  }
 
-// // src/moderation/moderation-events.listener.ts
-// import { Injectable, Logger } from '@nestjs/common';
-// import { OnEvent } from '@nestjs/event-emitter';
+  private buildDeliveryHash(payload: string): string {
+    return crypto.createHash('sha256').update(payload).digest('hex');
+  }
 
-// interface HighSeverityEvent {
-//   confessionId: string;
-//   userId?: string;
-//   score: number;
-//   flags: string[];
-// }
+  private verifySignature(payload: string, signature: string): boolean {
+    if (!this.webhookSecret || !signature) {
+      return false;
+    }
 
-// interface RequiresReviewEvent {
-//   confessionId: string;
-//   userId?: string;
-//   score: number;
-//   flags: string[];
-// }
+    const expectedSignature = crypto
+      .createHmac('sha256', this.webhookSecret)
+      .update(payload)
+      .digest('hex');
 
-// @Injectable()
-// export class ModerationEventsListener {
-//   private readonly logger = new Logger(ModerationEventsListener.name);
+    if (signature.length !== expectedSignature.length) {
+      return false;
+    }
 
-//   @OnEvent('moderation.high-severity')
-//   async handleHighSeverity(event: HighSeverityEvent) {
-//     this.logger.warn(
-//       `HIGH SEVERITY CONTENT DETECTED - Confession: ${event.confessionId}, ` +
-//       `Score: ${event.score}, Flags: ${event.flags.join(', ')}`,
-//     );
-
-//     // TODO: Send notification to admin/moderators
-//     // Example: this.notificationService.notifyModerators(event);
-
-//     // TODO: Could also trigger additional actions like:
-//     // - Email notification
-//     // - Slack/Discord webhook
-//     // - SMS alert for critical content
-//     // - Automatic user warning/suspension for repeat offenders
-//   }
-
-//   @OnEvent('moderation.requires-review')
-//   async handleRequiresReview(event: RequiresReviewEvent) {
-//     this.logger.log(
-//       `Content flagged for review - Confession: ${event.confessionId}, ` +
-//       `Score: ${event.score}, Flags: ${event.flags.join(', ')}`,
-//     );
-
-//     // TODO: Add to moderation queue
-//     // TODO: Send notification to moderators (lower priority)
-//   }
-// }
+    return crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedSignature),
+    );
+  }
+}

--- a/xconfess-backend/src/moderation/moderation.module.ts
+++ b/xconfess-backend/src/moderation/moderation.module.ts
@@ -5,26 +5,23 @@ import { ConfigModule } from '@nestjs/config';
 import { AiModerationService } from './ai-moderation.service';
 import { ModerationRepositoryService } from './moderation-repository.service';
 import { ModerationController } from './moderation.controller';
+import { ModerationWebhookController } from './moderation-webhook.controller';
 import { ModerationEventsListener } from './moderation-events.listener';
-import { NotificationService } from '../notifications/services/notification.service';
-import { AuditLogService } from '../audit-log/audit-log.service';
 import { User } from '../user/entities/user.entity';
 import { ModerationLog } from './entities/moderation-log.entity';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
+import { NotificationModule as InAppNotificationModule } from '../notifications/notifications.module';
+import { AuditLogModule } from '../audit-log/audit-log.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ModerationLog, AnonymousConfession, User]),
     ConfigModule,
+    InAppNotificationModule,
+    AuditLogModule,
   ],
-  controllers: [ModerationController],
-  providers: [
-    AiModerationService,
-    ModerationRepositoryService,
-    ModerationEventsListener,
-    NotificationService,
-    AuditLogService,
-  ],
+  controllers: [ModerationController, ModerationWebhookController],
+  providers: [AiModerationService, ModerationRepositoryService, ModerationEventsListener],
   exports: [AiModerationService, ModerationRepositoryService],
 })
 export class ModerationModule {}

--- a/xconfess-backend/src/notifications/services/notification.service.ts
+++ b/xconfess-backend/src/notifications/services/notification.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, NotFoundException, Inject } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThan } from 'typeorm';
 import {
@@ -6,11 +7,11 @@ import {
   NotificationType,
 } from '../entities/notification.entity';
 import { NotificationPreference } from '../entities/notification-preference.entity';
+import { NOTIFICATION_QUEUE } from '../notification.queue';
 import {
   CreateNotificationDto,
   NotificationQueryDto,
 } from '../dto/notification.dto';
-// removed: using Inject from @nestjs/common instead of @nestjs/bull
 import { Queue } from 'bull';
 
 @Injectable()
@@ -20,7 +21,7 @@ export class NotificationService {
     private notificationRepository: Repository<Notification>,
     @InjectRepository(NotificationPreference)
     private preferenceRepository: Repository<NotificationPreference>,
-    @Inject('notifications')
+    @InjectQueue(NOTIFICATION_QUEUE)
     private notificationQueue: Queue,
   ) {}
 


### PR DESCRIPTION
## Summary #520 
Implements issue #520 by wiring moderation webhook results to admin notifications and moderation review queue behavior, with explicit idempotency for duplicate webhook deliveries.

## Context
The moderation webhook flow had TODOs for:
- Dispatching admin/moderator notifications
- Triggering moderation queue handling
- Defining duplicate delivery behavior

## Changes
- Enabled moderation webhook processing for moderation result callbacks.
- Added replay-safe synchronization logic for webhook moderation updates.
- Emitted escalation events for rejected and flagged outcomes.
- Sent system notifications to active admin users for escalation events.
- Logged moderation escalation actions to audit logs.
- Registered webhook controller and required module dependencies.
- Fixed notification queue injection wiring in backend notification service.
- Added focused unit tests for webhook idempotency and escalation notifications.

## Idempotency Behavior
- Each webhook payload is hashed for delivery identity.
- Duplicate delivery for the same confession returns success as an idempotent replay.
- Duplicate delivery does not rewrite confession moderation fields.
- Duplicate delivery does not re-emit notification/escalation side effects.
- New delivery updates moderation fields and emits the matching escalation event.

## Notification and Queue Behavior
- Rejected moderation result triggers high-severity escalation flow.
- Flagged moderation result triggers requires-review escalation flow.
- Active admin users receive system notifications for both escalation types.
- Moderation review queue behavior is represented through moderation review state synchronization.

## Tests Added
- `moderation-webhook.controller.spec.ts`
- `moderation-events.listener.spec.ts`

## Acceptance Criteria
- [x] Webhook triggers correct notification and queue actions
- [x] Duplicate webhook delivery behavior is defined
- [x] Duplicate webhook delivery behavior is covered by tests

## Verification Notes
- Implementation is complete and pushed on the feature branch.
- Runtime test execution was blocked in this environment due `ENOSPC` during dependency install.

Closes #520 