### PR TITLE
prevent duplicate export submissions and conflicting form states

### DIFF
--- a/xconfess-backend/src/data-export/data-export.controller.spec.ts
+++ b/xconfess-backend/src/data-export/data-export.controller.spec.ts
@@ -4,6 +4,7 @@ import { DataExportService } from './data-export.service';
 import { ConfigService } from '@nestjs/config';
 import {
   BadRequestException,
+  ConflictException,
   UnauthorizedException,
   NotFoundException,
 } from '@nestjs/common';
@@ -370,6 +371,75 @@ describe('DataExportController', () => {
       expect(mockExportService.getExportHistory).toHaveBeenCalledWith(userId);
       expect(result.latest).toBe(mockLatest);
       expect(result.history).toEqual(mockHistory);
+    });
+  });
+
+  // ── Request Export Tests ─────────────────────────────────────────────────────
+
+  describe('Request Export Endpoint', () => {
+    it('should create a new export job and return 201', async () => {
+      const userId = 'user-1';
+      const mockUser = { id: userId };
+      const mockResult = { requestId: 'req-new', status: 'PENDING', queuedAt: new Date() };
+
+      mockExportService.requestExport.mockResolvedValue(mockResult as any);
+
+      const result = await controller.requestExport({ user: mockUser } as any);
+
+      expect(mockExportService.requestExport).toHaveBeenCalledWith(userId);
+      expect(result.requestId).toBe('req-new');
+      expect(result.status).toBe('PENDING');
+    });
+
+    it('should propagate ConflictException (409) when an active export already exists', async () => {
+      const userId = 'user-2';
+      const mockUser = { id: userId };
+
+      mockExportService.requestExport.mockRejectedValue(
+        new ConflictException('An export is already in progress. Please wait for it to complete.'),
+      );
+
+      await expect(
+        controller.requestExport({ user: mockUser } as any),
+      ).rejects.toThrow(ConflictException);
+
+      expect(mockExportService.requestExport).toHaveBeenCalledWith(userId);
+    });
+
+    it('should propagate BadRequestException (400) for the 7-day rate limit', async () => {
+      const userId = 'user-3';
+      const mockUser = { id: userId };
+
+      mockExportService.requestExport.mockRejectedValue(
+        new BadRequestException('Export allowed once every 7 days.'),
+      );
+
+      await expect(
+        controller.requestExport({ user: mockUser } as any),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockExportService.requestExport).toHaveBeenCalledWith(userId);
+    });
+
+    it('should not create a second job when called twice concurrently for the same user', async () => {
+      const userId = 'user-4';
+      const mockUser = { id: userId };
+      const mockResult = { requestId: 'req-first', status: 'PENDING', queuedAt: new Date() };
+
+      // First call succeeds; second call raises ConflictException as if an active job exists.
+      mockExportService.requestExport
+        .mockResolvedValueOnce(mockResult as any)
+        .mockRejectedValueOnce(
+          new ConflictException('An export is already in progress. Please wait for it to complete.'),
+        );
+
+      const first = controller.requestExport({ user: mockUser } as any);
+      const second = controller.requestExport({ user: mockUser } as any);
+
+      const [firstResult] = await Promise.allSettled([first, second]);
+
+      expect(firstResult.status).toBe('fulfilled');
+      expect(mockExportService.requestExport).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/xconfess-backend/src/data-export/data-export.service.ts
+++ b/xconfess-backend/src/data-export/data-export.service.ts
@@ -2,6 +2,7 @@
 import {
   Injectable,
   BadRequestException,
+  ConflictException,
   NotFoundException,
   Optional,
 } from '@nestjs/common';
@@ -67,7 +68,21 @@ export class DataExportService {
   ) {}
 
   async requestExport(userId: string) {
-    // 1. Rate Limit Check: Find any request created in the last 7 days
+    // 1a. Duplicate-submission guard: reject if a job is already PENDING or PROCESSING.
+    const activeJob = await this.exportRepository.findOne({
+      where: [
+        { userId, status: 'PENDING' },
+        { userId, status: 'PROCESSING' },
+      ],
+    });
+
+    if (activeJob) {
+      throw new ConflictException(
+        'An export is already in progress. Please wait for it to complete.',
+      );
+    }
+
+    // 1b. Rate Limit Check: Find any request created in the last 7 days
     const sevenDaysAgo = new Date();
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 

--- a/xconfess-frontend/app/(dashboard)/settings/data-export/DataExportRequest.tsx
+++ b/xconfess-frontend/app/(dashboard)/settings/data-export/DataExportRequest.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
-import { AlertCircle, CheckCircle2, Clock3, Download, RotateCw, ShieldCheck, XCircle } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Clock3, Download, Loader2, RotateCw, ShieldCheck, XCircle } from 'lucide-react';
 import ErrorState from '@/app/components/common/ErrorState';
 import { useGlobalToast } from '@/app/components/common/Toast';
 import {
@@ -14,6 +14,9 @@ const STORAGE_KEY = 'xconfess-active-export-job';
 const POLLING_INTERVAL = 5000;
 const FOCUS_RECOVERY_DELAY = 1000;
 
+/** HTTP status code the server returns when an active export already exists. */
+const CONFLICT_STATUS = 409;
+
 export default function DataExportRequest() {
   const { addToast } = useGlobalToast();
   const [history, setHistory] = useState<DataExportHistoryItem[]>([]);
@@ -23,6 +26,8 @@ export default function DataExportRequest() {
   const [actionLoadingId, setActionLoadingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [lastNotifiedStatus, setLastNotifiedStatus] = useState<Record<string, DataExportStatus>>({});
+  /** Prevents concurrent submissions from double-clicks or fast retries. */
+  const submittingRef = useRef(false);
   
   const pollingTimerRef = useRef<NodeJS.Timeout | null>(null);
   const focusRecoveryTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -189,16 +194,32 @@ export default function DataExportRequest() {
   }, []);
   
   const handleRequestExport = async () => {
+    // Guard against concurrent submissions from fast double-clicks or slow networks.
+    if (submittingRef.current || requestingExport || hasInProgressJob) return;
+
+    submittingRef.current = true;
     setRequestingExport(true);
+    setError(null);
     try {
       const response = await dataExportApi.requestExport();
       if (response.jobId) {
         localStorage.setItem(STORAGE_KEY, response.jobId);
       }
+      addToast('Export request submitted successfully!', 'success');
       await loadHistory(true);
-    } catch {
-      setError('Unable to request a new archive right now. Please try again shortly.');
+    } catch (err: unknown) {
+      const status = (err as { status?: number; response?: { status?: number } })?.status
+        ?? (err as { status?: number; response?: { status?: number } })?.response?.status;
+
+      if (status === CONFLICT_STATUS) {
+        // Server already has an active job for this user — sync UI state.
+        addToast('An export is already in progress. Check the status below.', 'info');
+        await loadHistory(true);
+      } else {
+        setError('Unable to request a new archive right now. Please try again shortly.');
+      }
     } finally {
+      submittingRef.current = false;
       setRequestingExport(false);
     }
   };
@@ -337,16 +358,20 @@ export default function DataExportRequest() {
           <button
             onClick={handleRequestExport}
             disabled={requestingExport || hasInProgressJob}
-            className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-6 rounded-lg transition-all disabled:bg-slate-300"
+            aria-disabled={requestingExport || hasInProgressJob}
+            aria-live="polite"
+            className="inline-flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-6 rounded-lg transition-all disabled:bg-slate-300 disabled:cursor-not-allowed"
           >
+            {requestingExport && <Loader2 size={15} className="animate-spin" />}
             {requestingExport ? 'Initiating...' : 'Generate New Archive'}
           </button>
           <p className="text-[11px] text-slate-400 mt-3 italic">
             You can request an export once every 7 days.
           </p>
           {hasInProgressJob && (
-            <p className="text-xs text-amber-700 mt-2">
-              An export is currently running. Refresh to see updated status.
+            <p className="text-xs text-amber-700 mt-2 flex items-center justify-center gap-1">
+              <Clock3 size={12} className="shrink-0" />
+              An export is already in progress — the button will re-enable once it completes.
             </p>
           )}
         </div>
@@ -388,9 +413,11 @@ export default function DataExportRequest() {
                       <button
                         type="button"
                         onClick={handleRequestExport}
-                        disabled={requestingExport}
-                        className="rounded-md border border-slate-300 px-3 py-2 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+                        disabled={requestingExport || hasInProgressJob}
+                        aria-disabled={requestingExport || hasInProgressJob}
+                        className="inline-flex items-center gap-1.5 rounded-md border border-slate-300 px-3 py-2 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60 disabled:cursor-not-allowed"
                       >
+                        {requestingExport && <Loader2 size={12} className="animate-spin" />}
                         Request New Link
                       </button>
                     )}

--- a/xconfess-frontend/app/components/ui/button.tsx
+++ b/xconfess-frontend/app/components/ui/button.tsx
@@ -1,19 +1,24 @@
 import * as React from "react";
+import { Loader2 } from "lucide-react";
 import { cn } from "@/app/lib/utils/cn";
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "default" | "outline" | "ghost" | "destructive";
   size?: "sm" | "md" | "lg";
+  /** When true, renders a spinner and disables the button. */
+  isLoading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", size = "md", type = "button", ...props }, ref) => {
+  ({ className, variant = "default", size = "md", type = "button", isLoading, disabled, children, ...props }, ref) => {
     return (
       <button
         type={type}
+        disabled={disabled || isLoading}
+        aria-disabled={disabled || isLoading}
         className={cn(
-          "inline-flex items-center justify-center rounded-lg font-medium transition-colors",
+          "inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
           "focus-visible:ring-zinc-400 disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
           {
@@ -30,7 +35,10 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         ref={ref}
         {...props}
-      />
+      >
+        {isLoading && <Loader2 className="animate-spin" size={16} aria-hidden="true" />}
+        {children}
+      </button>
     );
   }
 );


### PR DESCRIPTION
closes #431 

### Changes Summary
- Added `Loader2` import from `lucide-react`.
- Defined `CONFLICT_STATUS = 409` constant to avoid magic numbers.
- Added `submittingRef` (`useRef(false)`) — a ref-based lock that blocks concurrent in-flight submissions even before React state re-renders (handles rapid double-clicks and slow networks without relying solely on state).
- Rewrote `handleRequestExport`:
  - Early-return guard checks `submittingRef.current || requestingExport || hasInProgressJob`.
  - Sets `submittingRef.current = true` immediately, cleared in `finally`.
  - Clears `error` before each attempt.
  - On `409 Conflict`, shows an info toast and re-syncs history instead of showing an error banner (reconciles optimistic UI with server state).
  - On any other error, shows the error banner.
  - Shows a success toast on submission.
- "Generate New Archive" button: added `aria-disabled`, `aria-live="polite"`, spinner (`Loader2`) when `requestingExport`, `disabled:cursor-not-allowed`.
- Active-export notice now shows a `Clock3` icon and a clearer message: *"the button will re-enable once it completes."*
- "Request New Link" row button: also guards against `hasInProgressJob` and shows spinner.

- Added `isLoading?: boolean` prop to `ButtonProps`.
- Button auto-disables and sets `aria-disabled` when `isLoading` is `true`.
- Renders a `Loader2` spinner before children when `isLoading`.
- Added `gap-2` to the flex layout to space the spinner from label text.

- Imported `ConflictException`.
- Added a **pre-check** at the top of `requestExport`: queries for any `PENDING` or `PROCESSING` job for the user and throws `ConflictException` (→ HTTP 409) if found, **before** the 7-day rate-limit check (which remains `BadRequestException` → HTTP 400). This gives the frontend a distinct, unambiguous signal to sync state rather than show an error.


- Imported `ConflictException`.
- Added a new `Request Export Endpoint` describe block with 4 tests:
  1. Happy-path: creates a new job.
  2. `ConflictException` propagation when an active job exists (409).
  3. `BadRequestException` propagation for the 7-day rate limit (400).
  4. Concurrent double-submission: first call succeeds, second call raises `ConflictException` — verifies the service is called exactly twice and the first result is fulfilled.