### PR TITLE
test(frontend): add mobile auth recovery scenarios

### DIFF
--- a/xconfess-frontend/tests/mobile-auth-recovery.spec.tsx
+++ b/xconfess-frontend/tests/mobile-auth-recovery.spec.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const mockPush = jest.fn();
+
+type MockAuthState = {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  user: { username: string; email: string; role: string } | null;
+  logout: jest.Mock;
+};
+
+const defaultAuthState: MockAuthState = {
+  isAuthenticated: true,
+  isLoading: false,
+  user: { username: "testuser", email: "test@example.com", role: "user" },
+  logout: jest.fn(),
+};
+
+let mockAuthState: MockAuthState = defaultAuthState;
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/app/lib/hooks/useAuth", () => ({
+  useAuth: () => mockAuthState,
+}));
+
+import { AuthGuard } from "@/app/components/AuthGuard";
+
+describe("Mobile Auth Recovery Regression Coverage", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockAuthState = {
+      ...defaultAuthState,
+      logout: jest.fn(),
+    };
+  });
+
+  function renderGuard(children: ReactNode = <div>Protected Content</div>) {
+    return render(<AuthGuard>{children}</AuthGuard>);
+  }
+
+  it("shows loading state without redirecting while auth is unresolved", () => {
+    mockAuthState = {
+      ...mockAuthState,
+      isAuthenticated: false,
+      isLoading: true,
+      user: null,
+    };
+
+    renderGuard();
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("redirects unauthenticated users to login and suppresses protected content", async () => {
+    mockAuthState = {
+      ...mockAuthState,
+      isAuthenticated: false,
+      isLoading: false,
+      user: null,
+    };
+
+    renderGuard();
+
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("renders protected content for authenticated users without redirecting", () => {
+    renderGuard();
+
+    expect(screen.getByText("Protected Content")).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/xconfess-frontend/tests/mobile-navigation-regression.spec.tsx
+++ b/xconfess-frontend/tests/mobile-navigation-regression.spec.tsx
@@ -247,13 +247,6 @@ describe("Mobile Navigation Regression Coverage", () => {
     });
   });
 
-  describe("Auth Recovery on Mobile", () => {
-    // TODO: Add AuthGuard mobile tests in separate file due to mocking complexity
-    it("placeholder for auth recovery tests", () => {
-      expect(true).toBe(true);
-    });
-  });
-
   describe("Dashboard Layout on Mobile", () => {
     it("renders header and main content on mobile", () => {
       render(


### PR DESCRIPTION
This pull request adds comprehensive regression tests for the `AuthGuard` component's authentication and recovery logic on mobile, and removes a placeholder test from the mobile navigation regression suite. The new tests ensure that the `AuthGuard` correctly handles loading, unauthenticated, and authenticated states, and that users are redirected appropriately.

**Authentication and AuthGuard Testing Improvements:**

* Added a new test suite in `mobile-auth-recovery.spec.tsx` to cover `AuthGuard` behavior, including loading state handling, redirecting unauthenticated users, and rendering protected content for authenticated users.

**Test Suite Maintenance:**

* Removed the "Auth Recovery on Mobile" placeholder test from `mobile-navigation-regression.spec.tsx`, as this logic is now fully covered in the dedicated test file.

Closes #652 