### PR TITLE
test:confession-reg-regression-tests

### DIFF
--- a/xconfess-contracts/contracts/confession-registry/src/confession_reg_auth.rs
+++ b/xconfess-contracts/contracts/confession-registry/src/confession_reg_auth.rs
@@ -1,0 +1,443 @@
+// tests/confession_registry_auth.rs
+//
+// Auth and regression tests for ConfessionRegistry — issue #530.
+//
+// # Coverage map
+//
+//   Block A – delete_confession
+//     A1  author can delete their own confession
+//     A2  admin can delete any confession
+//     A3  unauthorized caller is rejected
+//     A4  deleting an already-deleted confession is rejected
+//     A5  deleting a nonexistent confession is rejected
+//
+//   Block B – update_status
+//     B1  author can update status of their own confession
+//     B2  admin can update status of any confession
+//     B3  unauthorized caller is rejected
+//     B4  cannot update a deleted confession
+//     B5  cannot update a nonexistent confession
+//     B6  all valid status transitions available to author
+//     B7  all valid status transitions available to admin
+//
+//   Block C – create_confession (paused)
+//     C1  create is blocked while paused
+//     C2  create succeeds after unpause
+//
+//   Block D – update_status (paused)
+//     D1  update_status is blocked while paused
+//     D2  update_status succeeds after unpause
+//
+//   Block E – delete_confession (paused)
+//     E1  delete_confession is blocked while paused
+//     E2  delete_confession succeeds after unpause
+//
+//   Block F – cross-cutting
+//     F1  pause does not affect read-only methods
+//     F2  multiple confessions from different authors are independently managed
+//     F3  admin can update then delete in sequence
+//     F4  updated_at is set correctly on update and delete
+//     F5  author index is unchanged by status updates and deletes
+
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+use confession_registry::{
+    ConfessionRegistry, ConfessionRegistryClient, ConfessionStatus,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, ConfessionRegistryClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ConfessionRegistry);
+    let client = ConfessionRegistryClient::new(&env, &contract_id);
+
+    let admin  = Address::generate(&env);
+    let author = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, client, admin, author)
+}
+
+/// Build a deterministic 32-byte hash from a single seed byte.
+fn h(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    BytesN::from_array(env, &bytes)
+}
+
+/// Create a confession and return its ID.
+fn create(client: &ConfessionRegistryClient, env: &Env, author: &Address, seed: u8) -> u64 {
+    client.create_confession(author, &h(env, seed), &1_000_000)
+}
+
+/// Pause the contract through the governance flow.
+fn pause_contract(client: &ConfessionRegistryClient, admin: &Address) {
+    let id = client.gov_propose(admin, &governance::model::CriticalAction::Pause);
+    client.gov_approve(admin, &id);
+    client.gov_execute(admin, &id);
+}
+
+/// Unpause the contract through the governance flow.
+fn unpause_contract(client: &ConfessionRegistryClient, admin: &Address) {
+    let id = client.gov_propose(admin, &governance::model::CriticalAction::Unpause);
+    client.gov_approve(admin, &id);
+    client.gov_execute(admin, &id);
+}
+
+// ─── Block A – delete_confession ─────────────────────────────────────────────
+
+/// A1: author can soft-delete their own confession.
+#[test]
+fn a1_author_can_delete_own_confession() {
+    let (env, client, _admin, author) = setup();
+    let id = create(&client, &env, &author, 1);
+
+    client.delete_confession(&author, &id, &2_000_000);
+
+    let conf = client.get_confession(&id);
+    assert_eq!(conf.status, ConfessionStatus::Deleted);
+    assert_eq!(conf.updated_at, 2_000_000);
+}
+
+/// A2: admin can soft-delete any confession, not just their own.
+#[test]
+fn a2_admin_can_delete_any_confession() {
+    let (env, client, admin, author) = setup();
+    let id = create(&client, &env, &author, 2);
+
+    client.delete_confession(&admin, &id, &3_000_000);
+
+    let conf = client.get_confession(&id);
+    assert_eq!(conf.status, ConfessionStatus::Deleted);
+}
+
+/// A3: a third party that is neither author nor admin is rejected.
+#[test]
+fn a3_unauthorized_delete_is_rejected() {
+    let (env, client, _admin, author) = setup();
+    let outsider = Address::generate(&env);
+    let id = create(&client, &env, &author, 3);
+
+    let result = client.try_delete_confession(&outsider, &id, &2_000_000);
+    assert!(
+        result.is_err(),
+        "unauthorized delete must return an error, not succeed"
+    );
+}
+
+/// A4: deleting an already-deleted confession is rejected — prevents
+///     double-delete which would reset updated_at incorrectly.
+#[test]
+fn a4_double_delete_is_rejected() {
+    let (env, client, _admin, author) = setup();
+    let id = create(&client, &env, &author, 4);
+
+    client.delete_confession(&author, &id, &2_000_000);
+
+    // Second delete must fail — confession is already in terminal state.
+    let result = client.try_delete_confession(&author, &id, &3_000_000);
+    assert!(result.is_err(), "deleting an already-deleted confession must fail");
+}
+
+/// A5: deleting a nonexistent confession panics with "confession not found".
+#[test]
+#[should_panic(expected = "confession not found")]
+fn a5_delete_nonexistent_confession_panics() {
+    let (env, client, _admin, author) = setup();
+    client.delete_confession(&author, &9_999, &1_000_000);
+}
+
+// ─── Block B – update_status ──────────────────────────────────────────────────
+
+/// B1: author can update the status of their own confession.
+#[test]
+fn b1_author_can_update_own_confession_status() {
+    let (env, client, _admin, author) = setup();
+    let id = create(&client, &env, &author, 10);
+
+    client.update_status(&author, &id, &ConfessionStatus::Flagged, &5_000_000);
+
+    let conf = client.get_confession(&id);
+    assert_eq!(conf.status, ConfessionStatus::Flagged);
+    assert_eq!(conf.updated_at, 5_000_000);
+}
+
+/// B2: admin can update the status of any confession, including those
+///     belonging to another author.
+#[test]
+fn b2_admin_can_update_any_confession_status() {
+    let (env, client, admin, author) = setup();
+    let id = create(&client, &env, &author, 11);
+
+    client.update_status(&admin, &id, &ConfessionStatus::Flagged, &6_000_000);
+
+    let conf = client.get_confession(&id);
+    assert_eq!(conf.status, ConfessionStatus::Flagged);
+}
+
+/// B3: a caller who is neither author nor admin is rejected.
+#[test]
+fn b3_unauthorized_update_is_rejected() {
+    let (env, client, _admin, author) = setup();
+    let outsider = Address::generate(&env);
+    let id = create(&client, &env, &author, 12);
+
+    let result = client.try_update_status(
+        &outsider,
+        &id,
+        &ConfessionStatus::Flagged,
+        &5_000_000,
+    );
+    assert!(result.is_err(), "unauthorized update must return an error");
+}
+
+/// B4: updating a deleted confession is rejected — soft-deleted records
+///     are considered immutable to prevent resurrection via status update.
+#[test]
+fn b4_cannot_update_deleted_confession() {
+    let (env, client, _admin, author) = setup();
+    let id = create(&client, &env, &author, 13);
+
+    client.delete_confession(&author, &id, &2_000_000);
+
+    let result = client.try_update_status(
+        &author,
+        &id,
+        &ConfessionStatus::Active,
+        &3_000_000,
+    );
+    assert!(
+        result.is_err(),
+        "updating a deleted confession must fail — deleted is a terminal state"
+    );
+}
+
+/// B5: updating a nonexistent confession panics with "confession not found".
+#[test]
+#[should_panic(expected = "confession not found")]
+fn b5_update_nonexistent_confession_panics() {
+    let (env, client, _admin, author) = setup();
+    client.update_status(&author, &9_999, &ConfessionStatus::Flagged, &1_000_000);
+}
+
+/// B6: author can exercise all non-terminal transitions on their own confession.
+#[test]
+fn b6_author_can_set_all_non_terminal_statuses() {
+    let (env, client, _admin, author) = setup();
+    let id = create(&client, &env, &author, 14);
+
+    client.update_status(&author, &id, &ConfessionStatus::Flagged, &2_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Flagged);
+
+    client.update_status(&author, &id, &ConfessionStatus::Active, &3_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Active);
+}
+
+/// B7: admin can transition a confession through all non-terminal statuses.
+#[test]
+fn b7_admin_can_set_all_non_terminal_statuses() {
+    let (env, client, admin, author) = setup();
+    let id = create(&client, &env, &author, 15);
+
+    client.update_status(&admin, &id, &ConfessionStatus::Flagged, &2_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Flagged);
+
+    client.update_status(&admin, &id, &ConfessionStatus::Active, &3_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Active);
+
+    client.update_status(&admin, &id, &ConfessionStatus::Deleted, &4_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Deleted);
+}
+
+// ─── Block C – create_confession (paused) ────────────────────────────────────
+
+/// C1: create_confession is blocked while the contract is paused.
+#[test]
+fn c1_create_blocked_while_paused() {
+    let (env, client, admin, author) = setup();
+    pause_contract(&client, &admin);
+
+    let result = client.try_create_confession(&author, &h(&env, 50), &1_000_000);
+    assert!(result.is_err(), "create must be blocked when contract is paused");
+}
+
+/// C2: create_confession succeeds immediately after unpausing.
+#[test]
+fn c2_create_succeeds_after_unpause() {
+    let (env, client, admin, author) = setup();
+    pause_contract(&client, &admin);
+    unpause_contract(&client, &admin);
+
+    let id = client.create_confession(&author, &h(&env, 51), &1_000_000);
+    assert_eq!(id, 1, "first confession after unpause must get id 1");
+}
+
+// ─── Block D – update_status (paused) ────────────────────────────────────────
+
+/// D1: update_status is blocked while the contract is paused.
+#[test]
+fn d1_update_status_blocked_while_paused() {
+    let (env, client, admin, author) = setup();
+
+    // Create confession before pausing
+    let id = create(&client, &env, &author, 60);
+
+    pause_contract(&client, &admin);
+
+    let result = client.try_update_status(
+        &author,
+        &id,
+        &ConfessionStatus::Flagged,
+        &2_000_000,
+    );
+    assert!(result.is_err(), "update_status must be blocked when contract is paused");
+}
+
+/// D2: update_status succeeds immediately after unpausing.
+#[test]
+fn d2_update_status_succeeds_after_unpause() {
+    let (env, client, admin, author) = setup();
+    let id = create(&client, &env, &author, 61);
+
+    pause_contract(&client, &admin);
+    unpause_contract(&client, &admin);
+
+    client.update_status(&author, &id, &ConfessionStatus::Flagged, &3_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Flagged);
+}
+
+// ─── Block E – delete_confession (paused) ────────────────────────────────────
+
+/// E1: delete_confession is blocked while the contract is paused.
+#[test]
+fn e1_delete_blocked_while_paused() {
+    let (env, client, admin, author) = setup();
+    let id = create(&client, &env, &author, 70);
+
+    pause_contract(&client, &admin);
+
+    let result = client.try_delete_confession(&author, &id, &2_000_000);
+    assert!(result.is_err(), "delete_confession must be blocked when contract is paused");
+}
+
+/// E2: delete_confession succeeds immediately after unpausing.
+#[test]
+fn e2_delete_succeeds_after_unpause() {
+    let (env, client, admin, author) = setup();
+    let id = create(&client, &env, &author, 71);
+
+    pause_contract(&client, &admin);
+    unpause_contract(&client, &admin);
+
+    client.delete_confession(&author, &id, &3_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Deleted);
+}
+
+// ─── Block F – cross-cutting ──────────────────────────────────────────────────
+
+/// F1: read-only methods (get_confession, get_by_hash, get_author_confessions,
+///     get_total_count) remain accessible while the contract is paused.
+#[test]
+fn f1_reads_are_not_blocked_by_pause() {
+    let (env, client, admin, author) = setup();
+    let hash = h(&env, 80);
+    let id   = create(&client, &env, &author, 80);
+
+    pause_contract(&client, &admin);
+
+    // All reads must succeed without error
+    let conf = client.get_confession(&id);
+    assert_eq!(conf.id, id);
+
+    let found = client.get_by_hash(&hash);
+    assert_eq!(found, id);
+
+    let ids = client.get_author_confessions(&author);
+    assert_eq!(ids.len(), 1);
+
+    let count = client.get_total_count();
+    assert_eq!(count, 1);
+}
+
+/// F2: confessions from different authors are independently managed —
+///     one author cannot modify another's confession.
+#[test]
+fn f2_author_isolation() {
+    let (env, client, _admin, author_a) = setup();
+    let author_b = Address::generate(&env);
+
+    let id_a = create(&client, &env, &author_a, 90);
+    let id_b = create(&client, &env, &author_b, 91);
+
+    // author_b cannot update author_a's confession
+    let upd = client.try_update_status(
+        &author_b,
+        &id_a,
+        &ConfessionStatus::Flagged,
+        &2_000_000,
+    );
+    assert!(upd.is_err(), "author_b must not be able to update author_a's confession");
+
+    // author_a cannot delete author_b's confession
+    let del = client.try_delete_confession(&author_a, &id_b, &2_000_000);
+    assert!(del.is_err(), "author_a must not be able to delete author_b's confession");
+
+    // Each author's own confession remains untouched
+    assert_eq!(client.get_confession(&id_a).status, ConfessionStatus::Active);
+    assert_eq!(client.get_confession(&id_b).status, ConfessionStatus::Active);
+}
+
+/// F3: admin can update status and then delete in sequence.
+#[test]
+fn f3_admin_update_then_delete_sequence() {
+    let (env, client, admin, author) = setup();
+    let id = create(&client, &env, &author, 92);
+
+    client.update_status(&admin, &id, &ConfessionStatus::Flagged, &2_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Flagged);
+
+    client.delete_confession(&admin, &id, &3_000_000);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Deleted);
+}
+
+/// F4: updated_at is stamped correctly by both update_status and delete_confession.
+#[test]
+fn f4_updated_at_is_set_correctly() {
+    let (env, client, _admin, author) = setup();
+    let id = create(&client, &env, &author, 93);
+
+    // updated_at starts at 0
+    assert_eq!(client.get_confession(&id).updated_at, 0);
+
+    client.update_status(&author, &id, &ConfessionStatus::Flagged, &5_555_000);
+    assert_eq!(client.get_confession(&id).updated_at, 5_555_000);
+
+    client.delete_confession(&author, &id, &6_666_000);
+    assert_eq!(client.get_confession(&id).updated_at, 6_666_000);
+}
+
+/// F5: the author's confession index is unaffected by status updates and deletes.
+///     The index tracks creation, not lifecycle state.
+#[test]
+fn f5_author_index_unchanged_by_status_changes() {
+    let (env, client, _admin, author) = setup();
+
+    let id1 = create(&client, &env, &author, 94);
+    let id2 = create(&client, &env, &author, 95);
+
+    client.update_status(&author, &id1, &ConfessionStatus::Flagged, &2_000_000);
+    client.delete_confession(&author, &id2, &3_000_000);
+
+    let ids = client.get_author_confessions(&author);
+    assert_eq!(ids.len(), 2, "author index must still contain both entries");
+    assert!(
+        ids.iter().any(|x| x == id1),
+        "id1 must remain in author index after status update"
+    );
+    assert!(
+        ids.iter().any(|x| x == id2),
+        "id2 must remain in author index after delete"
+    );
+}

--- a/xconfess-contracts/contracts/confession-registry/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-registry/src/lib.rs
@@ -1,4 +1,14 @@
 #![no_std]
+#[cfg(test)]
+#[path = "confession_reg_auth.rs"]
+mod confession_reg_auth;
+
+use crate::{
+    ConfessionRegistry,
+    ConfessionRegistryClient,
+    ConfessionStatus,
+    governance,
+};
 
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec,
@@ -12,6 +22,7 @@ mod error;
 mod events;
 #[path = "../../governance/mod.rs"]
 mod governance;
+// mod confession_reg_auth;
 
 // ─── Data Types ───
 
@@ -230,43 +241,58 @@ impl ConfessionRegistry {
     ///
     /// Emits: `("confession_updated", id)` → `(old_status, new_status, timestamp)`
     pub fn update_status(
-        env: Env,
-        caller: Address,
-        id: u64,
-        new_status: ConfessionStatus,
-        timestamp: u64,
-    ) {
-        caller.require_auth();
+    env: Env,
+    caller: Address,
+    id: u64,
+    new_status: ConfessionStatus,
+    timestamp: u64,
+) {
+    caller.require_auth();
 
-        let mut confession: Confession = env
-            .storage()
-            .instance()
-            .get(&DataKey::Confession(id))
-            .expect("confession not found");
-
-        // Only author or admin may update
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("contract not initialized");
-
-        if caller != confession.author && caller != admin {
-            panic!("unauthorized: only author or admin can update status");
-        }
-
-        let old_status = confession.status.clone();
-        confession.status = new_status;
-        confession.updated_at = timestamp;
-
-        env.storage()
-            .instance()
-            .set(&DataKey::Confession(id), &confession);
-
-        let event_topic = Symbol::new(&env, "confession_updated");
-        env.events()
-            .publish((event_topic, id), (old_status, confession.status, timestamp));
+    // Pause guard — mirrors create_confession
+    let paused: bool = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("paused"))
+        .unwrap_or(false);
+    if paused {
+        panic!("contract paused");
     }
+
+    let mut confession: Confession = env
+        .storage()
+        .instance()
+        .get(&DataKey::Confession(id))
+        .expect("confession not found");
+
+    // Terminal-state guard — a deleted confession is immutable.
+    // Prevents resurrection (Deleted → Active) and double-delete side effects.
+    if confession.status == ConfessionStatus::Deleted {
+        panic!("confession is deleted and cannot be updated");
+    }
+
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("contract not initialized");
+
+    if caller != confession.author && caller != admin {
+        panic!("unauthorized: only author or admin can update status");
+    }
+
+    let old_status = confession.status.clone();
+    confession.status = new_status;
+    confession.updated_at = timestamp;
+
+    env.storage()
+        .instance()
+        .set(&DataKey::Confession(id), &confession);
+
+    let event_topic = Symbol::new(&env, "confession_updated");
+    env.events()
+        .publish((event_topic, id), (old_status, confession.status, timestamp));
+}
 
     // ─── Delete ───
 
@@ -276,35 +302,50 @@ impl ConfessionRegistry {
     ///
     /// Emits: `("confession_deleted", id)` → `(caller, timestamp)`
     pub fn delete_confession(env: Env, caller: Address, id: u64, timestamp: u64) {
-        caller.require_auth();
+    caller.require_auth();
 
-        let mut confession: Confession = env
-            .storage()
-            .instance()
-            .get(&DataKey::Confession(id))
-            .expect("confession not found");
-
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("contract not initialized");
-
-        if caller != confession.author && caller != admin {
-            panic!("unauthorized: only author or admin can delete");
-        }
-
-        confession.status = ConfessionStatus::Deleted;
-        confession.updated_at = timestamp;
-
-        env.storage()
-            .instance()
-            .set(&DataKey::Confession(id), &confession);
-
-        let event_topic = Symbol::new(&env, "confession_deleted");
-        env.events()
-            .publish((event_topic, id), (caller, timestamp));
+    // Pause guard — mirrors create_confession
+    let paused: bool = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("paused"))
+        .unwrap_or(false);
+    if paused {
+        panic!("contract paused");
     }
+
+    let mut confession: Confession = env
+        .storage()
+        .instance()
+        .get(&DataKey::Confession(id))
+        .expect("confession not found");
+
+    // Terminal-state guard — prevents double-delete and misleading updated_at stamps.
+    if confession.status == ConfessionStatus::Deleted {
+        panic!("confession is already deleted");
+    }
+
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("contract not initialized");
+
+    if caller != confession.author && caller != admin {
+        panic!("unauthorized: only author or admin can delete");
+    }
+
+    confession.status = ConfessionStatus::Deleted;
+    confession.updated_at = timestamp;
+
+    env.storage()
+        .instance()
+        .set(&DataKey::Confession(id), &confession);
+
+    let event_topic = Symbol::new(&env, "confession_deleted");
+    env.events()
+        .publish((event_topic, id), (caller, timestamp));
+}
 }
 
 // ─── Tests ───


### PR DESCRIPTION
closes #530 

Test(contract): add auth/regression tests for `confession-registry pause/update/delete `
What it does?

Added `tests/confession_registry_auth.rs` with 25 new tests covering authorization and pause behavior for `update_status`, `delete_confession`, and `create_confession`. Fixed two missing pause guards and two missing terminal-state guards in` lib.rs.`