### PR TITLE
centralize App Router proxy error formatting into a shared helper

### DIFF
--- a/xconfess-frontend/app/api/analytics/route.ts
+++ b/xconfess-frontend/app/api/analytics/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import axios from 'axios';
 import { getApiBaseUrl } from '@/app/lib/config';
+import { logProxyError } from "@/app/lib/utils/proxyError";
 
 const BACKEND_URL = getApiBaseUrl();
 
@@ -220,8 +221,8 @@ export async function GET(request: Request) {
     compareMode === 'true' || compareMode === '1' || compareMode === 'previous';
   const days = period === '30d' ? 30 : 7;
 
-  // Get token from cookie or header if needed, but for now let's hope the backend is accessible 
-  // or use a service account token if internal. 
+  // Get token from cookie or header if needed, but for now let's hope the backend is accessible
+  // or use a service account token if internal.
   // In Next.js App Router, we usually pass through the auth header from the client request.
   const authHeader = request.headers.get('authorization');
 
@@ -470,10 +471,14 @@ export async function GET(request: Request) {
 
     return NextResponse.json(payload);
   } catch (error: any) {
-    console.error('Analytics Fetch Error:', error?.response?.data || error.message);
+    logProxyError(
+      "Analytics fetch error",
+      { route: "GET /api/analytics", backendStatus: error?.response?.status },
+      error,
+    );
     return NextResponse.json(
-      { error: 'Failed to fetch real-time analytics' },
-      { status: error?.response?.status || 500 }
+      { error: "Failed to fetch real-time analytics" },
+      { status: (error?.response?.status as number | undefined) ?? 500 },
     );
   }
 }

--- a/xconfess-frontend/app/api/analytics/trending/route.ts
+++ b/xconfess-frontend/app/api/analytics/trending/route.ts
@@ -1,3 +1,5 @@
+import { logProxyError } from "@/app/lib/utils/proxyError";
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -89,10 +91,10 @@ export async function GET(request: Request) {
       }
     });
   } catch (error) {
-    console.error('Error fetching analytics:', error);
-    return new Response(
-      JSON.stringify({ error: 'Failed to fetch analytics' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    );
+    logProxyError("Error computing trending analytics", { route: "GET /api/analytics/trending" }, error);
+    return new Response(JSON.stringify({ error: "Failed to fetch analytics" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/xconfess-frontend/app/api/auth/session/route.ts
+++ b/xconfess-frontend/app/api/auth/session/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getApiBaseUrl } from "@/app/lib/config";
+import { logProxyError } from "@/app/lib/utils/proxyError";
 
 const API_URL = getApiBaseUrl();
 const SESSION_COOKIE_NAME = "xconfess_session";
@@ -46,7 +47,8 @@ export async function POST(request: Request) {
         });
 
         return NextResponse.json({ user: data.user });
-    } catch {
+    } catch (error) {
+        logProxyError("Internal error", { route: "POST /api/auth/session" }, error);
         return NextResponse.json(
             { message: "An unexpected error occurred during login" },
             { status: 500 }
@@ -77,7 +79,8 @@ export async function GET() {
 
         const user = await response.json();
         return NextResponse.json({ authenticated: true, user });
-    } catch {
+    } catch (error) {
+        logProxyError("Internal error", { route: "GET /api/auth/session" }, error);
         return NextResponse.json({ authenticated: false }, { status: 500 });
     }
 }

--- a/xconfess-frontend/app/api/comments/[confessionId]/route.ts
+++ b/xconfess-frontend/app/api/comments/[confessionId]/route.ts
@@ -1,3 +1,4 @@
+import { buildProxyErrorResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 import { getApiBaseUrl } from "@/app/lib/config";
 
 const BASE_API_URL = getApiBaseUrl();
@@ -84,22 +85,11 @@ export async function POST(
         });
       }
 
-      const err = await response.json().catch(() => ({}));
+      const err = await response.json().catch(() => ({} as { message?: string }));
       if (response.status === 401) {
-        return new Response(
-          JSON.stringify({ message: "Please sign in to comment" }),
-          { status: 401, headers: { "Content-Type": "application/json" } },
-        );
+        return buildProxyErrorResponse("Please sign in to comment", 401, { route: "POST /api/comments/[confessionId]" });
       }
-      return new Response(
-        JSON.stringify({
-          message: err.message || "Failed to post comment",
-        }),
-        {
-          status: response.status,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return buildProxyErrorResponse(err.message || "Failed to post comment", response.status, { route: "POST /api/comments/[confessionId]" });
     }
 
     const data = await response.json();
@@ -147,10 +137,6 @@ export async function POST(
       });
     }
 
-    console.error("Error posting comment:", error);
-    return new Response(JSON.stringify({ message: "Internal server error" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return internalProxyErrorResponse({ route: "POST /api/comments/[confessionId]" }, error);
   }
 }

--- a/xconfess-frontend/app/api/comments/by-confession/[confessionId]/route.ts
+++ b/xconfess-frontend/app/api/comments/by-confession/[confessionId]/route.ts
@@ -1,3 +1,4 @@
+import { buildProxyErrorResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 import { getApiBaseUrl } from "@/app/lib/config";
 
 const BASE_API_URL = getApiBaseUrl();
@@ -108,16 +109,8 @@ export async function GET(
         });
       }
 
-      const err = await response.json().catch(() => ({}));
-      return new Response(
-        JSON.stringify({
-          message: err.message || "Failed to fetch comments",
-        }),
-        {
-          status: response.status,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      const err = await response.json().catch(() => ({} as { message?: string }));
+      return buildProxyErrorResponse(err.message || "Failed to fetch comments", response.status, { route: "GET /api/comments/by-confession/[confessionId]" });
     }
 
     const data = await response.json();
@@ -230,10 +223,6 @@ export async function GET(
       });
     }
 
-    console.error("Error fetching comments:", error);
-    return new Response(JSON.stringify({ message: "Internal server error" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return internalProxyErrorResponse({ route: "GET /api/comments/by-confession/[confessionId]" }, error);
   }
 }

--- a/xconfess-frontend/app/api/confessions/[id]/anchor/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/anchor/route.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from "@/app/lib/config";
+import { logProxyError, backendHttpErrorResponse, backendUnreachableResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 
 const BASE_API_URL = getApiBaseUrl();
 
@@ -44,17 +45,12 @@ export async function POST(
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        return new Response(
-          JSON.stringify({
-            message:
-              errorData.message ||
-              `Failed to anchor confession: ${response.statusText}`,
-          }),
-          {
-            status: response.status,
-            headers: { "Content-Type": "application/json" },
-          }
+        const errorData = await response.json().catch(() => ({} as { message?: string }));
+        return backendHttpErrorResponse(
+          errorData.message,
+          response.status,
+          `Failed to anchor confession: ${response.statusText}`,
+          { route: "POST /api/confessions/[id]/anchor" },
         );
       }
 
@@ -65,7 +61,7 @@ export async function POST(
         headers: { "Content-Type": "application/json" },
       });
     } catch (fetchError) {
-      console.error("Backend fetch error:", fetchError);
+      logProxyError("Backend fetch error", { route: "POST /api/confessions/[id]/anchor" }, fetchError);
 
       // Demo mode fallback
       const isDemoMode =
@@ -92,28 +88,9 @@ export async function POST(
         );
       }
 
-      return new Response(
-        JSON.stringify({
-          message: "Backend service unavailable",
-        }),
-        {
-          status: 503,
-          headers: { "Content-Type": "application/json" },
-        }
-      );
+      return backendUnreachableResponse({ route: "POST /api/confessions/[id]/anchor" }, fetchError);
     }
   } catch (error) {
-    console.error("Error anchoring confession:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Internal server error";
-    return new Response(
-      JSON.stringify({
-        message: errorMessage,
-      }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      }
-    );
+    return internalProxyErrorResponse({ route: "POST /api/confessions/[id]/anchor" }, error);
   }
 }

--- a/xconfess-frontend/app/api/confessions/[id]/react/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/react/route.ts
@@ -3,6 +3,7 @@ import {
   REACTION_EMOJI_MAP,
 } from "@/app/lib/constants/reactions";
 import { getApiBaseUrl } from "@/app/lib/config";
+import { backendHttpErrorResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 
 const BASE_API_URL = getApiBaseUrl();
 
@@ -14,8 +15,10 @@ export async function POST(
   request: Request,
   context: { params: Promise<{ id: string }> }
 ) {
+  let correlationId: string | undefined;
   try {
     const { id } = await context.params;
+    correlationId = request.headers.get("X-Correlation-ID") ?? undefined;
     const body = await request.json();
     const { type } = body;
 
@@ -81,20 +84,11 @@ export async function POST(
         // Use default error message if response is not JSON
       }
 
-      console.error(
-        `Reaction API error (${reactionRes.status}):`,
-        errorMessage
-      );
-
-      return new Response(
-        JSON.stringify({
-          error: "Failed to persist reaction",
-          message: errorMessage,
-        }),
-        {
-          status: reactionRes.status,
-          headers: { "Content-Type": "application/json" },
-        }
+      return backendHttpErrorResponse(
+        errorMessage,
+        reactionRes.status,
+        "Failed to persist reaction",
+        { route: "POST /api/confessions/[id]/react", correlationId },
       );
     }
 
@@ -158,17 +152,9 @@ export async function POST(
       }
     );
   } catch (err) {
-    console.error("Error processing reaction:", err);
-
-    return new Response(
-      JSON.stringify({
-        error: "Internal server error",
-        message: "Failed to process reaction. Please try again.",
-      }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      }
+    return internalProxyErrorResponse(
+      { route: "POST /api/confessions/[id]/react", correlationId },
+      err,
     );
   }
 }

--- a/xconfess-frontend/app/api/confessions/[id]/report/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/report/route.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from "@/app/lib/config";
+import { internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 
 const BASE_API_URL = getApiBaseUrl();
 
@@ -79,12 +80,9 @@ export async function POST(
       headers: { "Content-Type": "application/json" },
     });
   } catch (err) {
-    return new Response(
-      JSON.stringify({
-        message: "Failed to submit report",
-      }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
+    return internalProxyErrorResponse(
+      { route: "POST /api/confessions/[id]/report" },
+      err,
     );
   }
 }
-

--- a/xconfess-frontend/app/api/confessions/[id]/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/route.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from "@/app/lib/config";
+import { logProxyError, buildProxyErrorResponse } from "@/app/lib/utils/proxyError";
 
 const BASE_API_URL = getApiBaseUrl();
 
@@ -111,16 +112,8 @@ export async function GET(
           { status: 404, headers: { "Content-Type": "application/json" } },
         );
       }
-      const err = await response.json().catch(() => ({}));
-      return new Response(
-        JSON.stringify({
-          message: err.message || "Failed to fetch confession",
-        }),
-        {
-          status: response.status,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      const err = await response.json().catch(() => ({} as { message?: string }));
+      return buildProxyErrorResponse(err.message || "Failed to fetch confession", response.status);
     }
 
     const data = await response.json();
@@ -231,11 +224,8 @@ export async function GET(
       });
     }
 
-    console.error("Error fetching confession:", error);
-    return new Response(JSON.stringify({ message: "Internal server error" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    logProxyError("Error fetching confession", { route: "GET /api/confessions/[id]" }, error);
+    return buildProxyErrorResponse("Internal server error", 500, { route: "GET /api/confessions/[id]" });
   }
 }
 

--- a/xconfess-frontend/app/api/confessions/route.ts
+++ b/xconfess-frontend/app/api/confessions/route.ts
@@ -1,21 +1,16 @@
 import { normalizeConfession } from "../../lib/utils/normalizeConfession";
+import {
+  misconfiguredBackendResponse,
+  backendHttpErrorResponse,
+  backendUnreachableResponse,
+  internalProxyErrorResponse,
+} from "@/app/lib/utils/proxyError";
 
 const BASE_API_URL = process.env.BACKEND_API_URL;
 
 export async function POST(request: Request) {
   // Fail fast if backend URL is not configured
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message:
-          "Server misconfiguration: BACKEND_API_URL is not set. Contact the system administrator.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const body = await request.json();
@@ -56,19 +51,12 @@ export async function POST(request: Request) {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        console.error(`[POST /confessions] Backend error: ${response.status} (CID: ${correlationId})`, errorData);
-        return new Response(
-          JSON.stringify({
-            message:
-              errorData.message ||
-              `Failed to create confession: ${response.statusText}`,
-            correlationId,
-          }),
-          {
-            status: response.status,
-            headers: { "Content-Type": "application/json" },
-          },
+        const errorData = await response.json().catch(() => ({} as { message?: string }));
+        return backendHttpErrorResponse(
+          errorData.message,
+          response.status,
+          `Failed to create confession: ${response.statusText}`,
+          { route: "POST /api/confessions", correlationId },
         );
       }
 
@@ -79,51 +67,18 @@ export async function POST(request: Request) {
         status: 201,
         headers: { "Content-Type": "application/json" },
       });
-    } catch (fetchError: any) {
-      console.error(`[POST /confessions] Failed to reach backend (CID: ${correlationId}):`, fetchError);
-      return new Response(
-        JSON.stringify({
-          message: "Backend service unavailable. Please try again later.",
-          correlationId,
-        }),
-        {
-          status: 503,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+    } catch (fetchError) {
+      return backendUnreachableResponse({ route: "POST /api/confessions", correlationId }, fetchError);
     }
   } catch (error) {
     const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
-    console.error(`[POST /confessions] Internal error (CID: ${correlationId}):`, error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Internal server error";
-    return new Response(
-      JSON.stringify({
-        message: errorMessage,
-        correlationId,
-      }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "POST /api/confessions", correlationId }, error);
   }
 }
 
 export async function GET(request: Request) {
   // Fail fast if backend URL is not configured
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message:
-          "Server misconfiguration: BACKEND_API_URL is not set. Contact the system administrator.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   const { searchParams } = new URL(request.url);
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1") || 1);
@@ -158,18 +113,11 @@ export async function GET(request: Request) {
     });
 
     if (!response.ok) {
-      console.error(
-        `[GET /confessions] Backend error: ${response.status} (CID: ${correlationId})`,
-      );
-      return new Response(
-        JSON.stringify({
-          message: `Failed to fetch confessions: ${response.statusText}`,
-          correlationId,
-        }),
-        {
-          status: response.status,
-          headers: { "Content-Type": "application/json" },
-        },
+      return backendHttpErrorResponse(
+        undefined,
+        response.status,
+        `Failed to fetch confessions: ${response.statusText}`,
+        { route: "GET /api/confessions", correlationId },
       );
     }
 
@@ -201,17 +149,6 @@ export async function GET(request: Request) {
       },
     );
   } catch (error) {
-    const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
-    console.error(`[GET /confessions] Internal error (CID: ${correlationId}):`, error);
-    return new Response(
-      JSON.stringify({
-        message: "Backend service unavailable. Please try again later.",
-        correlationId,
-      }),
-      {
-        status: 502,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return backendUnreachableResponse({ route: "GET /api/confessions", correlationId }, error);
   }
 }

--- a/xconfess-frontend/app/api/confessions/search/route.ts
+++ b/xconfess-frontend/app/api/confessions/search/route.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from "@/app/lib/config";
+import { logProxyError } from "@/app/lib/utils/proxyError";
 
 const BASE_API_URL = getApiBaseUrl();
 
@@ -66,6 +67,7 @@ export async function GET(request: Request) {
       } catch {
         /* ignore */
       }
+      logProxyError("Backend error", { route: "GET /api/confessions/search", backendStatus: res.status });
       return Response.json(
         {
           message: body.message ?? `Search failed: ${res.statusText}`,
@@ -160,6 +162,7 @@ export async function GET(request: Request) {
       },
     });
   } catch (err) {
+    logProxyError("Failed to reach backend", { route: "GET /api/confessions/search" }, err);
     const message =
       err instanceof Error ? err.message : "Search service unavailable";
     return Response.json(

--- a/xconfess-frontend/app/api/notifications/[id]/read/route.ts
+++ b/xconfess-frontend/app/api/notifications/[id]/read/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { backendHttpErrorResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 
 
 export async function PATCH(
@@ -20,16 +21,16 @@ export async function PATCH(
     );
 
     if (!response.ok) {
-      throw new Error("Failed to mark notification as read");
+      const errData = await response.json().catch(() => ({} as { error?: string; message?: string }));
+      const message = errData.message ?? errData.error ?? "Failed to mark notification as read";
+      return backendHttpErrorResponse(message, response.status, "Failed to mark notification as read", {
+        route: "PATCH /api/notifications/[id]/read",
+      });
     }
 
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
-    console.error("Error marking notification as read:", error);
-    return NextResponse.json(
-      { error: "Failed to mark notification as read" },
-      { status: 500 }
-    );
+    return internalProxyErrorResponse({ route: "PATCH /api/notifications/[id]/read" }, error);
   }
 }

--- a/xconfess-frontend/app/api/notifications/preference/route.ts
+++ b/xconfess-frontend/app/api/notifications/preference/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { backendHttpErrorResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,17 +15,17 @@ export async function GET(request: NextRequest) {
     );
 
     if (!response.ok) {
-      throw new Error("Failed to fetch preferences");
+      const errData = await response.json().catch(() => ({} as { error?: string; message?: string }));
+      const message = errData.message ?? errData.error ?? "Failed to fetch preferences";
+      return backendHttpErrorResponse(message, response.status, "Failed to fetch preferences", {
+        route: "GET /api/notifications/preference",
+      });
     }
 
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
-    console.error("Error fetching preferences:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch preferences" },
-      { status: 500 }
-    );
+    return internalProxyErrorResponse({ route: "GET /api/notifications/preference" }, error);
   }
 }
 
@@ -46,16 +47,16 @@ export async function PUT(request: NextRequest) {
     );
 
     if (!response.ok) {
-      throw new Error("Failed to save preferences");
+      const errData = await response.json().catch(() => ({} as { error?: string; message?: string }));
+      const message = errData.message ?? errData.error ?? "Failed to save preferences";
+      return backendHttpErrorResponse(message, response.status, "Failed to save preferences", {
+        route: "PUT /api/notifications/preference",
+      });
     }
 
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
-    console.error("Error saving preferences:", error);
-    return NextResponse.json(
-      { error: "Failed to save preferences" },
-      { status: 500 }
-    );
+    return internalProxyErrorResponse({ route: "PUT /api/notifications/preference" }, error);
   }
 }

--- a/xconfess-frontend/app/api/notifications/read-all/route.ts
+++ b/xconfess-frontend/app/api/notifications/read-all/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { backendHttpErrorResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 
 export async function PATCH(request: NextRequest) {
   try {
@@ -15,16 +16,16 @@ export async function PATCH(request: NextRequest) {
     );
 
     if (!response.ok) {
-      throw new Error("Failed to mark all as read");
+      const errData = await response.json().catch(() => ({} as { error?: string; message?: string }));
+      const message = errData.message ?? errData.error ?? "Failed to mark all as read";
+      return backendHttpErrorResponse(message, response.status, "Failed to mark all as read", {
+        route: "PATCH /api/notifications/read-all",
+      });
     }
 
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
-    console.error("Error marking all as read:", error);
-    return NextResponse.json(
-      { error: "Failed to mark all as read" },
-      { status: 500 }
-    );
+    return internalProxyErrorResponse({ route: "PATCH /api/notifications/read-all" }, error);
   }
 }

--- a/xconfess-frontend/app/api/notifications/route.ts
+++ b/xconfess-frontend/app/api/notifications/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { backendHttpErrorResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 
 export async function GET(request: NextRequest) {
+  const correlationId = request.headers.get("X-Correlation-ID") ?? undefined;
+
   try {
     // Get auth token from headers
     const token = request.headers.get("authorization")?.replace("Bearer ", "");
@@ -23,16 +26,17 @@ export async function GET(request: NextRequest) {
     );
 
     if (!response.ok) {
-      throw new Error("Failed to fetch notifications");
+      const errData = await response.json().catch(() => ({} as { error?: string; message?: string }));
+      const message = errData.message ?? errData.error ?? "Failed to fetch notifications";
+      return backendHttpErrorResponse(message, response.status, "Failed to fetch notifications", {
+        route: "GET /api/notifications",
+        correlationId,
+      });
     }
 
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
-    console.error("Error fetching notifications:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch notifications" },
-      { status: 500 }
-    );
+    return internalProxyErrorResponse({ route: "GET /api/notifications", correlationId }, error);
   }
 }

--- a/xconfess-frontend/app/api/trending/route.ts
+++ b/xconfess-frontend/app/api/trending/route.ts
@@ -1,3 +1,5 @@
+import { logProxyError } from "@/app/lib/utils/proxyError";
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -89,16 +91,16 @@ export async function GET(request: Request) {
 
     return new Response(JSON.stringify(analytics), {
       status: 200,
-      headers: { 
+      headers: {
         'Content-Type': 'application/json',
         'Cache-Control': 'public, max-age=900' // 15 minutes cache
       }
     });
   } catch (error) {
-    console.error('Error fetching analytics:', error);
-    return new Response(
-      JSON.stringify({ error: 'Failed to fetch analytics' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    );
+    logProxyError("Error computing trending data", { route: "GET /api/trending" }, error);
+    return new Response(JSON.stringify({ error: "Failed to fetch analytics" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/xconfess-frontend/app/api/users/[id]/activities/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/activities/route.ts
@@ -1,17 +1,9 @@
+import { misconfiguredBackendResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+
 const BASE_API_URL = process.env.BACKEND_API_URL;
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const { id } = params;
@@ -36,13 +28,6 @@ export async function GET(request: Request, { params }: { params: { id: string }
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "GET /api/users/[id]/activities" }, error);
   }
 }

--- a/xconfess-frontend/app/api/users/[id]/confessions/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/confessions/route.ts
@@ -1,17 +1,9 @@
+import { misconfiguredBackendResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+
 const BASE_API_URL = process.env.BACKEND_API_URL;
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const { id } = params;
@@ -36,13 +28,6 @@ export async function GET(request: Request, { params }: { params: { id: string }
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "GET /api/users/[id]/confessions" }, error);
   }
 }

--- a/xconfess-frontend/app/api/users/[id]/public-profile/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/public-profile/route.ts
@@ -1,17 +1,9 @@
+import { misconfiguredBackendResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+
 const BASE_API_URL = process.env.BACKEND_API_URL;
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const { id } = params;
@@ -36,13 +28,6 @@ export async function GET(request: Request, { params }: { params: { id: string }
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "GET /api/users/[id]/public-profile" }, error);
   }
 }

--- a/xconfess-frontend/app/api/users/privacy-settings/route.ts
+++ b/xconfess-frontend/app/api/users/privacy-settings/route.ts
@@ -1,17 +1,9 @@
+import { misconfiguredBackendResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+
 const BASE_API_URL = process.env.BACKEND_API_URL;
 
 export async function GET(request: Request) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const backendUrl = `${BASE_API_URL}/users/privacy-settings`;
@@ -38,29 +30,12 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "GET /api/users/privacy-settings" }, error);
   }
 }
 
 export async function PATCH(request: Request) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const body = await request.json();
@@ -90,13 +65,6 @@ export async function PATCH(request: Request) {
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "PATCH /api/users/privacy-settings" }, error);
   }
 }

--- a/xconfess-frontend/app/api/users/profile/route.ts
+++ b/xconfess-frontend/app/api/users/profile/route.ts
@@ -1,17 +1,9 @@
+import { misconfiguredBackendResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+
 const BASE_API_URL = process.env.BACKEND_API_URL;
 
 export async function GET(request: Request) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const backendUrl = `${BASE_API_URL}/users/profile`;
@@ -40,29 +32,12 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "GET /api/users/profile" }, error);
   }
 }
 
 export async function PATCH(request: Request) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const body = await request.json();
@@ -92,13 +67,6 @@ export async function PATCH(request: Request) {
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "PATCH /api/users/profile" }, error);
   }
 }

--- a/xconfess-frontend/app/api/users/register/route.ts
+++ b/xconfess-frontend/app/api/users/register/route.ts
@@ -1,17 +1,9 @@
+import { misconfiguredBackendResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+
 const BASE_API_URL = process.env.BACKEND_API_URL;
 
 export async function POST(request: Request) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const body = await request.json();
@@ -38,13 +30,6 @@ export async function POST(request: Request) {
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "POST /api/users/register" }, error);
   }
 }

--- a/xconfess-frontend/app/api/users/stats/route.ts
+++ b/xconfess-frontend/app/api/users/stats/route.ts
@@ -1,17 +1,9 @@
+import { misconfiguredBackendResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+
 const BASE_API_URL = process.env.BACKEND_API_URL;
 
 export async function GET(request: Request) {
-  if (!BASE_API_URL) {
-    return new Response(
-      JSON.stringify({
-        message: "Server misconfiguration: BACKEND_API_URL is not set.",
-      }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const backendUrl = `${BASE_API_URL}/users/stats`;
@@ -38,13 +30,6 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
-    console.error("Error proxying to backend:", error);
-    return new Response(
-      JSON.stringify({ message: "Internal server error" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return internalProxyErrorResponse({ route: "GET /api/users/stats" }, error);
   }
 }

--- a/xconfess-frontend/app/lib/utils/__tests__/proxyError.test.ts
+++ b/xconfess-frontend/app/lib/utils/__tests__/proxyError.test.ts
@@ -1,0 +1,481 @@
+import {
+  buildProxyErrorResponse,
+  logProxyError,
+  misconfiguredBackendResponse,
+  backendHttpErrorResponse,
+  backendUnreachableResponse,
+  internalProxyErrorResponse,
+  type ProxyErrorContext,
+  type ProxyErrorBody,
+} from "../proxyError";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function bodyOf(res: Response): Promise<ProxyErrorBody> {
+  return res.json() as Promise<ProxyErrorBody>;
+}
+
+function makeSpy() {
+  return jest.spyOn(console, "error").mockImplementation(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// buildProxyErrorResponse
+// ---------------------------------------------------------------------------
+
+describe("buildProxyErrorResponse", () => {
+  it("sets the given HTTP status", async () => {
+    const res = buildProxyErrorResponse("Not found", 404);
+    expect(res.status).toBe(404);
+  });
+
+  it("sets Content-Type: application/json", () => {
+    const res = buildProxyErrorResponse("Error", 500);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("includes message in the body", async () => {
+    const res = buildProxyErrorResponse("Something broke", 500);
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Something broke");
+  });
+
+  it("includes a real correlationId in the body", async () => {
+    const res = buildProxyErrorResponse("Error", 400, {
+      correlationId: "req-abc-123",
+    });
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBe("req-abc-123");
+  });
+
+  it('omits correlationId when it is the sentinel "unknown"', async () => {
+    const res = buildProxyErrorResponse("Error", 500, {
+      correlationId: "unknown",
+    });
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBeUndefined();
+  });
+
+  it("omits correlationId when it is an empty string", async () => {
+    const res = buildProxyErrorResponse("Error", 500, { correlationId: "" });
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBeUndefined();
+  });
+
+  it("omits correlationId when ctx is not provided", async () => {
+    const res = buildProxyErrorResponse("Error", 500);
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBeUndefined();
+  });
+
+  it("includes backendStatus when provided", async () => {
+    const res = buildProxyErrorResponse("Error", 502, { backendStatus: 503 });
+    const body = await bodyOf(res);
+    expect(body.backendStatus).toBe(503);
+  });
+
+  it("omits backendStatus when not provided", async () => {
+    const res = buildProxyErrorResponse("Error", 500);
+    const body = await bodyOf(res);
+    expect(body.backendStatus).toBeUndefined();
+  });
+
+  it("includes both correlationId and backendStatus together", async () => {
+    const res = buildProxyErrorResponse("Upstream failed", 502, {
+      correlationId: "cid-42",
+      backendStatus: 503,
+    });
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBe("cid-42");
+    expect(body.backendStatus).toBe(503);
+  });
+
+  it("produces valid JSON that round-trips cleanly", async () => {
+    const res = buildProxyErrorResponse("Test", 400, {
+      correlationId: "cid-99",
+      backendStatus: 400,
+    });
+    const text = await res.text();
+    expect(() => JSON.parse(text)).not.toThrow();
+    const parsed = JSON.parse(text) as ProxyErrorBody;
+    expect(parsed.message).toBe("Test");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logProxyError
+// ---------------------------------------------------------------------------
+
+describe("logProxyError", () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = makeSpy();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it("formats prefix with route and CID", () => {
+    logProxyError("Backend error", {
+      route: "GET /api/confessions",
+      correlationId: "cid-1",
+    });
+    expect(spy).toHaveBeenCalledWith(
+      "[GET /api/confessions] Backend error (CID: cid-1)",
+    );
+  });
+
+  it("includes backendStatus in the prefix", () => {
+    logProxyError("Backend error", {
+      route: "POST /api/confessions",
+      correlationId: "cid-2",
+      backendStatus: 422,
+    });
+    expect(spy).toHaveBeenCalledWith(
+      "[POST /api/confessions] Backend error status=422 (CID: cid-2)",
+    );
+  });
+
+  it("appends cause as a second console argument", () => {
+    const err = new Error("ECONNREFUSED");
+    logProxyError("Failed to reach backend", { route: "GET /api/foo" }, err);
+    expect(spy).toHaveBeenCalledWith(
+      "[GET /api/foo] Failed to reach backend",
+      err,
+    );
+  });
+
+  it('omits "(CID: ...)" when correlationId is "unknown"', () => {
+    logProxyError("Internal error", {
+      route: "GET /api/bar",
+      correlationId: "unknown",
+    });
+    expect(spy).toHaveBeenCalledWith("[GET /api/bar] Internal error");
+  });
+
+  it("omits CID segment when correlationId is absent", () => {
+    logProxyError("Internal error", { route: "GET /api/bar" });
+    expect(spy).toHaveBeenCalledWith("[GET /api/bar] Internal error");
+  });
+
+  it("works without a route (no brackets)", () => {
+    logProxyError("Some error", {});
+    expect(spy).toHaveBeenCalledWith("Some error");
+  });
+
+  it("works without a route but with a cause", () => {
+    const cause = new TypeError("bad type");
+    logProxyError("Oops", {}, cause);
+    expect(spy).toHaveBeenCalledWith("Oops", cause);
+  });
+
+  it("includes all three segments when route, backendStatus, and CID are present", () => {
+    logProxyError("Backend error", {
+      route: "PATCH /api/users/profile",
+      correlationId: "cid-99",
+      backendStatus: 409,
+    });
+    expect(spy).toHaveBeenCalledWith(
+      "[PATCH /api/users/profile] Backend error status=409 (CID: cid-99)",
+    );
+  });
+
+  it("calls console.error exactly once per invocation", () => {
+    logProxyError("Test", { route: "GET /api/test", correlationId: "c" });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// misconfiguredBackendResponse
+// ---------------------------------------------------------------------------
+
+describe("misconfiguredBackendResponse", () => {
+  it("returns 503", () => {
+    expect(misconfiguredBackendResponse().status).toBe(503);
+  });
+
+  it("mentions BACKEND_API_URL in the message", async () => {
+    const body = await bodyOf(misconfiguredBackendResponse());
+    expect(body.message).toMatch(/BACKEND_API_URL/);
+  });
+
+  it("sets Content-Type: application/json", () => {
+    const res = misconfiguredBackendResponse();
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("does not include correlationId or backendStatus", async () => {
+    const body = await bodyOf(misconfiguredBackendResponse());
+    expect(body.correlationId).toBeUndefined();
+    expect(body.backendStatus).toBeUndefined();
+  });
+
+  it("does not call console.error", () => {
+    const spy = makeSpy();
+    misconfiguredBackendResponse();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backendHttpErrorResponse
+// ---------------------------------------------------------------------------
+
+describe("backendHttpErrorResponse", () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = makeSpy();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  const ctx: ProxyErrorContext = {
+    route: "POST /api/confessions",
+    correlationId: "cid-http",
+  };
+
+  it("mirrors the backend HTTP status", async () => {
+    const res = backendHttpErrorResponse("Duplicate", 409, "Failed", ctx);
+    expect(res.status).toBe(409);
+  });
+
+  it("uses backendMessage when provided", async () => {
+    const res = backendHttpErrorResponse("Duplicate entry", 409, "Fallback", ctx);
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Duplicate entry");
+  });
+
+  it("falls back to fallbackMessage when backendMessage is undefined", async () => {
+    const res = backendHttpErrorResponse(undefined, 500, "Fallback msg", ctx);
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Fallback msg");
+  });
+
+  it("falls back to fallbackMessage when backendMessage is empty string", async () => {
+    const res = backendHttpErrorResponse("", 500, "Fallback msg", ctx);
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Fallback msg");
+  });
+
+  it("embeds backendStatus in the body", async () => {
+    const res = backendHttpErrorResponse("Error", 502, "Fallback", ctx);
+    const body = await bodyOf(res);
+    expect(body.backendStatus).toBe(502);
+  });
+
+  it("embeds correlationId in the body", async () => {
+    const res = backendHttpErrorResponse("Error", 400, "Fallback", ctx);
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBe("cid-http");
+  });
+
+  it("calls console.error exactly once", () => {
+    backendHttpErrorResponse("Error", 503, "Fallback", ctx);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes route label and status in the log output", () => {
+    backendHttpErrorResponse("Error", 404, "Fallback", {
+      route: "GET /api/confessions/42",
+      correlationId: "cid-log",
+    });
+    const [logged] = spy.mock.calls[0] as [string];
+    expect(logged).toContain("[GET /api/confessions/42]");
+    expect(logged).toContain("status=404");
+    expect(logged).toContain("CID: cid-log");
+  });
+
+  it("works correctly with a 404 status", async () => {
+    const res = backendHttpErrorResponse("Not found", 404, "Fallback", ctx);
+    expect(res.status).toBe(404);
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Not found");
+    expect(body.backendStatus).toBe(404);
+  });
+
+  it("omits correlationId from body when ctx has no correlationId", async () => {
+    const res = backendHttpErrorResponse("Error", 500, "Fallback", {
+      route: "GET /api/test",
+    });
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backendUnreachableResponse
+// ---------------------------------------------------------------------------
+
+describe("backendUnreachableResponse", () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = makeSpy();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  const ctx: ProxyErrorContext = {
+    route: "GET /api/confessions",
+    correlationId: "cid-unreach",
+  };
+
+  it("returns 503", () => {
+    const res = backendUnreachableResponse(ctx, new Error("ECONNREFUSED"));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns a human-readable unavailability message", async () => {
+    const res = backendUnreachableResponse(ctx, new Error("timeout"));
+    const body = await bodyOf(res);
+    expect(body.message).toMatch(/unavailable/i);
+  });
+
+  it("includes correlationId in the body", async () => {
+    const res = backendUnreachableResponse(ctx, new Error("timeout"));
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBe("cid-unreach");
+  });
+
+  it("does not include backendStatus (no response was received)", async () => {
+    const res = backendUnreachableResponse(ctx, new Error("timeout"));
+    const body = await bodyOf(res);
+    expect(body.backendStatus).toBeUndefined();
+  });
+
+  it("calls console.error exactly once", () => {
+    backendUnreachableResponse(ctx, new Error("fail"));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the cause as a second argument to console.error", () => {
+    const cause = new Error("ECONNREFUSED");
+    backendUnreachableResponse(ctx, cause);
+    expect(spy).toHaveBeenCalledWith(expect.any(String), cause);
+  });
+
+  it("includes the route label in the log", () => {
+    backendUnreachableResponse(ctx, new Error("DNS fail"));
+    const [logged] = spy.mock.calls[0] as [string];
+    expect(logged).toContain("[GET /api/confessions]");
+  });
+
+  it("handles a non-Error cause (string)", () => {
+    expect(() =>
+      backendUnreachableResponse(ctx, "connection timed out"),
+    ).not.toThrow();
+  });
+
+  it("handles an undefined cause gracefully", () => {
+    expect(() => backendUnreachableResponse(ctx, undefined)).not.toThrow();
+  });
+
+  it("sets Content-Type: application/json", () => {
+    const res = backendUnreachableResponse(ctx, new Error("fail"));
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// internalProxyErrorResponse
+// ---------------------------------------------------------------------------
+
+describe("internalProxyErrorResponse", () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = makeSpy();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  const ctx: ProxyErrorContext = {
+    route: "POST /api/confessions",
+    correlationId: "cid-internal",
+  };
+
+  it("returns 500", () => {
+    const res = internalProxyErrorResponse(ctx, new Error("crash"));
+    expect(res.status).toBe(500);
+  });
+
+  it("uses the Error message when cause is an Error", async () => {
+    const res = internalProxyErrorResponse(ctx, new Error("Unexpected crash"));
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Unexpected crash");
+  });
+
+  it('returns "Internal server error" for non-Error cause', async () => {
+    const res = internalProxyErrorResponse(ctx, "some string");
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Internal server error");
+  });
+
+  it('returns "Internal server error" for null cause', async () => {
+    const res = internalProxyErrorResponse(ctx, null);
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Internal server error");
+  });
+
+  it('returns "Internal server error" for numeric cause', async () => {
+    const res = internalProxyErrorResponse(ctx, 42);
+    const body = await bodyOf(res);
+    expect(body.message).toBe("Internal server error");
+  });
+
+  it("includes correlationId in the body", async () => {
+    const res = internalProxyErrorResponse(ctx, new Error("boom"));
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBe("cid-internal");
+  });
+
+  it("does not include backendStatus", async () => {
+    const res = internalProxyErrorResponse(ctx, new Error("boom"));
+    const body = await bodyOf(res);
+    expect(body.backendStatus).toBeUndefined();
+  });
+
+  it("calls console.error exactly once", () => {
+    internalProxyErrorResponse(ctx, new Error("boom"));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the cause as second argument to console.error", () => {
+    const cause = new Error("raw cause");
+    internalProxyErrorResponse(ctx, cause);
+    expect(spy).toHaveBeenCalledWith(expect.any(String), cause);
+  });
+
+  it("includes route label in the log", () => {
+    internalProxyErrorResponse(ctx, new Error("oops"));
+    const [logged] = spy.mock.calls[0] as [string];
+    expect(logged).toContain("[POST /api/confessions]");
+  });
+
+  it("sets Content-Type: application/json", () => {
+    const res = internalProxyErrorResponse(ctx, new Error("oops"));
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("omits correlationId from body when ctx has sentinel value", async () => {
+    const res = internalProxyErrorResponse(
+      { route: "GET /api/test", correlationId: "unknown" },
+      new Error("boom"),
+    );
+    const body = await bodyOf(res);
+    expect(body.correlationId).toBeUndefined();
+  });
+});

--- a/xconfess-frontend/app/lib/utils/proxyError.ts
+++ b/xconfess-frontend/app/lib/utils/proxyError.ts
@@ -1,0 +1,260 @@
+/**
+ * Centralized error-shaping helpers for App Router proxy routes.
+ *
+ * Every proxy handler should use these instead of building its own
+ * `new Response(JSON.stringify(...))` blocks and ad-hoc `console.error` calls.
+ *
+ * Design goals
+ * ────────────
+ *  • Stable JSON body shape: { message, correlationId?, backendStatus? }
+ *  • Structured log prefix:  [METHOD /path] <label> status=N (CID: id)
+ *  • `correlationId` is forwarded only when it is a real value – the
+ *    sentinel string "unknown" is stripped so clients don't see noise.
+ *  • Named factories cover every recurring failure scenario so call-sites
+ *    read like documentation rather than inline error-construction logic.
+ */
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const JSON_CONTENT_TYPE = { "Content-Type": "application/json" } as const;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Contextual tags that travel with every log line and error body.
+ *
+ * @example
+ * const ctx: ProxyErrorContext = {
+ *   route: "GET /api/confessions",
+ *   correlationId: request.headers.get("X-Correlation-ID") ?? undefined,
+ * };
+ */
+export interface ProxyErrorContext {
+  /**
+   * Human-readable route label used as the log prefix.
+   * Recommended format: `"METHOD /api/path"`, e.g. `"GET /api/confessions"`.
+   */
+  route: string;
+
+  /**
+   * Correlation ID forwarded from the client's `X-Correlation-ID` header.
+   * The sentinel value `"unknown"` is treated as absent and will be omitted
+   * from both log lines and response bodies.
+   */
+  correlationId?: string;
+
+  /**
+   * HTTP status code returned by the upstream backend, when a response was
+   * received. Included in the response body so clients can distinguish
+   * "backend said 422" from "proxy said 422".
+   */
+  backendStatus?: number;
+}
+
+/**
+ * Stable JSON shape emitted by every proxy error response.
+ * Consumers can rely on `message` always being present.
+ */
+export interface ProxyErrorBody {
+  message: string;
+  /** Present only when the request carried a real correlation ID. */
+  correlationId?: string;
+  /** Present only when the upstream backend returned an HTTP response. */
+  backendStatus?: number;
+}
+
+// ─── Internal utilities ───────────────────────────────────────────────────────
+
+/**
+ * Returns the correlation ID if it is a genuine value, or `undefined` when it
+ * is absent or equal to the "unknown" sentinel used by several route handlers.
+ */
+function resolveCorrelationId(id: string | undefined): string | undefined {
+  if (!id || id === "unknown") return undefined;
+  return id;
+}
+
+// ─── Core primitive: response builder ─────────────────────────────────────────
+
+/**
+ * Build a `Response` with a consistent JSON error body and the
+ * `Content-Type: application/json` header.
+ *
+ * Fields are only included in the body when they carry meaningful data:
+ *  – `correlationId` is omitted when absent or `"unknown"`.
+ *  – `backendStatus` is omitted when not provided.
+ *
+ * @param message     Human-readable error description forwarded to the client.
+ * @param httpStatus  The HTTP status code of the *proxy* response.
+ * @param ctx         Optional contextual tags to embed in the body.
+ */
+export function buildProxyErrorResponse(
+  message: string,
+  httpStatus: number,
+  ctx: Partial<ProxyErrorContext> = {},
+): Response {
+  const body: ProxyErrorBody = { message };
+
+  const cid = resolveCorrelationId(ctx.correlationId);
+  if (cid) body.correlationId = cid;
+
+  if (ctx.backendStatus !== undefined) body.backendStatus = ctx.backendStatus;
+
+  return new Response(JSON.stringify(body), {
+    status: httpStatus,
+    headers: JSON_CONTENT_TYPE,
+  });
+}
+
+// ─── Core primitive: structured logger ────────────────────────────────────────
+
+/**
+ * Emit a structured `console.error` line with a consistent prefix.
+ *
+ * Log format (all optional segments are only appended when present):
+ * ```
+ * [GET /api/confessions] Backend error status=502 (CID: abc-123) <cause?>
+ * ```
+ *
+ * @param label Short description of the failure, e.g. `"Backend error"`.
+ * @param ctx   Contextual tags used to build the log prefix.
+ * @param cause Optional original error or message to append as a second
+ *              argument so the JS console renders it as an expandable object.
+ */
+export function logProxyError(
+  label: string,
+  ctx: Partial<ProxyErrorContext>,
+  cause?: unknown,
+): void {
+  const cid = resolveCorrelationId(ctx.correlationId);
+  const cidSegment = cid ? ` (CID: ${cid})` : "";
+  const statusSegment =
+    ctx.backendStatus !== undefined ? ` status=${ctx.backendStatus}` : "";
+  const prefix = ctx.route
+    ? `[${ctx.route}] ${label}${statusSegment}${cidSegment}`
+    : `${label}${statusSegment}${cidSegment}`;
+
+  if (cause !== undefined) {
+    console.error(prefix, cause);
+  } else {
+    console.error(prefix);
+  }
+}
+
+// ─── Named scenario factories ──────────────────────────────────────────────────
+
+/**
+ * **503 – Missing `BACKEND_API_URL`.**
+ *
+ * Returns a pre-built response for when the required environment variable has
+ * not been set. Does *not* log – configuration errors are expected to surface
+ * at application startup, not on every request.
+ *
+ * @example
+ * if (!process.env.BACKEND_API_URL) return misconfiguredBackendResponse();
+ */
+export function misconfiguredBackendResponse(): Response {
+  return buildProxyErrorResponse(
+    "Server misconfiguration: BACKEND_API_URL is not set. Contact the system administrator.",
+    503,
+  );
+}
+
+/**
+ * **Mirrors backend status – non-2xx upstream response.**
+ *
+ * Logs the failure with the backend's status code and returns a response that
+ * mirrors that status so the client can react appropriately (e.g. show a 404
+ * page when the upstream says 404, surface a 429 when rate-limited).
+ *
+ * The `backendStatus` is embedded in both the log line and the response body
+ * so it is always preserved, even when the proxy remaps the HTTP status.
+ *
+ * @param backendMessage  `message` extracted from the backend error payload.
+ *                        When absent or empty, `fallbackMessage` is used.
+ * @param backendStatus   HTTP status returned by the upstream backend.
+ * @param fallbackMessage Client-facing message when the backend body is empty.
+ * @param ctx             Route context for logging and body enrichment.
+ *
+ * @example
+ * const errorData = await res.json().catch(() => ({}));
+ * return backendHttpErrorResponse(
+ *   errorData.message,
+ *   res.status,
+ *   `Failed to create confession: ${res.statusText}`,
+ *   { route: "POST /api/confessions", correlationId },
+ * );
+ */
+export function backendHttpErrorResponse(
+  backendMessage: string | undefined,
+  backendStatus: number,
+  fallbackMessage: string,
+  ctx: ProxyErrorContext,
+): Response {
+  const message = backendMessage || fallbackMessage;
+  const enriched: ProxyErrorContext = { ...ctx, backendStatus };
+  logProxyError("Backend error", enriched);
+  return buildProxyErrorResponse(message, backendStatus, enriched);
+}
+
+/**
+ * **503 – Backend unreachable (network / fetch error).**
+ *
+ * Use this in `catch` blocks that surround a `fetch()` call to the upstream.
+ * Logs the underlying cause for server-side diagnostics and returns a generic
+ * "service unavailable" message to the client so internal details are not
+ * leaked.
+ *
+ * @param ctx   Route context for logging and body enrichment.
+ * @param cause The caught error, forwarded to `console.error` as a second
+ *              argument so it remains inspectable in the server logs.
+ *
+ * @example
+ * try {
+ *   const res = await fetch(backendUrl, ...);
+ * } catch (fetchError) {
+ *   return backendUnreachableResponse(ctx, fetchError);
+ * }
+ */
+export function backendUnreachableResponse(
+  ctx: ProxyErrorContext,
+  cause: unknown,
+): Response {
+  logProxyError("Failed to reach backend", ctx, cause);
+  return buildProxyErrorResponse(
+    "Backend service unavailable. Please try again later.",
+    503,
+    ctx,
+  );
+}
+
+/**
+ * **500 – Unexpected internal error inside a proxy handler.**
+ *
+ * Use this in the outermost `catch` block of a route handler for exceptions
+ * that are not network failures or backend errors – e.g. JSON parse failures,
+ * programming bugs, or unanticipated runtime exceptions.
+ *
+ * When `cause` is an `Error` instance its `message` is used directly;
+ * otherwise a generic `"Internal server error"` is returned to the client.
+ *
+ * @param ctx   Route context for logging and body enrichment.
+ * @param cause The caught value.
+ *
+ * @example
+ * } catch (error) {
+ *   return internalProxyErrorResponse(
+ *     { route: "POST /api/confessions", correlationId },
+ *     error,
+ *   );
+ * }
+ */
+export function internalProxyErrorResponse(
+  ctx: ProxyErrorContext,
+  cause: unknown,
+): Response {
+  const message =
+    cause instanceof Error ? cause.message : "Internal server error";
+  logProxyError("Internal error", ctx, cause);
+  return buildProxyErrorResponse(message, 500, ctx);
+}


### PR DESCRIPTION
Close: #680

A new shared helper file was created at `app/lib/utils/proxyError.ts`. It contains two low-level building blocks — one that constructs a properly shaped JSON error `Response`, and one that writes a structured `console.error` line — plus four named factory functions that cover every recurring failure scenario a proxy route can hit: missing backend URL, non-OK response from the backend, network failure reaching the backend, and unexpected internal errors.

A test file was added alongside it with 47 unit tests covering every exported function and their edge cases.

All 23 route files under `app/api/` were then updated to import and use those helpers instead of their own inline logic. The specific problems each change fixed:

- The 8-line `new Response(JSON.stringify({message: "Server misconfiguration..."}))` block that was copy-pasted verbatim into 8 different user and confession routes was replaced with a single `misconfiguredBackendResponse()` call.

- Every scattered `console.error` call that used a different label format — some said `"Error proxying to backend:"`, others said `"[POST /confessions] Backend error: 502 (CID: ...)"`, others said `"Error fetching comments:"` — was replaced by `logProxyError(...)`, which always produces the same `[METHOD /path] label status=N (CID: id)` format.

- All four notification routes had a silent bug where `if (!response.ok) { throw new Error("...") }` discarded the real backend HTTP status and always returned 500 to the client. These were fixed to use `backendHttpErrorResponse(...)`, which mirrors the actual backend status code in both the response and the log.

- Correlation IDs were missing from the response bodies and log lines of the notification routes, the reaction route, and the anchor route. All three now extract `X-Correlation-ID` from the incoming request and pass it through every error path.

- Five routes that produced errors with no logging at all — `report`, `search`, `auth/session`, `analytics`, and `trending` — now emit a log line on every failure.