### PR TITLE
test(encryption): cover invalid ciphertext shapes and key size valida…

### DIFF
--- a/xconfess-backend/src/encryption/encryption.service.spec.ts
+++ b/xconfess-backend/src/encryption/encryption.service.spec.ts
@@ -4,16 +4,16 @@ import { EncryptionService } from './encryption.service';
 
 describe('EncryptionService', () => {
   let service: EncryptionService;
+  const validEncryptionKey =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
   const mockConfigService = {
-    get: jest
-      .fn()
-      .mockReturnValue(
-        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-      ),
+    get: jest.fn(),
   };
 
   beforeEach(async () => {
+    mockConfigService.get.mockReturnValue(validEncryptionKey);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EncryptionService,
@@ -67,5 +67,59 @@ describe('EncryptionService', () => {
 
   it('should throw error for invalid encrypted format', () => {
     expect(() => service.decrypt('invalid-format')).toThrow();
+  });
+
+  it('should reject ciphertext values with invalid payload shape', () => {
+    const invalidCiphertexts = [
+      'deadbeef',
+      'deadbeef:',
+      ':deadbeef:cafebabe',
+      'deadbeef:feedface:',
+      'deadbeef:feedface:cafebabe:extra',
+    ];
+
+    for (const ciphertext of invalidCiphertexts) {
+      expect(() => service.decrypt(ciphertext)).toThrow(
+        'Invalid encrypted data format',
+      );
+    }
+  });
+
+  it('should throw for malformed ciphertext parts with valid shape', () => {
+    const malformedCiphertexts = [
+      'not-hex:abcdef0123456789abcdef01234567:cafebabe',
+      '0011:invalid-tag:cafebabe',
+      '00112233445566778899aabbccddeeff:00112233445566778899aabbccddeeff:zz',
+    ];
+
+    for (const ciphertext of malformedCiphertexts) {
+      expect(() => service.decrypt(ciphertext)).toThrow();
+    }
+  });
+
+  it('should enforce ENCRYPTION_KEY presence at construction time', async () => {
+    mockConfigService.get.mockReturnValue(undefined);
+
+    await expect(
+      Test.createTestingModule({
+        providers: [
+          EncryptionService,
+          { provide: ConfigService, useValue: mockConfigService },
+        ],
+      }).compile(),
+    ).rejects.toThrow('ENCRYPTION_KEY must be set in environment variables');
+  });
+
+  it('should enforce ENCRYPTION_KEY size at construction time', async () => {
+    mockConfigService.get.mockReturnValue('001122');
+
+    await expect(
+      Test.createTestingModule({
+        providers: [
+          EncryptionService,
+          { provide: ConfigService, useValue: mockConfigService },
+        ],
+      }).compile(),
+    ).rejects.toThrow('ENCRYPTION_KEY must be 32 bytes (64 hex characters)');
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests for invalid encrypted payload shapes in `EncryptionService.decrypt()`
- add unit tests for malformed ciphertext segments (invalid IV/authTag/cipher hex data)
- add constructor validation tests for missing and invalid-size `ENCRYPTION_KEY`

## Why
Encryption should fail fast and predictably on bad input. These tests lock in deterministic rejection behavior for invalid ciphertext formats and enforce key-size constraints during service initialization.

## Test plan
- [x] Run `pnpm --dir xconfess-backend run test -- src/encryption/encryption.service.spec.ts`
- [x] Verify new tests pass:
  - invalid shape ciphertexts reject with `Invalid encrypted data format`
  - malformed 3-part ciphertexts throw
  - missing key throws expected error
  - short key throws expected error
- [x] Run full backend test suite if needed

Closes: #523 