### PR TITLE
test(frontend): add analytics dashboard fallback regression tests

### DIFF
--- a/xconfess-frontend/app/(dashboard)/analytics/__tests__/page.test.tsx
+++ b/xconfess-frontend/app/(dashboard)/analytics/__tests__/page.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import AnalyticsPage from '../page';
+
+jest.mock('next/dynamic', () => {
+  const React = require('react');
+
+  return (loader: () => Promise<any>, options?: { loading?: () => React.ReactNode }) => {
+    return function DynamicComponent(props: Record<string, unknown>) {
+      const [Resolved, setResolved] = React.useState<React.ComponentType<any> | null>(null);
+
+      React.useEffect(() => {
+        let mounted = true;
+
+        Promise.resolve(loader()).then((mod) => {
+          const nextComponent = mod.default ?? mod;
+          if (mounted) {
+            setResolved(() => nextComponent);
+          }
+        });
+
+        return () => {
+          mounted = false;
+        };
+      }, []);
+
+      if (!Resolved) {
+        return options?.loading ? options.loading() : null;
+      }
+
+      return React.createElement(Resolved, props);
+    };
+  };
+});
+
+jest.mock('@/app/components/analytics/ActivityChart', () => ({
+  ActivityChart: ({ data, loading }: { data: unknown[]; loading: boolean }) => (
+    <div data-testid="activity-chart">{loading ? 'loading' : `activity:${data.length}`}</div>
+  ),
+}));
+
+jest.mock('@/app/components/analytics/ReactionDistribution', () => ({
+  ReactionDistribution: ({ data, loading }: { data: unknown[]; loading: boolean }) => (
+    <div data-testid="reaction-distribution">{loading ? 'loading' : `reactions:${data.length}`}</div>
+  ),
+}));
+
+jest.mock('@/app/components/analytics/TrendingConfessions', () => ({
+  TrendingConfessions: ({
+    confessions,
+    loading,
+  }: {
+    confessions: unknown[];
+    loading: boolean;
+  }) => {
+    if (loading) {
+      return <div data-testid="trending-confessions">loading</div>;
+    }
+
+    if (confessions.length === 0) {
+      return <div>No trending confessions yet</div>;
+    }
+
+    return <div data-testid="trending-confessions">{confessions.length}</div>;
+  },
+}));
+
+jest.mock('@/app/components/analytics/TimePeriodSelector', () => ({
+  TimePeriodSelector: () => <div data-testid="time-period-selector">selector</div>,
+}));
+
+const emptyAnalyticsResponse = {
+  comparison: {
+    enabled: false,
+    availability: 'available',
+    source: 'backend',
+  },
+  metrics: {
+    totalConfessions: 0,
+    totalUsers: 0,
+    totalReactions: 0,
+    activeUsers: 0,
+    confessionsDelta: { percentage: null, direction: 'unknown', availability: 'unavailable' },
+    usersDelta: { percentage: null, direction: 'unknown', availability: 'unavailable' },
+    reactionsDelta: { percentage: null, direction: 'unknown', availability: 'unavailable' },
+    activeDelta: { percentage: null, direction: 'unknown', availability: 'unavailable' },
+  },
+  trendingConfessions: [],
+  reactionDistribution: [],
+  activityData: [],
+};
+
+describe('AnalyticsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (window.localStorage.getItem as jest.Mock).mockReturnValue(null);
+  });
+
+  it('renders loading UI while analytics data is pending', () => {
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              ok: true,
+              json: async () => emptyAnalyticsResponse,
+            });
+          }, 50);
+        }),
+    ) as jest.Mock;
+
+    render(<AnalyticsPage />);
+
+    expect(screen.getByText('Analytics Dashboard')).toBeInTheDocument();
+    expect(screen.getAllByRole('status', { name: 'loading' })).toHaveLength(4);
+  });
+
+  it('renders empty fallback UI when analytics returns no trending data', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => emptyAnalyticsResponse,
+    }) as jest.Mock;
+
+    render(<AnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No trending confessions yet')).toBeInTheDocument();
+    });
+  });
+
+  it('renders server-error fallback and retries successfully', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => emptyAnalyticsResponse,
+      }) as jest.Mock;
+
+    render(<AnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Error loading analytics')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('No trending confessions yet')).toBeInTheDocument();
+    });
+  });
+});

--- a/xconfess-frontend/app/components/analytics/__tests__/TrendingDashboard.test.tsx
+++ b/xconfess-frontend/app/components/analytics/__tests__/TrendingDashboard.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { TrendingDashboard } from '../TrendingDashboard';
+
+jest.mock('../TrendingConfessionCard', () => ({
+  TrendingConfessionCard: ({
+    confession,
+    rank,
+  }: {
+    confession: { content: string };
+    rank: number;
+  }) => <div>{`${rank}. ${confession.content}`}</div>,
+}));
+
+jest.mock('../ReactionChart', () => ({
+  ReactionChart: ({ data }: { data: unknown[] }) => <div>{`reaction-chart:${data.length}`}</div>,
+}));
+
+jest.mock('../ActivityChart', () => ({
+  ActivityChart: ({ data }: { data: unknown[] }) => <div>{`activity-chart:${data.length}`}</div>,
+}));
+
+jest.mock('../MetricsOverview', () => ({
+  MetricsOverview: ({ metrics }: { metrics: { totalConfessions: number } }) => (
+    <div>{`metrics:${metrics.totalConfessions}`}</div>
+  ),
+}));
+
+const emptyTrendingResponse = {
+  trending: [],
+  reactionDistribution: [],
+  dailyActivity: [],
+  totalMetrics: {
+    totalConfessions: 0,
+    totalReactions: 0,
+    totalUsers: 0,
+  },
+  period: '7days',
+};
+
+const populatedTrendingResponse = {
+  trending: [
+    {
+      id: 'conf-1',
+      content: 'A recovered confession',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      reactions: {
+        like: 2,
+        love: 1,
+      },
+      reactionCount: 3,
+    },
+  ],
+  reactionDistribution: [{ type: 'like', count: 3, percentage: 100 }],
+  dailyActivity: [{ date: '2025-01-01', confessions: 1, reactions: 3, activeUsers: 1 }],
+  totalMetrics: {
+    totalConfessions: 1,
+    totalReactions: 3,
+    totalUsers: 1,
+  },
+  period: '7days',
+};
+
+describe('TrendingDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders loading fallback while analytics are pending', () => {
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              ok: true,
+              json: async () => emptyTrendingResponse,
+            });
+          }, 50);
+        }),
+    ) as jest.Mock;
+
+    render(<TrendingDashboard />);
+
+    expect(screen.getByText('Loading analytics...')).toBeInTheDocument();
+  });
+
+  it('renders empty fallback UI when there are no trending confessions', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => emptyTrendingResponse,
+    }) as jest.Mock;
+
+    render(<TrendingDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No trending confessions yet')).toBeInTheDocument();
+    });
+  });
+
+  it('renders server-error fallback and retries successfully', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => populatedTrendingResponse,
+      }) as jest.Mock;
+
+    render(<TrendingDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to Load Analytics')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('1. A recovered confession')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add regression coverage for the analytics dashboard page loading, empty, and server-error states
- add regression coverage for the trending analytics dashboard loading, empty, and server-error states
- verify retry behavior for both error fallback UIs

## Validation
- `npx jest --config jest.config.ts --runInBand --runTestsByPath "C:/Users/HP/bamielearn/Xconfess/xconfess-frontend/app/(dashboard)/analytics/__tests__/page.test.tsx"`
- `npx jest --config jest.config.ts --runInBand "app/components/analytics/__tests__/TrendingDashboard.test.tsx"`

Closes #517
