### PR TITLE
FE: standardize API base URL and env resolution across client code an…

### DIFF
--- a/xconfess-frontend/README.md
+++ b/xconfess-frontend/README.md
@@ -78,7 +78,15 @@ logout();
 
 ```env
 # xconfess-frontend/.env.local
+
+# Server-side backend API URL (used by API routes)
+BACKEND_API_URL=http://localhost:5000
+
+# Client-side API URL (used by client-side code)
 NEXT_PUBLIC_API_URL=http://localhost:5000
+
+# WebSocket URL (used by client-side WebSocket connections)
+NEXT_PUBLIC_WS_URL=http://localhost:3001
 ```
 
 ### Note on /api/auth/* route

--- a/xconfess-frontend/app/(dashboard)/admin/layout.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/layout.tsx
@@ -7,6 +7,7 @@ import { io, Socket } from "socket.io-client";
 import { useQueryClient } from "@tanstack/react-query";
 import { AUTH_TOKEN_KEY, USER_DATA_KEY } from "@/app/lib/api/constants";
 import { useFocusTrap } from "@/app/lib/hooks/useFocusTrap";
+import { getApiBaseUrl } from "@/app/lib/config";
 
 function isMockAdminEnabled(): boolean {
   if (process.env.NEXT_PUBLIC_ADMIN_MOCK === "true") return true;
@@ -83,7 +84,7 @@ export default function AdminLayout({
         : null;
     if (!token) return;
 
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+    const baseUrl = getApiBaseUrl();
     if (!baseUrl) return;
 
     const socket: Socket = io(`${baseUrl}/admin`, {

--- a/xconfess-frontend/app/api/analytics/route.ts
+++ b/xconfess-frontend/app/api/analytics/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import axios from 'axios';
+import { getApiBaseUrl } from '@/app/lib/config';
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const BACKEND_URL = getApiBaseUrl();
 
 type ComparisonAvailability = 'available' | 'estimated' | 'unavailable';
 type DeltaDirection = 'up' | 'down' | 'flat' | 'unknown';

--- a/xconfess-frontend/app/api/auth/session/route.ts
+++ b/xconfess-frontend/app/api/auth/session/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
+const API_URL = getApiBaseUrl();
 const SESSION_COOKIE_NAME = "xconfess_session";
 
 export async function POST(request: Request) {

--- a/xconfess-frontend/app/api/client.ts
+++ b/xconfess-frontend/app/api/client.ts
@@ -8,7 +8,9 @@ export interface TemplateRollout {
   lastValidationFailure?: string;
 }
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api';
+import { getApiBaseUrl } from '@/app/lib/config';
+
+const API_BASE_URL = getApiBaseUrl();
 
 async function fetchApi<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;

--- a/xconfess-frontend/app/api/comments/[confessionId]/route.ts
+++ b/xconfess-frontend/app/api/comments/[confessionId]/route.ts
@@ -1,4 +1,6 @@
-const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BASE_API_URL = getApiBaseUrl();
 
 export async function POST(
   request: Request,

--- a/xconfess-frontend/app/api/comments/by-confession/[confessionId]/route.ts
+++ b/xconfess-frontend/app/api/comments/by-confession/[confessionId]/route.ts
@@ -1,4 +1,6 @@
-const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BASE_API_URL = getApiBaseUrl();
 
 export async function GET(
   _request: Request,

--- a/xconfess-frontend/app/api/confessions/[id]/anchor/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/anchor/route.ts
@@ -1,4 +1,6 @@
-const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BASE_API_URL = getApiBaseUrl();
 
 export async function POST(
   request: Request,

--- a/xconfess-frontend/app/api/confessions/[id]/react/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/react/route.ts
@@ -3,9 +3,9 @@ import {
   isValidReactionType,
   REACTION_EMOJI_MAP,
 } from "@/app/lib/constants/reactions";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL =
-  process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+const BASE_API_URL = getApiBaseUrl();
 
 /**
  * POST /api/confessions/[id]/react

--- a/xconfess-frontend/app/api/confessions/[id]/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/route.ts
@@ -1,4 +1,6 @@
-const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BASE_API_URL = getApiBaseUrl();
 
 export async function GET(
   _request: Request,

--- a/xconfess-frontend/app/api/confessions/search/route.ts
+++ b/xconfess-frontend/app/api/confessions/search/route.ts
@@ -1,4 +1,6 @@
-const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BASE_API_URL = getApiBaseUrl();
 
 function parseNumber(value: unknown, fallback: number): number {
   if (typeof value === "number" && Number.isFinite(value)) return value;

--- a/xconfess-frontend/app/lib/api/auth.ts
+++ b/xconfess-frontend/app/lib/api/auth.ts
@@ -1,5 +1,7 @@
 import { AUTH_TOKEN_KEY } from "./constants";
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const API_URL = getApiBaseUrl();
 
 export interface AuthTokenPayload {
   sub: string;

--- a/xconfess-frontend/app/lib/api/authService.ts
+++ b/xconfess-frontend/app/lib/api/authService.ts
@@ -14,8 +14,9 @@ import {
     RegisterResponse,
     User,
 } from '../types/auth';
+import { getApiBaseUrl } from '@/app/lib/config';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_URL = getApiBaseUrl();
 
 /**
  * Axios instance for API calls

--- a/xconfess-frontend/app/lib/api/client.ts
+++ b/xconfess-frontend/app/lib/api/client.ts
@@ -2,9 +2,10 @@ import axios, { AxiosError, AxiosResponse } from "axios";
 import { logError } from "@/app/lib/utils/errorHandler";
 import { AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY } from "./constants";
 import { useAuthStore } from "@/app/lib/store/authStore";
+import { getApiBaseUrl } from "@/app/lib/config";
 
 const apiClient = axios.create({
-	baseURL: process.env.NEXT_PUBLIC_API_URL,
+	baseURL: getApiBaseUrl(),
 	headers: { "Content-Type": "application/json" },
 	timeout: 30000,
 });

--- a/xconfess-frontend/app/lib/config.ts
+++ b/xconfess-frontend/app/lib/config.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical Backend URL Resolution
+ * Server-side: Uses BACKEND_API_URL (private)
+ * Client-side: Uses NEXT_PUBLIC_API_URL (public)
+ */
+
+export const getApiBaseUrl = (): string => {
+  // 1. Server-side check
+  if (typeof window === 'undefined') {
+    const serverUrl = process.env.BACKEND_API_URL;
+    if (!serverUrl) {
+      throw new Error("Missing BACKEND_API_URL environment variable on server.");
+    }
+    return serverUrl;
+  }
+
+  // 2. Client-side check
+  const clientUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!clientUrl) {
+    // We avoid hardcoded localhost fallbacks here to fail fast in dev/preview
+    throw new Error("Missing NEXT_PUBLIC_API_URL environment variable on client.");
+  }
+  return clientUrl;
+};
+
+/**
+ * Canonical WebSocket URL Resolution
+ * Client-side: Uses NEXT_PUBLIC_WS_URL (public)
+ */
+export const getWsUrl = (): string => {
+  if (typeof window === 'undefined') {
+    throw new Error("WebSocket URL is only available on client-side.");
+  }
+
+  const wsUrl = process.env.NEXT_PUBLIC_WS_URL;
+  if (!wsUrl) {
+    throw new Error("Missing NEXT_PUBLIC_WS_URL environment variable on client.");
+  }
+  return wsUrl;
+};

--- a/xconfess-frontend/app/lib/hooks/useNotifications.ts
+++ b/xconfess-frontend/app/lib/hooks/useNotifications.ts
@@ -9,8 +9,9 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { io, Socket } from "socket.io-client";
 import { notificationApi } from "@/app/lib/api/notification";
 import { useApiError } from "@/app/lib/hooks/useApiError";
+import { getWsUrl } from "@/app/lib/config";
 
-const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "http://localhost:3001";
+const WS_URL = getWsUrl();
 
 interface UseNotificationsReturn {
   notifications: Notification[];


### PR DESCRIPTION
This PR unifies the backend origin resolution strategy across the frontend. It replaces fragmented logic and hardcoded localhost fallbacks with a single, canonical configuration utility that handles both Server-side (App Router/Node) and Client-side (Browser) environments.

The Problem
The codebase currently relies on a mix of BACKEND_API_URL, NEXT_PUBLIC_API_URL, and various hardcoded defaults (:3000, :5000, :8000). This inconsistency leads to:

Environment Drift: Server-side route handlers and client-side Axios instances disagreeing on the API location.

Silent Failures: Production builds attempting to hit localhost because a fallback was triggered instead of an error.

Maintenance Overhead: Updating the API URL required changes across multiple files in app/api/* and lib/*.

Changes
⚙️ Core Configuration
Created app/lib/config.ts to serve as the single source of truth for the API base URL.

Implemented a fail-fast approach: the app will now throw a descriptive error if environment variables are missing, rather than falling back to hardcoded strings.

🔌 API Clients & Services
Refactored app/lib/api/client.ts and app/api/client.ts to use the unified getApiBaseUrl() utility.

Updated authService.ts to ensure consistent URL resolution during the authentication flow.

🛣️ Route Handlers (Proxies)
Standardized app/api/confessions/route.ts, app/api/auth/session/route.ts, and app/api/analytics/route.ts.

These routes now consistently use the server-side environment variable to communicate with the backend.

🧹 Cleanup & Docs
Removed all instances of hardcoded localhost strings from runtime code paths.

Updated .env.example to clearly define BACKEND_API_URL (Server) vs NEXT_PUBLIC_API_URL (Client).

Verification Plan
Local Dev: Verify that setting BACKEND_API_URL=http://localhost:5000 in .env allows the frontend to boot and fetch data correctly.

Build Check: Run npm run build to ensure no environment variable leaks or missing config errors occur during the build step.

Proxy Test: Verify that App Router proxies (e.g., /api/confessions) correctly forward requests to the backend origin defined in the server environment.

Checklist
[x] No hardcoded :5000 or :8000 remaining in app/

[x] Server-side routes use BACKEND_API_URL

[x] Client-side components use NEXT_PUBLIC_API_URL

[x] .env.example updated

Closes #615 