### PR TITLE
security(backend): allowlist and audit Stellar invoke-contract (#655)

### DIFF
--- a/xconfess-backend/migrations/20260329000100-add-stellar-contract-invocation-audit-action.ts
+++ b/xconfess-backend/migrations/20260329000100-add-stellar-contract-invocation-audit-action.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStellarContractInvocationAuditAction20260329000100
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM pg_type t
+          WHERE t.typname = 'audit_logs_action_enum'
+        ) THEN
+          ALTER TYPE "audit_logs_action_enum" ADD VALUE IF NOT EXISTS 'stellar_contract_invocation';
+        END IF;
+      END
+      $$;
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // Postgres enum values are not removed safely in a reversible way.
+  }
+}

--- a/xconfess-backend/src/audit-log/audit-log.entity.ts
+++ b/xconfess-backend/src/audit-log/audit-log.entity.ts
@@ -59,6 +59,9 @@ export enum AuditActionType {
   EXPORT_GENERATION_COMPLETED = 'export_generation_completed',
   EXPORT_LINK_REFRESHED = 'export_link_refreshed',
   EXPORT_DOWNLOADED = 'export_downloaded',
+
+  /** Privileged Stellar server-signed contract invocation */
+  STELLAR_CONTRACT_INVOCATION = 'stellar_contract_invocation',
 }
 
 @Entity('audit_logs')

--- a/xconfess-backend/src/audit-log/audit-log.service.ts
+++ b/xconfess-backend/src/audit-log/audit-log.service.ts
@@ -646,9 +646,9 @@ export class AuditLogService {
         .getMany();
 
       return logs;
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(
-        `Failed to find audit logs by entity: ${error.message}`,
+        `Failed to find audit logs by entity: ${error instanceof Error ? error.message : String(error)}`,
       );
       return [];
     }
@@ -669,8 +669,10 @@ export class AuditLogService {
         order: { createdAt: 'DESC' },
         relations: ['admin'],
       });
-    } catch (error) {
-      this.logger.error(`Failed to find audit logs by user: ${error.message}`);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to find audit logs by user: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return [];
     }
   }
@@ -805,8 +807,10 @@ export class AuditLogService {
         limit: options.limit || 100,
         offset: options.offset || 0,
       };
-    } catch (error) {
-      this.logger.error(`Failed to get audit logs: ${error.message}`);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to get audit logs: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return {
         logs: [],
         total: 0,
@@ -858,8 +862,10 @@ export class AuditLogService {
         totalLogs,
         actionTypeCounts,
       };
-    } catch (error) {
-      this.logger.error(`Failed to get audit log statistics: ${error.message}`);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to get audit log statistics: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return {
         totalLogs: 0,
         actionTypeCounts: [],
@@ -940,9 +946,9 @@ export class AuditLogService {
         limit: options.limit || 100,
         offset: options.offset || 0,
       };
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error(
-        `Failed to get template rollout history: ${error.message}`,
+        `Failed to get template rollout history: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         logs: [],
@@ -1036,8 +1042,10 @@ export class AuditLogService {
         limit: options.limit || 100,
         offset: options.offset || 0,
       };
-    } catch (error) {
-      this.logger.error(`Failed to get export access trail: ${error.message}`);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to get export access trail: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return {
         logs: [],
         total: 0,

--- a/xconfess-backend/src/stellar/__tests__/contract.service.spec.ts
+++ b/xconfess-backend/src/stellar/__tests__/contract.service.spec.ts
@@ -1,5 +1,6 @@
-// src/stellar/__tests__/stellar.service.spec.ts
+// src/stellar/__tests__/contract.service.spec.ts
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
 import { ContractService } from '../contract.service';
 import { StellarConfigService } from '../stellar-config.service';
 import { TransactionBuilderService } from '../transaction-builder.service';
@@ -7,6 +8,7 @@ import {
   StellarTimeoutError,
   StellarMalformedTransactionError,
 } from '../utils/stellar-error.handler';
+import { InvokeContractDto } from '../dto/invoke-contract.dto';
 
 describe('ContractService', () => {
   let service: ContractService;
@@ -15,6 +17,12 @@ describe('ContractService', () => {
 
   beforeEach(async () => {
     module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          ignoreEnvFile: true,
+        }),
+      ],
       providers: [
         ContractService,
         StellarConfigService,
@@ -30,17 +38,34 @@ describe('ContractService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('encodeContractArgs', () => {
-    it('should return args as-is (temporary placeholder)', () => {
-      const args = ['foo', 123, true];
-      expect(service['encodeContractArgs'](args)).toEqual(args);
+  describe('invocationFromAllowlistedDto', () => {
+    it('maps anchor_confession to configured contract and typed args', () => {
+      const stellarConfig = module.get(StellarConfigService);
+      jest.spyOn(stellarConfig, 'getContractId').mockReturnValue('CC_TEST');
+
+      const dto = {
+        operation: 'anchor_confession' as const,
+        confessionHash: 'ab'.repeat(32),
+        timestamp: 99,
+        sourceAccount: 'G_SIGNER',
+      } satisfies InvokeContractDto;
+
+      const inv = service.invocationFromAllowlistedDto(dto, 'G_SIGNER');
+
+      expect(inv).toEqual({
+        contractId: 'CC_TEST',
+        functionName: 'anchor_confession',
+        args: [
+          { type: 'bytes', value: Buffer.from(dto.confessionHash, 'hex') },
+          { type: 'u64', value: 99 },
+        ],
+        sourceAccount: 'G_SIGNER',
+      });
     });
   });
 
   describe('Negative Paths & Error Handling', () => {
     it('should throw StellarTimeoutError when transaction times out', async () => {
-      // Mock internal methods
-      jest.spyOn(service as any, 'encodeContractArgs').mockReturnValue([]);
       jest
         .spyOn(txBuilderService, 'buildTransaction')
         .mockResolvedValue({} as any);
@@ -52,18 +77,18 @@ describe('ContractService', () => {
       await expect(
         service.invokeContract(
           {
-            contractId: 'CC...',
+            contractId:
+              'CADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP5KR',
             functionName: 'test',
             args: [],
-            sourceAccount: 'G...',
+            sourceAccount: 'GACRG7PJ62DGGUXXVA3XVTAAZGMFMHEIYNN7MUT56LBXC4WW6KKDOPM2',
           },
-          'S...',
+          'SCS5KNRWMGTYHLXX6QHBCLIGGSERWUOO3N5EF4EPW5OO23S6MW3NHJID',
         ),
       ).rejects.toThrow(StellarTimeoutError);
     });
 
     it('should throw StellarMalformedTransactionError on tx_bad_seq', async () => {
-      jest.spyOn(service as any, 'encodeContractArgs').mockReturnValue([]);
       jest
         .spyOn(txBuilderService, 'buildTransaction')
         .mockResolvedValue({} as any);
@@ -86,12 +111,13 @@ describe('ContractService', () => {
       await expect(
         service.invokeContract(
           {
-            contractId: 'CC...',
+            contractId:
+              'CADQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQOBYHA4DQP5KR',
             functionName: 'test',
             args: [],
-            sourceAccount: 'G...',
+            sourceAccount: 'GACRG7PJ62DGGUXXVA3XVTAAZGMFMHEIYNN7MUT56LBXC4WW6KKDOPM2',
           },
-          'S...',
+          'SCS5KNRWMGTYHLXX6QHBCLIGGSERWUOO3N5EF4EPW5OO23S6MW3NHJID',
         ),
       ).rejects.toThrow(StellarMalformedTransactionError);
     });

--- a/xconfess-backend/src/stellar/contract.service.ts
+++ b/xconfess-backend/src/stellar/contract.service.ts
@@ -8,6 +8,7 @@ import {
 } from './interfaces/stellar-config.interface';
 import { handleStellarError } from './utils/stellar-error.handler';
 import { encodeContractArgs, ContractArg } from './utils/parameter.encoder';
+import { InvokeContractDto } from './dto/invoke-contract.dto';
 
 @Injectable()
 export class ContractService {
@@ -17,6 +18,32 @@ export class ContractService {
     private stellarConfig: StellarConfigService,
     private txBuilder: TransactionBuilderService,
   ) {}
+
+  /**
+   * Map an allowlisted HTTP DTO to a low-level invocation. Contract id and
+   * function name are never taken from the client — only from this mapping.
+   */
+  invocationFromAllowlistedDto(
+    dto: InvokeContractDto,
+    verifiedSignerPublicKey: string,
+  ): IContractInvocation {
+    switch (dto.operation) {
+      case 'anchor_confession':
+        return {
+          contractId: this.stellarConfig.getContractId('confessionAnchor'),
+          functionName: 'anchor_confession',
+          args: [
+            { type: 'bytes', value: Buffer.from(dto.confessionHash!, 'hex') },
+            { type: 'u64', value: dto.timestamp! },
+          ],
+          sourceAccount: verifiedSignerPublicKey,
+        };
+      default: {
+        const _never: never = dto.operation;
+        throw new Error(`Unhandled allowlisted operation: ${_never}`);
+      }
+    }
+  }
 
   /**
    * Invoke a Soroban contract function.
@@ -31,7 +58,7 @@ export class ContractService {
       const contract = new StellarSDK.Contract(invocation.contractId);
 
       // Single encoding path — delegates to parameter.encoder.ts
-      const encodedArgs = encodeContractArgs(invocation.args as ContractArg[]);
+      const encodedArgs = encodeContractArgs(invocation.args);
 
       const operation = contract.call(invocation.functionName, ...encodedArgs);
 

--- a/xconfess-backend/src/stellar/dto/invoke-contract.dto.ts
+++ b/xconfess-backend/src/stellar/dto/invoke-contract.dto.ts
@@ -1,22 +1,55 @@
-import { IsString, IsArray, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  Matches,
+  Max,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/** Operations permitted via POST /stellar/invoke-contract (server-signed). */
+export const STELLAR_INVOKE_ALLOWED_OPERATIONS = ['anchor_confession'] as const;
+export type StellarInvokeAllowedOperation =
+  (typeof STELLAR_INVOKE_ALLOWED_OPERATIONS)[number];
 
 export class InvokeContractDto {
-  @ApiProperty({ description: 'Contract ID' })
+  @ApiProperty({
+    enum: STELLAR_INVOKE_ALLOWED_OPERATIONS,
+    description: 'Allowlisted Soroban operation',
+  })
+  @IsIn([...STELLAR_INVOKE_ALLOWED_OPERATIONS])
+  operation: StellarInvokeAllowedOperation;
+
+  @ApiProperty({
+    description: '32-byte confession hash as 64 hex characters (anchor_confession only)',
+    required: false,
+  })
+  @ValidateIf((o: InvokeContractDto) => o.operation === 'anchor_confession')
   @IsString()
   @IsNotEmpty()
-  contractId: string;
+  @Matches(/^[0-9a-fA-F]{64}$/, {
+    message: 'confessionHash must be 64 hexadecimal characters',
+  })
+  confessionHash?: string;
 
-  @ApiProperty({ description: 'Function name to invoke' })
-  @IsString()
-  @IsNotEmpty()
-  functionName: string;
+  @ApiProperty({
+    description: 'Unix-style timestamp as u64 (anchor_confession only)',
+    required: false,
+  })
+  @ValidateIf((o: InvokeContractDto) => o.operation === 'anchor_confession')
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(Number.MAX_SAFE_INTEGER)
+  timestamp?: number;
 
-  @ApiProperty({ description: 'Function arguments', type: [Object] })
-  @IsArray()
-  args: any[];
-
-  @ApiProperty({ description: 'Source account public key' })
+  @ApiProperty({
+    description: 'Must equal the public key of STELLAR_SERVER_SECRET',
+  })
   @IsString()
   @IsNotEmpty()
   sourceAccount: string;

--- a/xconfess-backend/src/stellar/interfaces/stellar-config.interface.ts
+++ b/xconfess-backend/src/stellar/interfaces/stellar-config.interface.ts
@@ -1,6 +1,8 @@
 // src/stellar/interfaces/stellar-config.interface.ts
 // Stellar configuration and types for network and contract integration
 
+import type { ContractArg } from '../utils/parameter.encoder';
+
 export enum StellarNetwork {
   TESTNET = 'testnet',
   MAINNET = 'mainnet',
@@ -30,7 +32,7 @@ export interface ITransactionOptions {
 export interface IContractInvocation {
   contractId: string;
   functionName: string;
-  args: any[];
+  args: ContractArg[];
   sourceAccount: string;
 }
 

--- a/xconfess-backend/src/stellar/stellar.controller.spec.ts
+++ b/xconfess-backend/src/stellar/stellar.controller.spec.ts
@@ -1,9 +1,10 @@
 import request from 'supertest';
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import * as StellarSDK from '@stellar/stellar-sdk';
 import { StellarController } from './stellar.controller';
 import { StellarService } from './stellar.service';
 import { ContractService } from './contract.service';
@@ -12,14 +13,25 @@ import { UserRole } from '../user/entities/user.entity';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { StellarInvokeContractGuard } from './guards/stellar-invoke-contract.guard';
 import { UserService } from '../user/user.service';
+import { AuditLogService } from '../audit-log/audit-log.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
 
 describe('StellarController authz', () => {
   let app: INestApplication;
   let jwtService: JwtService;
-  let contractServiceMock: { invokeContract: jest.Mock };
+  let contractServiceMock: {
+    invokeContract: jest.Mock;
+    invocationFromAllowlistedDto: jest.Mock;
+  };
+  let auditLogMock: { log: jest.Mock };
 
-  const SIGNER_SECRET = 'SIGNER_SECRET';
   const JWT_SECRET = 'JWT_TEST_SECRET_123';
+
+  let SIGNER_SECRET: string;
+  let SIGNER_PUBLIC: string;
+
+  const VALID_HASH =
+    'a'.repeat(64);
 
   const makePayload = (opts: {
     sub: number;
@@ -33,12 +45,32 @@ describe('StellarController authz', () => {
     scopes: opts.scopes ?? [],
   });
 
+  const allowlistedBody = (overrides: Record<string, unknown> = {}) => ({
+    operation: 'anchor_confession',
+    confessionHash: VALID_HASH,
+    timestamp: 1_700_000_000,
+    sourceAccount: SIGNER_PUBLIC,
+    ...overrides,
+  });
+
   beforeAll(async () => {
+    const signerKp = StellarSDK.Keypair.random();
+    SIGNER_SECRET = signerKp.secret();
+    SIGNER_PUBLIC = signerKp.publicKey();
+
+    auditLogMock = { log: jest.fn().mockResolvedValue(undefined) };
+
     contractServiceMock = {
       invokeContract: jest.fn().mockResolvedValue({
         hash: 'tx-hash',
         success: true,
         result: { ok: true },
+      }),
+      invocationFromAllowlistedDto: jest.fn().mockReturnValue({
+        contractId: 'CCONTRACT',
+        functionName: 'anchor_confession',
+        args: [],
+        sourceAccount: SIGNER_PUBLIC,
       }),
     };
 
@@ -70,6 +102,7 @@ describe('StellarController authz', () => {
           useValue: { getNetworkConfig: jest.fn() },
         },
         { provide: ContractService, useValue: contractServiceMock },
+        { provide: AuditLogService, useValue: auditLogMock },
         {
           provide: UserService,
           useValue: {
@@ -80,6 +113,9 @@ describe('StellarController authz', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
     await app.init();
 
     jwtService = moduleFixture.get(JwtService);
@@ -89,15 +125,16 @@ describe('StellarController authz', () => {
     await app.close();
   });
 
+  beforeEach(() => {
+    contractServiceMock.invokeContract.mockClear();
+    contractServiceMock.invocationFromAllowlistedDto.mockClear();
+    auditLogMock.log.mockClear();
+  });
+
   it('returns 401 when Authorization header is missing', async () => {
     const res = await request(app.getHttpServer())
       .post('/stellar/invoke-contract')
-      .send({
-        contractId: 'contract-1',
-        functionName: 'invoke',
-        args: [],
-        sourceAccount: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      });
+      .send(allowlistedBody());
 
     expect(res.status).toBe(401);
   });
@@ -108,18 +145,14 @@ describe('StellarController authz', () => {
     const res = await request(app.getHttpServer())
       .post('/stellar/invoke-contract')
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        contractId: 'contract-1',
-        functionName: 'invoke',
-        args: [],
-        sourceAccount: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      });
+      .send(allowlistedBody());
 
     expect(res.status).toBe(403);
     expect(contractServiceMock.invokeContract).not.toHaveBeenCalled();
+    expect(auditLogMock.log).not.toHaveBeenCalled();
   });
 
-  it('succeeds when required scope claim is present', async () => {
+  it('succeeds when scope is present and payload matches allowlist', async () => {
     const token = jwtService.sign(
       makePayload({ sub: 1, scopes: ['stellar:invoke-contract'] }),
     );
@@ -127,15 +160,87 @@ describe('StellarController authz', () => {
     const res = await request(app.getHttpServer())
       .post('/stellar/invoke-contract')
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        contractId: 'contract-1',
-        functionName: 'invoke',
-        args: [{ x: 1 }],
-        sourceAccount: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      });
+      .send(allowlistedBody());
 
     expect([200, 201]).toContain(res.status);
+    expect(contractServiceMock.invocationFromAllowlistedDto).toHaveBeenCalledTimes(
+      1,
+    );
     expect(contractServiceMock.invokeContract).toHaveBeenCalledTimes(1);
     expect(res.body).toHaveProperty('hash', 'tx-hash');
+    expect(auditLogMock.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: AuditActionType.STELLAR_CONTRACT_INVOCATION,
+        metadata: expect.objectContaining({
+          outcome: 'success',
+          stellarOperation: 'anchor_confession',
+          transactionHash: 'tx-hash',
+        }),
+      }),
+    );
+  });
+
+  it('returns 400 when sourceAccount is not the server signer', async () => {
+    const token = jwtService.sign(
+      makePayload({ sub: 1, scopes: ['stellar:invoke-contract'] }),
+    );
+
+    const res = await request(app.getHttpServer())
+      .post('/stellar/invoke-contract')
+      .set('Authorization', `Bearer ${token}`)
+      .send(
+        allowlistedBody({
+          sourceAccount:
+            'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+        }),
+      );
+
+    expect(res.status).toBe(400);
+    expect(contractServiceMock.invokeContract).not.toHaveBeenCalled();
+    expect(auditLogMock.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: AuditActionType.STELLAR_CONTRACT_INVOCATION,
+        metadata: expect.objectContaining({
+          outcome: 'denied',
+          denialReason: 'source_account_mismatch',
+        }),
+      }),
+    );
+  });
+
+  it('returns 400 when confessionHash is not 64 hex chars', async () => {
+    const token = jwtService.sign(
+      makePayload({ sub: 1, scopes: ['stellar:invoke-contract'] }),
+    );
+
+    const res = await request(app.getHttpServer())
+      .post('/stellar/invoke-contract')
+      .set('Authorization', `Bearer ${token}`)
+      .send(
+        allowlistedBody({
+          confessionHash: 'deadbeef',
+        }),
+      );
+
+    expect(res.status).toBe(400);
+    expect(contractServiceMock.invokeContract).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when operation is not allowlisted', async () => {
+    const token = jwtService.sign(
+      makePayload({ sub: 1, scopes: ['stellar:invoke-contract'] }),
+    );
+
+    const res = await request(app.getHttpServer())
+      .post('/stellar/invoke-contract')
+      .set('Authorization', `Bearer ${token}`)
+      .send(
+        allowlistedBody({
+          operation: 'arbitrary_mint',
+        }),
+      );
+
+    expect(res.status).toBe(400);
+    expect(contractServiceMock.invokeContract).not.toHaveBeenCalled();
   });
 });

--- a/xconfess-backend/src/stellar/stellar.controller.ts
+++ b/xconfess-backend/src/stellar/stellar.controller.ts
@@ -5,16 +5,21 @@ import {
   Get,
   Param,
   Post,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
+import * as StellarSDK from '@stellar/stellar-sdk';
 import { StellarService } from './stellar.service';
 import { ContractService } from './contract.service';
 import { VerifyTransactionDto } from './dto/verify-transaction.dto';
 import { InvokeContractDto } from './dto/invoke-contract.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { StellarInvokeContractGuard } from './guards/stellar-invoke-contract.guard';
+import { AuditLogService } from '../audit-log/audit-log.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
+import { AuthenticatedRequest } from '../auth/interfaces/jwt-payload.interface';
 
 @ApiTags('Stellar')
 @Controller('stellar')
@@ -23,6 +28,7 @@ export class StellarController {
     private stellarService: StellarService,
     private contractService: ContractService,
     private configService: ConfigService,
+    private auditLogService: AuditLogService,
   ) {}
 
   @Get('config')
@@ -54,9 +60,14 @@ export class StellarController {
   }
 
   @Post('invoke-contract')
-  @ApiOperation({ summary: 'Invoke Soroban contract (admin only)' })
+  @ApiOperation({
+    summary: 'Invoke allowlisted Soroban operation (server-signed, admin)',
+  })
   @UseGuards(JwtAuthGuard, StellarInvokeContractGuard)
-  async invokeContract(@Body() dto: InvokeContractDto) {
+  async invokeContract(
+    @Body() dto: InvokeContractDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
     const signerSecret = this.configService.get<string>(
       'STELLAR_SERVER_SECRET',
     );
@@ -66,14 +77,68 @@ export class StellarController {
       );
     }
 
-    return this.contractService.invokeContract(
-      {
-        contractId: dto.contractId,
-        functionName: dto.functionName,
-        args: dto.args,
-        sourceAccount: dto.sourceAccount,
-      },
-      signerSecret,
+    const signerPk = StellarSDK.Keypair.fromSecret(signerSecret).publicKey();
+    if (dto.sourceAccount !== signerPk) {
+      await this.auditStellarInvocation(req, dto, {
+        outcome: 'denied',
+        denialReason: 'source_account_mismatch',
+        expectedSourceAccount: signerPk,
+      });
+      throw new BadRequestException(
+        'sourceAccount must be the public key of the configured server signer',
+      );
+    }
+
+    const invocation = this.contractService.invocationFromAllowlistedDto(
+      dto,
+      signerPk,
     );
+
+    try {
+      const result = await this.contractService.invokeContract(
+        invocation,
+        signerSecret,
+      );
+      await this.auditStellarInvocation(req, dto, {
+        outcome: result.success ? 'success' : 'failed',
+        transactionHash: result.hash,
+        chainSuccess: result.success,
+        contractId: invocation.contractId,
+        functionName: invocation.functionName,
+      });
+      return result;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      await this.auditStellarInvocation(req, dto, {
+        outcome: 'failed',
+        contractId: invocation.contractId,
+        functionName: invocation.functionName,
+        errorMessage: message.slice(0, 500),
+      });
+      throw err;
+    }
+  }
+
+  private async auditStellarInvocation(
+    req: AuthenticatedRequest,
+    dto: InvokeContractDto,
+    fields: Record<string, unknown>,
+  ): Promise<void> {
+    const base: Record<string, unknown> = {
+      entityType: 'stellar_invocation',
+      entityId: dto.operation,
+      stellarOperation: dto.operation,
+      actorUserId: req.user.id,
+      ...fields,
+    };
+    if (dto.operation === 'anchor_confession') {
+      base.confessionHash = dto.confessionHash;
+      base.timestamp = dto.timestamp;
+    }
+    await this.auditLogService.log({
+      actionType: AuditActionType.STELLAR_CONTRACT_INVOCATION,
+      context: { userId: req.user.id },
+      metadata: base,
+    });
   }
 }

--- a/xconfess-backend/src/stellar/stellar.module.ts
+++ b/xconfess-backend/src/stellar/stellar.module.ts
@@ -6,9 +6,10 @@ import { StellarService } from './stellar.service';
 import { ContractService } from './contract.service';
 import { StellarController } from './stellar.controller';
 import { StellarInvokeContractGuard } from './guards/stellar-invoke-contract.guard';
+import { AuditLogModule } from '../audit-log/audit-log.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, AuditLogModule],
   providers: [
     StellarConfigService,
     TransactionBuilderService,


### PR DESCRIPTION
Restrict POST /stellar/invoke-contract to typed allowlisted operations (anchor_confession), derive contract and function from server config, and require sourceAccount to match STELLAR_SERVER_SECRET. Log invocations to audit_logs with STELLAR_CONTRACT_INVOCATION. Add Postgres enum migration and expand tests for allowed and rejected payloads.

closes #655 