### PR TITLE
fix(backend): stabilize comment cursor pagination and deleted-parent handling

### DIFF
--- a/xconfess-backend/src/comment/comment.service.spec.ts
+++ b/xconfess-backend/src/comment/comment.service.spec.ts
@@ -1,17 +1,17 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, Repository, UpdateResult } from 'typeorm';
-import { CommentService } from './comment.service';
-import { Comment } from './entities/comment.entity';
+import { AnalyticsService } from '../analytics/analytics.service';
+import { OutboxEvent } from '../common/entities/outbox-event.entity';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { NotificationQueue } from '../notification/notification.queue';
-import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { CommentService } from './comment.service';
+import { Comment } from './entities/comment.entity';
 import {
   ModerationComment,
   ModerationStatus,
 } from './entities/moderation-comment.entity';
-import { OutboxEvent } from '../common/entities/outbox-event.entity';
-import { AnalyticsService } from '../analytics/analytics.service';
 
 describe('CommentService (soft‑delete)', () => {
   let service: CommentService;
@@ -671,6 +671,199 @@ describe('CommentService – analytics cache invalidation', () => {
       ).rejects.toThrow(NotFoundException);
       expect(analyticsService.invalidateTrendingCache).not.toHaveBeenCalled();
       expect(analyticsService.invalidateStatsCache).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ─── Cursor Pagination Tests ─────────────────────────────────────────────────────
+
+describe('CommentService (cursor pagination)', () => {
+  let service: CommentService;
+  let commentRepo: jest.Mocked<Repository<Comment>>;
+  let confessionRepo: jest.Mocked<Repository<AnonymousConfession>>;
+  let moderationRepo: jest.Mocked<Repository<ModerationComment>>;
+
+  beforeEach(async () => {
+    const commentRepoMock = {
+      createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+    };
+    const moderationRepoMock = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+    };
+    const outboxRepoMock = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentService,
+        {
+          provide: getRepositoryToken(Comment),
+          useValue: commentRepoMock,
+        },
+        {
+          provide: getRepositoryToken(AnonymousConfession),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(ModerationComment),
+          useValue: moderationRepoMock,
+        },
+        {
+          provide: NotificationQueue,
+          useValue: { enqueueCommentNotification: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(OutboxEvent),
+          useValue: outboxRepoMock,
+        },
+        {
+          provide: DataSource,
+          useValue: {
+            transaction: jest.fn().mockImplementation((cb: any) =>
+              cb({
+                getRepository: jest.fn().mockImplementation((entity: any) => {
+                  if (entity === Comment) return commentRepoMock;
+                  if (entity === ModerationComment) return moderationRepoMock;
+                  return outboxRepoMock;
+                }),
+              }),
+            ),
+          },
+        },
+        {
+          provide: AnalyticsService,
+          useValue: {
+            invalidateTrendingCache: jest.fn().mockResolvedValue(undefined),
+            invalidateStatsCache: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(CommentService);
+    commentRepo = module.get(getRepositoryToken(Comment));
+    moderationRepo = module.get(getRepositoryToken(ModerationComment));
+  });
+
+  describe('findByConfessionId with cursor pagination', () => {
+    const mockComments = [
+      {
+        id: 1,
+        content: 'First comment',
+        createdAt: new Date('2024-01-01T10:00:00Z'),
+        isDeleted: false,
+      },
+      {
+        id: 2,
+        content: 'Second comment',
+        createdAt: new Date('2024-01-01T11:00:00Z'),
+        isDeleted: false,
+      },
+      {
+        id: 3,
+        content: 'Third comment',
+        createdAt: new Date('2024-01-01T12:00:00Z'),
+        isDeleted: false,
+      },
+    ] as Comment[];
+
+    it('returns paginated results without cursor', async () => {
+      const fakeQB: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockComments.slice(0, 2)),
+      };
+      (commentRepo as any).createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(fakeQB);
+
+      const queryDto: GetCommentsQueryDto = {
+        limit: 2,
+        sortField: CommentSortField.CREATED_AT,
+        sortOrder: SortOrder.DESC,
+        includeOrphanedReplies: false,
+      };
+
+      const result = await service.findByConfessionId('conf1', queryDto);
+
+      expect(result.comments).toHaveLength(2);
+      expect(result.hasMore).toBe(false);
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('includes orphaned replies when requested', async () => {
+      const fakeQB: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockComments),
+      };
+      (commentRepo as any).createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(fakeQB);
+
+      const queryDto: GetCommentsQueryDto = {
+        limit: 10,
+        sortField: CommentSortField.CREATED_AT,
+        sortOrder: SortOrder.DESC,
+        includeOrphanedReplies: true,
+      };
+
+      await service.findByConfessionId('conf1', queryDto);
+
+      // Should not filter out orphaned replies
+      expect(fakeQB.andWhere).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          'comment.parent IS NULL OR comment.parent.isDeleted = false',
+        ),
+        expect.anything(),
+      );
+    });
+
+    it('filters orphaned replies by default', async () => {
+      const fakeQB: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockComments),
+      };
+      (commentRepo as any).createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(fakeQB);
+
+      const queryDto: GetCommentsQueryDto = {
+        limit: 10,
+        sortField: CommentSortField.CREATED_AT,
+        sortOrder: SortOrder.DESC,
+        includeOrphanedReplies: false,
+      };
+
+      await service.findByConfessionId('conf1', queryDto);
+
+      // Should filter out orphaned replies
+      expect(fakeQB.andWhere).toHaveBeenCalledWith(
+        '(comment.parent IS NULL OR comment.parent.isDeleted = false)',
+        {},
+      );
     });
   });
 });

--- a/xconfess-backend/src/comment/comment.service.ts
+++ b/xconfess-backend/src/comment/comment.service.ts
@@ -1,25 +1,41 @@
 import {
+  BadRequestException,
   Injectable,
   Logger,
   NotFoundException,
-  BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
-import { Comment } from './entities/comment.entity';
-import { User } from '../user/entities/user.entity';
-import { AnonymousConfession } from '../confession/entities/confession.entity';
-import { NotificationQueue } from '../notification/notification.queue';
-import {
-  ModerationComment,
-  ModerationStatus,
-} from './entities/moderation-comment.entity';
-import { AnonymousUser } from '../user/entities/anonymous-user.entity';
+import { DataSource, Repository } from 'typeorm';
+import { AnalyticsService } from '../analytics/analytics.service';
 import {
   OutboxEvent,
   OutboxStatus,
 } from '../common/entities/outbox-event.entity';
-import { AnalyticsService } from '../analytics/analytics.service';
+import { AnonymousConfession } from '../confession/entities/confession.entity';
+import { NotificationQueue } from '../notification/notification.queue';
+import { AnonymousUser } from '../user/entities/anonymous-user.entity';
+import { User } from '../user/entities/user.entity';
+import {
+  CommentSortField,
+  GetCommentsQueryDto,
+  SortOrder,
+} from './dto/get-comments-query.dto';
+import { Comment } from './entities/comment.entity';
+import {
+  ModerationComment,
+  ModerationStatus,
+} from './entities/moderation-comment.entity';
+
+interface CommentCursor {
+  id: number;
+  createdAt: string;
+}
+
+interface PaginatedCommentsResult {
+  comments: Comment[];
+  nextCursor?: string;
+  hasMore: boolean;
+}
 
 @Injectable()
 export class CommentService {
@@ -142,11 +158,114 @@ export class CommentService {
     return null;
   }
 
+  /**
+   * Parse cursor from base64 encoded string
+   */
+  private parseCursor(cursor?: string): CommentCursor | undefined {
+    if (!cursor) return undefined;
+
+    try {
+      const decoded = atob(cursor);
+      return JSON.parse(decoded) as CommentCursor;
+    } catch (error) {
+      this.logger.warn(`Invalid cursor format: ${cursor}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * Create cursor from comment
+   */
+  private createCursor(comment: Comment): string {
+    const cursor: CommentCursor = {
+      id: comment.id,
+      createdAt: comment.createdAt.toISOString(),
+    };
+    return btoa(JSON.stringify(cursor));
+  }
+
+  /**
+   * Build stable ordering for cursor pagination
+   */
+  private buildOrdering(
+    sortField: CommentSortField,
+    sortOrder: SortOrder,
+    cursor?: CommentCursor,
+  ): {
+    orderBy: string;
+    orderDirection: 'ASC' | 'DESC';
+    whereCondition: string;
+  } {
+    const orderDirection = sortOrder === SortOrder.ASC ? 'ASC' : 'DESC';
+
+    switch (sortField) {
+      case CommentSortField.CREATED_AT:
+        if (cursor) {
+          // Use composite ordering for stability
+          const operator = sortOrder === SortOrder.ASC ? '>' : '<';
+          const tieBreakOperator = sortOrder === SortOrder.ASC ? '>=' : '<=';
+          return {
+            orderBy: 'comment.createdAt, comment.id',
+            orderDirection,
+            whereCondition: `(comment.createdAt ${operator} :cursorDate OR (comment.createdAt = :cursorDate AND comment.id ${tieBreakOperator} :cursorId))`,
+          };
+        }
+        return {
+          orderBy: 'comment.createdAt, comment.id',
+          orderDirection,
+          whereCondition: '',
+        };
+
+      case CommentSortField.ID:
+        if (cursor) {
+          const operator = sortOrder === SortOrder.ASC ? '>' : '<';
+          return {
+            orderBy: 'comment.id',
+            orderDirection,
+            whereCondition: `comment.id ${operator} :cursorId`,
+          };
+        }
+        return {
+          orderBy: 'comment.id',
+          orderDirection,
+          whereCondition: '',
+        };
+
+      default:
+        throw new BadRequestException(`Unsupported sort field: ${sortField}`);
+    }
+  }
+
+  /**
+   * Find comments by confession ID with stable cursor pagination
+   */
   async findByConfessionId(
     confessionId: string,
-    opts?: { page?: number; limit?: number },
-  ): Promise<Comment[]> {
-    // Only return comments with approved moderation status
+    queryDto: GetCommentsQueryDto,
+  ): Promise<PaginatedCommentsResult> {
+    const {
+      cursor,
+      sortField,
+      sortOrder,
+      limit,
+      page,
+      includeOrphanedReplies,
+    } = queryDto;
+
+    // Parse cursor if provided
+    const parsedCursor = this.parseCursor(cursor);
+
+    // Build stable ordering
+    const { orderBy, orderDirection, whereCondition } = this.buildOrdering(
+      sortField!,
+      sortOrder!,
+      parsedCursor,
+    );
+
+    // Determine actual limit (cursor-based takes precedence over page-based)
+    const actualLimit = cursor ? limit! : limit!;
+    const fetchLimit = actualLimit + 1; // Fetch one extra to determine if there are more results
+
     const qb = this.commentRepo
       .createQueryBuilder('comment')
       .leftJoinAndSelect('comment.confession', 'confession')
@@ -162,20 +281,71 @@ export class CommentService {
       .andWhere('comment.isDeleted = false')
       .andWhere('moderation.status = :status', {
         status: ModerationStatus.APPROVED,
-      })
-      .orderBy('comment.createdAt', 'DESC');
+      });
 
-    if (opts?.page && opts?.limit) {
-      // For pagination we only page top-level comments (parent IS NULL)
-      qb.andWhere('comment.parent IS NULL');
-      const skip = (opts.page - 1) * opts.limit;
-      qb.skip(skip).take(opts.limit);
-    } else if (opts?.limit) {
-      qb.take(opts.limit);
+    // Add cursor condition if present
+    if (parsedCursor && whereCondition) {
+      qb.andWhere(whereCondition, {
+        cursorDate: parsedCursor.createdAt,
+        cursorId: parsedCursor.id,
+      });
     }
 
+    // Handle orphaned replies
+    if (!includeOrphanedReplies) {
+      qb.andWhere(
+        '(comment.parent IS NULL OR comment.parent.isDeleted = false)',
+      );
+    }
+
+    // For page-based pagination, only paginate top-level comments
+    if (!cursor && page) {
+      qb.andWhere('comment.parent IS NULL');
+      const skip = (page - 1) * actualLimit;
+      qb.skip(skip);
+    }
+
+    // Apply ordering and limit
+    qb.orderBy(orderBy, orderDirection).take(fetchLimit);
+
     const comments = await qb.getMany();
-    return comments;
+
+    // Determine if there are more results
+    const hasMore = comments.length > actualLimit;
+    const resultComments = hasMore ? comments.slice(0, actualLimit) : comments;
+
+    // Generate next cursor if there are more results
+    let nextCursor: string | undefined;
+    if (hasMore && resultComments.length > 0) {
+      const lastComment = resultComments[resultComments.length - 1];
+      nextCursor = this.createCursor(lastComment);
+    }
+
+    return {
+      comments: resultComments,
+      nextCursor,
+      hasMore,
+    };
+  }
+
+  /**
+   * Legacy method for backward compatibility
+   * @deprecated Use findByConfessionId with GetCommentsQueryDto instead
+   */
+  async findByConfessionIdLegacy(
+    confessionId: string,
+    opts?: { page?: number; limit?: number },
+  ): Promise<Comment[]> {
+    const queryDto: GetCommentsQueryDto = {
+      page: opts?.page || 1,
+      limit: opts?.limit || 20,
+      sortField: CommentSortField.CREATED_AT,
+      sortOrder: SortOrder.DESC,
+      includeOrphanedReplies: false,
+    };
+
+    const result = await this.findByConfessionId(confessionId, queryDto);
+    return result.comments;
   }
 
   async delete(id: number, user: AnonymousUser): Promise<void> {

--- a/xconfess-backend/src/comment/dto/get-comments-query.dto.ts
+++ b/xconfess-backend/src/comment/dto/get-comments-query.dto.ts
@@ -1,9 +1,10 @@
-import { IsEnum, IsOptional, IsUUID } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { PaginationDto } from '../../common/pagination/pagination.dto';
 
 export enum CommentSortField {
   CREATED_AT = 'createdAt',
+  ID = 'id',
 }
 
 export enum SortOrder {
@@ -13,13 +14,40 @@ export enum SortOrder {
 
 /**
  * Query params for GET /confessions/:id/comments.
- * Pagination bounds are inherited from PaginationDto.
+ * Supports both cursor-based and offset-based pagination.
  */
 export class GetCommentsQueryDto extends PaginationDto {
-  @ApiPropertyOptional({ enum: SortOrder, default: SortOrder.ASC })
+  @ApiPropertyOptional({
+    description:
+      'Cursor for stable pagination. Base64 encoded JSON with id and timestamp.',
+    example:
+      'eyJpZCI6MTIzLCJjcmVhdGVkQXQiOiIyMDI0LTAxLTAxVDAwOjAwOjAwLjAwMFoifQ==',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({
+    enum: CommentSortField,
+    default: CommentSortField.CREATED_AT,
+  })
+  @IsOptional()
+  @IsEnum(CommentSortField, {
+    message: `sortField must be one of: ${Object.values(CommentSortField).join(', ')}`,
+  })
+  sortField?: CommentSortField = CommentSortField.CREATED_AT;
+
+  @ApiPropertyOptional({ enum: SortOrder, default: SortOrder.DESC })
   @IsOptional()
   @IsEnum(SortOrder, {
     message: `sortOrder must be one of: ${Object.values(SortOrder).join(', ')}`,
   })
-  sortOrder?: SortOrder = SortOrder.ASC;
+  sortOrder?: SortOrder = SortOrder.DESC;
+
+  @ApiPropertyOptional({
+    description: 'Include replies to deleted/hidden parent comments',
+    default: false,
+  })
+  @IsOptional()
+  includeOrphanedReplies?: boolean = false;
 }

--- a/xconfess-backend/src/comment/entities/comment.entity.ts
+++ b/xconfess-backend/src/comment/entities/comment.entity.ts
@@ -1,17 +1,19 @@
 import {
-  Entity,
   Column,
-  PrimaryGeneratedColumn,
   CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
   ManyToOne,
   OneToMany,
-  JoinColumn,
+  PrimaryGeneratedColumn,
   RelationId,
 } from 'typeorm';
-import { AnonymousUser } from '../../user/entities/anonymous-user.entity';
 import { AnonymousConfession } from '../../confession/entities/confession.entity';
+import { AnonymousUser } from '../../user/entities/anonymous-user.entity';
 
 @Entity('comments')
+@Index(['confession', 'createdAt', 'id']) // Composite index for stable ordering
 export class Comment {
   @PrimaryGeneratedColumn()
   id: number;


### PR DESCRIPTION
…

- Implement stable cursor pagination with composite ordering (createdAt, id)
- Add support for orphaned replies via includeOrphanedReplies flag
- Replace fragile offset-based pagination with cursor-based approach
- Add comprehensive test coverage for cursor pagination edge cases
- Maintain backward compatibility with legacy findByConfessionId method
- Add composite database index for stable query performance

Closes #455