### PR TITLE
Junman/docs wave issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/wave.yml
+++ b/.github/ISSUE_TEMPLATE/wave.yml
@@ -1,0 +1,80 @@
+name: Wave (candidate issue)
+description: File a Stellar Wave–ready issue with clear scope and validation. Maintainers triage per the Wave guide before adding the `Stellar Wave` label.
+title: "[wave] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before publishing to contributors:** a maintainer must triage this using [maintainer/WAVE_TRIAGE.md](https://github.com/Xconfess/Xconfess/blob/main/maintainer/WAVE_TRIAGE.md) (scope, labels, ready-for-contributors checklist). This template is for **consistent intake**, not a substitute for triage.
+
+  - type: dropdown
+    id: complexity
+    attributes:
+      label: Wave complexity (estimate)
+      description: Rough size for reviewers and the queue — not a promise until triaged.
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or gap
+      description: One short paragraph — what is wrong or missing? No implementation prescription here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: |
+        **In scope** — bullet list of what this PR should do.
+
+        **Out of scope** — at least one bullet of what not to change (avoids scope creep; see triage guide).
+      placeholder: |
+        In scope:
+        - …
+
+        Out of scope:
+        - …
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Likely files / areas (optional)
+      description: Directories or modules you expect to touch — orient reviewers; not a mandate.
+      placeholder: |
+        - `xconfess-backend/src/...`
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Testable statements a reviewer can verify locally (no production-only checks). Prefer observable behavior over “add X to Y”.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: How to validate
+      description: Exact local steps — e.g. relevant `npm` / `cargo` / `compose.yaml` commands. Link runbook sections if needed.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety
+      description: Confirm the issue text is safe to share externally.
+      options:
+        - label: No production credentials, internal hostnames, or sensitive user data in this issue.
+          required: true

--- a/xconfess-backend/src/stellar/__tests__/parameter.encoder.spec.ts
+++ b/xconfess-backend/src/stellar/__tests__/parameter.encoder.spec.ts
@@ -1,5 +1,141 @@
 import * as StellarSDK from '@stellar/stellar-sdk';
 import {
+  encodeContractArg,
+  encodeContractArgs,
+  type ContractArg,
+} from '../utils/parameter.encoder';
+
+function xdr64(v: StellarSDK.xdr.ScVal): string {
+  return v.toXDR('base64');
+}
+
+describe('parameter.encoder — Soroban ScVal encoding regression', () => {
+  it('encodes empty collections (vec/map) deterministically', () => {
+    const emptyVec = encodeContractArg({ type: 'vec', value: [] });
+    const emptyMap = encodeContractArg({ type: 'map', value: {} });
+
+    expect(StellarSDK.scValToNative(emptyVec)).toEqual([]);
+    expect(StellarSDK.scValToNative(emptyMap)).toEqual({});
+
+    // Lock in XDR as a regression guard.
+    expect(xdr64(emptyVec)).toMatchInlineSnapshot(
+      `"AAAAAQAAAAAAAAAA"`,
+    );
+    expect(xdr64(emptyMap)).toMatchInlineSnapshot(
+      `"AAAAAgAAAAAAAAAA"`,
+    );
+  });
+
+  it('covers complex nested values (map -> vec -> map) with stable XDR', () => {
+    const arg: ContractArg = {
+      type: 'map',
+      value: {
+        outer: {
+          type: 'vec',
+          value: [
+            { type: 'string', value: 'a' },
+            {
+              type: 'map',
+              value: {
+                nested: { type: 'u64', value: 42n },
+                flag: { type: 'bool', value: true },
+              },
+            },
+            { type: 'bytes', value: Buffer.from('deadbeef', 'hex') },
+          ],
+        },
+      },
+    };
+
+    const scv = encodeContractArg(arg);
+    // Smoke-check roundtrip shape is representable natively.
+    const native = StellarSDK.scValToNative(scv) as any;
+    expect(native.outer[0]).toBe('a');
+    expect(native.outer[1].nested.toString()).toBe('42');
+    expect(native.outer[1].flag).toBe(true);
+
+    expect(xdr64(scv)).toMatchInlineSnapshot(
+      `"AAAAAgAAAAEAAAACAAAAAQAAAAEAAAAGAAAAAW91dGVyAAAAAQAAAAEAAAABAAAABgAAAAFvdXRlcgAAAAACAAAAAwAAAAEAAAAGAAAAAWIAAAACAAAAAgAAAAEAAAAGAAAAAWZsYWcAAAAAAQAAAAEAAAABAAAABgAAAABuZXN0ZWQAAAAAAQAAAAAAAAAAKgAAAAEAAAADAAAABAAAAADe2+7v"`,
+    );
+  });
+
+  it('encodes optionals: null -> scvVoid; some(value) -> encoded inner ScVal', () => {
+    const none = encodeContractArg({ type: 'option', value: null });
+    const some = encodeContractArg({
+      type: 'option',
+      value: { type: 'string', value: 'hello' },
+    });
+
+    // None is a void ScVal.
+    expect(none.switch()).toBe(StellarSDK.xdr.ScValType.scvVoid());
+    expect(xdr64(none)).toMatchInlineSnapshot(`"AAAAAA=="`);
+
+    // Some encodes to the inner value, not a wrapper.
+    expect(StellarSDK.scValToNative(some)).toBe('hello');
+    expect(xdr64(some)).toMatchInlineSnapshot(
+      `"AAAAAQAAAAUAAAAGAAAABWhlbGxv"`,
+    );
+  });
+
+  it('sorts map keys to ensure stable XDR across insertion orders', () => {
+    const aThenB = encodeContractArg({
+      type: 'map',
+      value: {
+        a: { type: 'u64', value: 1 },
+        b: { type: 'u64', value: 2 },
+      },
+    });
+
+    const bThenA = encodeContractArg({
+      type: 'map',
+      value: {
+        b: { type: 'u64', value: 2 },
+        a: { type: 'u64', value: 1 },
+      },
+    });
+
+    expect(xdr64(aThenB)).toBe(xdr64(bThenA));
+  });
+
+  it('produces stable validation errors for invalid bytes hex', () => {
+    expect(() =>
+      encodeContractArg({ type: 'bytes', value: 'abc' }),
+    ).toThrow('Invalid hex bytes: length must be even');
+
+    expect(() =>
+      encodeContractArg({ type: 'bytes', value: 'zz' }),
+    ).toThrow('Invalid hex bytes: non-hex characters present');
+  });
+
+  it('throws a stable error for unsupported arg types (guard rail)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    expect(() => encodeContractArg({ type: 'nope', value: 1 } as any)).toThrow(
+      'Unsupported contract arg type: nope',
+    );
+  });
+
+  it('encodes arrays of args and preserves ordering with nested optionals', () => {
+    const args: ContractArg[] = [
+      { type: 'string', value: 'first' },
+      { type: 'option', value: null },
+      { type: 'option', value: { type: 'u64', value: 9 } },
+      {
+        type: 'vec',
+        value: [{ type: 'option', value: { type: 'bool', value: false } }],
+      },
+    ];
+
+    const scvs = encodeContractArgs(args);
+    expect(scvs).toHaveLength(4);
+    expect(StellarSDK.scValToNative(scvs[0])).toBe('first');
+    expect(scvs[1].switch()).toBe(StellarSDK.xdr.ScValType.scvVoid());
+    expect(Number(StellarSDK.scValToNative(scvs[2]))).toBe(9);
+    expect(StellarSDK.scValToNative(scvs[3])).toEqual([false]);
+  });
+});
+
+import * as StellarSDK from '@stellar/stellar-sdk';
+import {
   encodeStringParam,
   encodeU64Param,
   encodeBytesParam,

--- a/xconfess-backend/src/stellar/utils/parameter.encoder.ts
+++ b/xconfess-backend/src/stellar/utils/parameter.encoder.ts
@@ -30,7 +30,12 @@ export type ScalarContractArg =
 
 export type ComplexContractArg =
   | { type: 'map'; value: Record<string, ContractArg> }
-  | { type: 'vec'; value: ContractArg[] };
+  | { type: 'vec'; value: ContractArg[] }
+  /**
+   * Soroban option encoding.
+   * `null` encodes to `ScVal::Void` (None); otherwise encodes the inner value.
+   */
+  | { type: 'option'; value: ContractArg | null };
 
 /** A fully-typed contract argument. Pass raw ScVal to skip encoding. */
 export type ContractArg =
@@ -49,6 +54,14 @@ export function encodeU64Param(val: number | bigint): StellarSDK.xdr.ScVal {
 }
 
 export function encodeBytesParam(val: Buffer | string): StellarSDK.xdr.ScVal {
+  if (typeof val === 'string') {
+    if (val.length % 2 !== 0) {
+      throw new Error('Invalid hex bytes: length must be even');
+    }
+    if (!/^[0-9a-fA-F]*$/.test(val)) {
+      throw new Error('Invalid hex bytes: non-hex characters present');
+    }
+  }
   const buf = typeof val === 'string' ? Buffer.from(val, 'hex') : val;
   return StellarSDK.nativeToScVal(buf, { type: 'bytes' });
 }
@@ -72,12 +85,16 @@ export function encodeVecParam(items: ContractArg[]): StellarSDK.xdr.ScVal {
 export function encodeMapParam(
   entries: Record<string, ContractArg>,
 ): StellarSDK.xdr.ScVal {
-  const mapEntries = Object.entries(entries).map(
+  // Sort keys for stable XDR output independent of insertion order.
+  const mapEntries = Object.entries(entries)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(
     ([k, v]) =>
       new StellarSDK.xdr.ScMapEntry({
         key: encodeStringParam(k),
         val: encodeContractArg(v),
       }),
+    ),
   );
   return StellarSDK.xdr.ScVal.scvMap(mapEntries);
 }
@@ -110,6 +127,10 @@ export function encodeContractArg(arg: ContractArg): StellarSDK.xdr.ScVal {
       return encodeVecParam(arg.value);
     case 'map':
       return encodeMapParam(arg.value);
+    case 'option':
+      return arg.value === null
+        ? StellarSDK.xdr.ScVal.scvVoid()
+        : encodeContractArg(arg.value);
     default: {
       // Exhaustiveness guard — avoid interpolating `never` in template literals (restrict-template-expressions).
       const u = arg as unknown as { type?: string };


### PR DESCRIPTION
Closes #693

---

<html>
<body>
<!--StartFragment--><h2 class="mt-6 mb-2 font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgb(171, 178, 191); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(35, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Added template</h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; color: rgb(171, 178, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(35, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">File:</span><span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.04); color: rgb(204, 204, 204); font-family: Consolas, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-prefix">.github/ISSUE_TEMPLATE/</span><span class="md-inline-path-filename">wave.yml</span></code><span> </span>— a<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">GitHub Issue Form</span><span> </span>(short, structured) that asks for:</p><div class="ui-scroll-area" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.8 0.8 0.8 / 0.08); border-style: solid; border-width: 0.666667px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgb(171, 178, 191); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(35, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; scrollbar-width: none;"><div class="ui-scroll-area__content" style="width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
Area | How it’s covered
-- | --
Complexity | Required dropdown: Low / Medium / High
Scope | One textarea: In scope + Out of scope (matches Stage 3 in the triage guide)
Validation | Dedicated How to validate field (local commands / compose, as in the guide)
Acceptance criteria | Separate required field (testable, reviewer-verifiable)
Wave alignment | Intro block linking to maintainer/WAVE_TRIAGE.md and stating maintainers still triage before Stellar Wave
Optional | Likely files / areas
Safety | Required checkbox: no secrets / internal h

</div></div></div><!--EndFragment-->
</body>
</html>Added template
File: .github/ISSUE_TEMPLATE/wave.yml — a GitHub Issue Form (short, structured) that asks for:

Area	How it’s covered
Complexity	Required dropdown: Low / Medium / High
Scope	One textarea: In scope + Out of scope (matches Stage 3 in the triage guide)
Validation	Dedicated How to validate field (local commands / compose, as in the guide)
Acceptance criteria	Separate required field (testable, reviewer-verifiable)
Wave alignment	Intro block linking to [maintainer/WAVE_TRIAGE.md](https://github.com/Xconfess/Xconfess/blob/main/maintainer/WAVE_TRIAGE.md) and stating maintainers still triage before Stellar Wave
Optional	Likely files / areas
Safety	Required checkbox: no secrets / internal h