### PR TITLE
added undo-style recovery feedback after user ban and unban actions

### DIFF
--- a/xconfess-frontend/app/components/admin/UserManagement.tsx
+++ b/xconfess-frontend/app/components/admin/UserManagement.tsx
@@ -28,10 +28,15 @@ export default function UserManagement() {
   const banMutation = useMutation({
     mutationFn: ({ id, reason }: { id: string; reason?: string }) =>
       adminApi.banUser(id, reason),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['admin-users-search'] });
       setSelectedUser(null);
-      toast.success('User banned.');
+      toast.success('User banned.', {
+        action: {
+          label: 'Undo',
+          onClick: () => unbanMutation.mutate(variables.id),
+        },
+      });
     },
     onError: () => {
       toast.error('Failed to ban user.');
@@ -40,10 +45,15 @@ export default function UserManagement() {
 
   const unbanMutation = useMutation({
     mutationFn: (id: string) => adminApi.unbanUser(id),
-    onSuccess: () => {
+    onSuccess: (_, id) => {
       queryClient.invalidateQueries({ queryKey: ['admin-users-search'] });
       setSelectedUser(null);
-      toast.success('User unbanned.');
+      toast.success('User unbanned.', {
+        action: {
+          label: 'Undo',
+          onClick: () => banMutation.mutate({ id }),
+        },
+      });
     },
     onError: () => {
       toast.error('Failed to unban user.');

--- a/xconfess-frontend/app/components/common/Toast.tsx
+++ b/xconfess-frontend/app/components/common/Toast.tsx
@@ -122,9 +122,25 @@ const ToastItem: React.FC<ToastProps> = ({ toast, onRemove }) => {
       <div className={`flex-grow ${getTextColor()} text-sm font-medium`}>
         {toast.message}
       </div>
+      {toast.action && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            toast.action?.onClick();
+            onRemove(toast.id);
+          }}
+          className={`
+            flex-shrink-0 px-3 py-1 rounded-full text-xs font-bold uppercase tracking-wider
+            bg-white/20 hover:bg-white/30 transition-colors duration-200
+            ${getTextColor()}
+          `}
+        >
+          {toast.action.label}
+        </button>
+      )}
       <button
         onClick={() => onRemove(toast.id)}
-        className={`flex-shrink-0 ml-2 ${getTextColor()} hover:opacity-70 transition-opacity`}
+        className={`flex-shrink-0 ml-1 ${getTextColor()} hover:opacity-70 transition-opacity`}
         aria-label="Close notification"
       >
         <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">

--- a/xconfess-frontend/app/lib/hooks/useToast.ts
+++ b/xconfess-frontend/app/lib/hooks/useToast.ts
@@ -7,9 +7,18 @@ export interface Toast {
   message: string;
   type: 'success' | 'error' | 'warning' | 'info';
   duration?: number;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
 }
 
 const DEFAULT_DURATION = 3000;
+
+export interface ToastOptions {
+  duration?: number;
+  action?: Toast['action'];
+}
 
 export const useToast = () => {
   const [toasts, setToasts] = useState<Toast[]>([]);
@@ -22,10 +31,11 @@ export const useToast = () => {
     (
       message: string,
       type: 'success' | 'error' | 'warning' | 'info' = 'info',
-      duration = DEFAULT_DURATION
+      duration = DEFAULT_DURATION,
+      action?: Toast['action']
     ): string => {
       const id = `toast-${Date.now()}-${Math.random()}`;
-      const toast: Toast = { id, message, type, duration };
+      const toast: Toast = { id, message, type, duration, action };
 
       setToasts((prev) => [...prev, toast]);
 
@@ -41,22 +51,26 @@ export const useToast = () => {
   );
 
   const success = useCallback(
-    (message: string, duration?: number) => addToast(message, 'success', duration),
+    (message: string, options?: ToastOptions) =>
+      addToast(message, 'success', options?.duration, options?.action),
     [addToast]
   );
 
   const error = useCallback(
-    (message: string, duration?: number) => addToast(message, 'error', duration),
+    (message: string, options?: ToastOptions) =>
+      addToast(message, 'error', options?.duration, options?.action),
     [addToast]
   );
 
   const warning = useCallback(
-    (message: string, duration?: number) => addToast(message, 'warning', duration),
+    (message: string, options?: ToastOptions) =>
+      addToast(message, 'warning', options?.duration, options?.action),
     [addToast]
   );
 
   const info = useCallback(
-    (message: string, duration?: number) => addToast(message, 'info', duration),
+    (message: string, options?: ToastOptions) =>
+      addToast(message, 'info', options?.duration, options?.action),
     [addToast]
   );
 


### PR DESCRIPTION
 Close: #687
 
 I have completed the task of adding undo-style recovery feedback for user ban and unban actions.

Summary of Changes
Toast System Upgrade:
Updated the Toast interface in 

useToast.ts to support optional actions with custom labels and click handlers.
Modified the ToastItem component in Toast.tsx to render a premium-styled "Undo" pill button when an action is available.
Moderation Recovery:
Updated the UserManagement.tsx component to include an "Undo" action in the success notifications for both ban and unban operations.
Banning a user now provides a 3-second window to click "Undo", which immediately restores the user's active status.
Unbanning a user provides a similar window to revert the action and re-apply the ban.
Both recovery paths work seamlessly without requiring a page refresh, maintaining consistent moderation state via React Query's cache invalidation.