### PR TITLE
unify CSV export feedback across admin analytics and reports

### DIFF
--- a/xconfess-frontend/app/components/admin/AnalyticsDashboard.tsx
+++ b/xconfess-frontend/app/components/admin/AnalyticsDashboard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Analytics } from '@/app/lib/api/admin';
-import { useGlobalToast } from '@/app/components/common/Toast';
+import { useExportCSV } from '@/app/lib/hooks/useExportCSV';
+import { ExportCsvButton } from '@/app/components/admin/ExportCsvButton';
 import {
   LineChart,
   Line,
@@ -17,7 +18,6 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import { exportToCSV } from '@/app/lib/utils/csvExport';
 
 interface AnalyticsDashboardProps {
   analytics: Analytics;
@@ -26,7 +26,7 @@ interface AnalyticsDashboardProps {
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884d8', '#82ca9d'];
 
 export default function AnalyticsDashboard({ analytics }: AnalyticsDashboardProps) {
-  const toast = useGlobalToast();
+  const { triggerExport, isExporting } = useExportCSV({ label: 'analytics' });
   const { overview, reports, trends } = analytics;
 
   const reportsByStatusData = reports.byStatus.map((item) => ({
@@ -45,35 +45,14 @@ export default function AnalyticsDashboard({ analytics }: AnalyticsDashboardProp
   }));
 
   const handleExportAnalytics = () => {
-    const exportData = [
-      {
-        metric: 'Total Users',
-        value: overview.totalUsers,
-      },
-      {
-        metric: 'Active Users (30d)',
-        value: overview.activeUsers,
-      },
-      {
-        metric: 'Total Confessions',
-        value: overview.totalConfessions,
-      },
-      {
-        metric: 'Total Reports',
-        value: overview.totalReports,
-      },
-      {
-        metric: 'Banned Users',
-        value: overview.bannedUsers,
-      },
-      {
-        metric: 'Hidden Confessions',
-        value: overview.hiddenConfessions,
-      },
-      {
-        metric: 'Deleted Confessions',
-        value: overview.deletedConfessions,
-      },
+    const exportData: Record<string, unknown>[] = [
+      { metric: 'Total Users',           value: overview.totalUsers },
+      { metric: 'Active Users (30d)',     value: overview.activeUsers },
+      { metric: 'Total Confessions',      value: overview.totalConfessions },
+      { metric: 'Total Reports',          value: overview.totalReports },
+      { metric: 'Banned Users',           value: overview.bannedUsers },
+      { metric: 'Hidden Confessions',     value: overview.hiddenConfessions },
+      { metric: 'Deleted Confessions',    value: overview.deletedConfessions },
       ...reports.byStatus.map((item) => ({
         metric: `Reports - ${item.status}`,
         value: parseInt(item.count, 10),
@@ -83,27 +62,18 @@ export default function AnalyticsDashboard({ analytics }: AnalyticsDashboardProp
         value: parseInt(item.count, 10),
       })),
     ];
-    const exported = exportToCSV(
-      exportData,
-      `analytics-${new Date().toISOString().split('T')[0]}.csv`,
-    );
-    if (!exported) {
-      toast.warning('No analytics data available to export.');
-      return;
-    }
 
-    toast.success('Analytics CSV exported.');
+    triggerExport(exportData, `analytics-${new Date().toISOString().split('T')[0]}.csv`);
   };
 
   return (
     <div className="space-y-6">
       <div className="flex justify-end">
-        <button
+        <ExportCsvButton
           onClick={handleExportAnalytics}
-          className="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 text-sm"
-        >
-          Export Analytics CSV
-        </button>
+          isExporting={isExporting}
+          label="Export Analytics CSV"
+        />
       </div>
       {/* Overview Cards */}
       <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">

--- a/xconfess-frontend/app/components/admin/ExportCsvButton.tsx
+++ b/xconfess-frontend/app/components/admin/ExportCsvButton.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Download, Loader2 } from 'lucide-react';
+import { cn } from '@/app/lib/utils/cn';
+
+export interface ExportCsvButtonProps {
+  onClick: () => void;
+  /** When true, disables the button and swaps the icon for a spinner. */
+  isExporting?: boolean;
+  /** Visible button label. Defaults to "Export CSV". */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Shared export-to-CSV trigger used across all admin surfaces.
+ *
+ * Renders a consistent button with:
+ * - A Download icon in the idle state
+ * - A spinning Loader2 icon while exporting
+ * - `aria-busy` + `aria-label` so screen readers announce progress
+ * - `disabled` to prevent duplicate clicks during export
+ */
+export function ExportCsvButton({
+  onClick,
+  isExporting = false,
+  label = 'Export CSV',
+  className,
+}: ExportCsvButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isExporting}
+      aria-busy={isExporting}
+      aria-label={isExporting ? 'Exporting, please wait…' : label}
+      className={cn(
+        'inline-flex items-center gap-2 rounded-md bg-gray-600 px-4 py-2 text-sm font-medium text-white',
+        'transition-colors hover:bg-gray-700',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2',
+        'disabled:cursor-not-allowed disabled:opacity-60',
+        className,
+      )}
+    >
+      {isExporting ? (
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+      ) : (
+        <Download className="h-4 w-4" aria-hidden="true" />
+      )}
+      <span>{isExporting ? 'Exporting…' : label}</span>
+    </button>
+  );
+}

--- a/xconfess-frontend/app/components/admin/ReportList.tsx
+++ b/xconfess-frontend/app/components/admin/ReportList.tsx
@@ -6,7 +6,8 @@ import { adminApi, Report } from "@/app/lib/api/admin";
 import ReportDetail from "./ReportDetail";
 import { ConfirmDialog } from "@/app/components/admin/ConfirmDialog";
 import { useGlobalToast } from "@/app/components/common/Toast";
-import { exportToCSV } from "@/app/lib/utils/csvExport";
+import { useExportCSV } from "@/app/lib/hooks/useExportCSV";
+import { ExportCsvButton } from "@/app/components/admin/ExportCsvButton";
 
 export default function ReportList() {
   const [selectedReport, setSelectedReport] = useState<string | null>(null);
@@ -20,6 +21,7 @@ export default function ReportList() {
 
   const queryClient = useQueryClient();
   const toast = useGlobalToast();
+  const { triggerExport, isExporting: isExportingCsv } = useExportCSV({ label: 'reports' });
 
   const { data, isLoading } = useQuery({
     queryKey: [
@@ -287,9 +289,9 @@ export default function ReportList() {
             />
           </div>
           <div className="flex items-end gap-2">
-            <button
+            <ExportCsvButton
               onClick={() => {
-                const exportData = reports.map((r: Report) => ({
+                const exportData: Record<string, unknown>[] = reports.map((r: Report) => ({
                   id: r.id,
                   type: r.type,
                   status: r.status,
@@ -300,21 +302,14 @@ export default function ReportList() {
                     ? new Date(r.resolvedAt).toLocaleString()
                     : "",
                 }));
-                const exported = exportToCSV(
+                triggerExport(
                   exportData,
                   `reports-${new Date().toISOString().split("T")[0]}.csv`,
                 );
-                if (!exported) {
-                  toast.warning("No reports available to export.");
-                  return;
-                }
-
-                toast.success("Reports CSV exported.");
               }}
-              className="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 text-sm"
-            >
-              Export CSV
-            </button>
+              isExporting={isExportingCsv}
+              label="Export Reports CSV"
+            />
             {selectedIds.size > 0 && (
               <button
                 onClick={handleBulkResolve}

--- a/xconfess-frontend/app/lib/hooks/useExportCSV.ts
+++ b/xconfess-frontend/app/lib/hooks/useExportCSV.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { exportToCSV, CsvEmptyError } from '@/app/lib/utils/csvExport';
+import { useGlobalToast } from '@/app/components/common/Toast';
+
+export interface UseExportCSVOptions {
+  /**
+   * Short noun that names the exported data, used in toast copy.
+   * e.g. "analytics", "reports"
+   */
+  label: string;
+}
+
+export interface UseExportCSVReturn {
+  /**
+   * Call this to kick off an export.
+   * Handles empty-state, success, and failure toasts automatically.
+   */
+  triggerExport: (data: Record<string, unknown>[], filename: string) => void;
+  /** True while the CSV is being generated and the download is initiated. */
+  isExporting: boolean;
+}
+
+/**
+ * Centralises CSV-export feedback so every admin export surface shows the
+ * same success, empty-state, and failure messaging without browser alerts.
+ *
+ * @example
+ * const { triggerExport, isExporting } = useExportCSV({ label: 'reports' });
+ * triggerExport(rows, 'reports-2024-01-01.csv');
+ */
+export function useExportCSV({ label }: UseExportCSVOptions): UseExportCSVReturn {
+  const [isExporting, setIsExporting] = useState(false);
+  const toast = useGlobalToast();
+
+  const triggerExport = useCallback(
+    (data: Record<string, unknown>[], filename: string) => {
+      setIsExporting(true);
+
+      try {
+        exportToCSV(data, filename);
+
+        const rowWord = data.length === 1 ? 'row' : 'rows';
+        toast.success(`${data.length} ${rowWord} exported to ${filename}.`);
+      } catch (err) {
+        if (err instanceof CsvEmptyError) {
+          toast.warning(
+            `No ${label} to export. Try adjusting your filters.`,
+          );
+        } else {
+          toast.error('Export failed — please try again.');
+        }
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [label, toast],
+  );
+
+  return { triggerExport, isExporting };
+}

--- a/xconfess-frontend/app/lib/utils/csvExport.ts
+++ b/xconfess-frontend/app/lib/utils/csvExport.ts
@@ -1,31 +1,49 @@
-export function exportToCSV(data: any[], filename: string): boolean {
+/** Thrown when there is no data to include in the CSV. */
+export class CsvEmptyError extends Error {
+  constructor() {
+    super('No data to export.');
+    this.name = 'CsvEmptyError';
+  }
+}
+
+/**
+ * Serialises `data` to a CSV file and triggers a browser download.
+ *
+ * @throws {CsvEmptyError}  when `data` is empty.
+ * @throws {Error}          when the browser fails to create or download the file.
+ */
+export function exportToCSV(data: Record<string, unknown>[], filename: string): void {
   if (data.length === 0) {
-    return false;
+    throw new CsvEmptyError();
   }
 
   const headers = Object.keys(data[0]);
+
+  const escape = (value: unknown): string => {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'object') return `"${JSON.stringify(value).replace(/"/g, '""')}"`;
+    return `"${String(value).replace(/"/g, '""')}"`;
+  };
+
   const csvContent = [
     headers.join(','),
-    ...data.map((row) =>
-      headers
-        .map((header) => {
-          const value = row[header];
-          if (value === null || value === undefined) return '';
-          if (typeof value === 'object') return JSON.stringify(value);
-          return `"${String(value).replace(/"/g, '""')}"`;
-        })
-        .join(','),
-    ),
+    ...data.map((row) => headers.map((h) => escape(row[h])).join(',')),
   ].join('\n');
 
-  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-  const link = document.createElement('a');
-  const url = URL.createObjectURL(blob);
-  link.setAttribute('href', url);
-  link.setAttribute('download', filename);
-  link.style.visibility = 'hidden';
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  return true;
+  try {
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.setAttribute('href', url);
+    link.setAttribute('download', filename);
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    throw new Error(
+      `Failed to create CSV download: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }


### PR DESCRIPTION
Close: #695 
Here's a summary of every change made and the reasoning behind each decision:

## What changed and why

### `app/lib/utils/csvExport.ts` — hardened utility

Three improvements:
1. **`CsvEmptyError` class** — gives callers a typed signal they can `instanceof`-check. Previously the empty case returned `false`, which any caller had to remember to handle.
2. **Download step wrapped in `try/catch`** — `URL.createObjectURL` and `document.body.appendChild` are browser APIs that can throw in certain sandboxed or privacy-hardened contexts. Now those failures surface as a real `Error` instead of a silent crash.
3. **`URL.revokeObjectURL` added** — the object URL was previously leaked after the click.

### `app/lib/hooks/useExportCSV.ts` — new shared hook

This is the single source of truth for all three message states:

| State | Toast type | Message |
|---|---|---|
| Empty | `warning` | `No {label} to export. Try adjusting your filters.` |
| Success | `success` | `{n} row(s) exported to {filename}.` |
| Failure | `error` | `Export failed — please try again.` |

It also owns `isExporting` state, which prevents double-clicks and drives the button's spinner.

### `app/components/admin/ExportCsvButton.tsx` — new shared button

A single reusable button that both export surfaces now render identically:
- **Idle**: `Download` icon + label text
- **Busy**: `Loader2` spinner + "Exporting…" text, `disabled`, `aria-busy=true`, `aria-label="Exporting, please wait…"`
- `focus-visible` ring for keyboard users
- Accepts a `className` prop for context-specific layout overrides