### PR TITLE
Feat/one time download token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -414,6 +414,7 @@
       "version": "7.28.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2344,6 +2345,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2367,6 +2369,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3995,6 +3998,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -4054,6 +4058,7 @@
       "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -5462,6 +5467,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -5930,6 +5936,7 @@
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6076,7 +6083,6 @@
       "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6097,7 +6103,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6108,7 +6113,6 @@
       "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
       }
@@ -6118,8 +6122,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/dom/node_modules/pretty-format": {
       "version": "27.5.1",
@@ -6127,7 +6130,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6142,8 +6144,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -6657,6 +6658,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -6691,6 +6693,7 @@
     "node_modules/@types/react": {
       "version": "19.2.9",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6699,6 +6702,7 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6925,6 +6929,7 @@
       "version": "8.53.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -7982,6 +7987,7 @@
       "version": "8.15.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8037,6 +8043,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8735,6 +8742,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -9153,6 +9161,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9232,6 +9241,7 @@
       "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
       "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "^4.9.0",
         "get-port": "^5.1.1",
@@ -9259,6 +9269,7 @@
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.71.1.tgz",
       "integrity": "sha512-kOBfdcsHmO6wwmIjpersoVdYQ7jkjTgky4Yop0loc7QwSdgxliSzD69U9ijZuRrkyCJwz5p5eqxeGeQkJ0YGZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "4.9.0",
         "ioredis": "5.10.1",
@@ -9303,6 +9314,7 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -9334,6 +9346,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -9608,6 +9621,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -9653,13 +9667,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -10719,7 +10735,6 @@
       "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.5",
@@ -11286,7 +11301,6 @@
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -11422,6 +11436,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11520,6 +11535,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11609,6 +11625,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12097,6 +12114,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -12906,8 +12924,7 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -13374,6 +13391,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -13428,7 +13446,6 @@
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -13585,7 +13602,6 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -13931,7 +13947,6 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -14058,6 +14073,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -14832,6 +14848,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -16721,7 +16738,6 @@
       "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -16737,7 +16753,6 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -16826,7 +16841,6 @@
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1"
@@ -17185,6 +17199,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -17295,6 +17310,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -17563,6 +17579,7 @@
       "version": "3.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17848,6 +17865,7 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17855,6 +17873,7 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17878,7 +17897,8 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -17908,6 +17928,7 @@
     "node_modules/react-redux": {
       "version": "9.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -18136,7 +18157,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -18875,8 +18897,7 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -19728,7 +19749,8 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -19831,6 +19853,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20042,6 +20065,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20633,6 +20657,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21218,6 +21243,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21287,6 +21313,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21997,6 +22024,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -22322,6 +22350,7 @@
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -22368,6 +22397,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -22749,6 +22779,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/xconfess-backend/src/data-export/data-export.controller.spec.ts
+++ b/xconfess-backend/src/data-export/data-export.controller.spec.ts
@@ -25,6 +25,8 @@ describe('DataExportController', () => {
       getExportFile: jest.fn(),
       getExportChunk: jest.fn(),
       generateSignedDownloadUrl: jest.fn(),
+      validateAndConsumeToken: jest.fn().mockResolvedValue(true),
+      invalidateDownloadToken: jest.fn(),
     } as any;
 
     mockConfigService = {
@@ -58,18 +60,50 @@ describe('DataExportController', () => {
 
   // ── Download Endpoint Security Tests ────────────────────────────────────────
 
+  // Helper: build a valid signed token + signature for single-file downloads.
+  function buildSingleFileParams(
+    requestId: string,
+    userId: string,
+    expiresMs: number,
+    token: string,
+    secret = 'test-secret',
+  ) {
+    const dataToSign = `${requestId}:${userId}:${expiresMs}:${token}`;
+    const signature = crypto
+      .createHmac('sha256', secret)
+      .update(dataToSign)
+      .digest('hex');
+    return { signature, token };
+  }
+
+  // Helper: build a valid signed signature for chunked downloads.
+  function buildChunkParams(
+    requestId: string,
+    userId: string,
+    chunkIndex: number,
+    expiresMs: number,
+    secret = 'test-secret',
+  ) {
+    const dataToSign = `${requestId}:${userId}:${chunkIndex}:${expiresMs}`;
+    const signature = crypto
+      .createHmac('sha256', secret)
+      .update(dataToSign)
+      .digest('hex');
+    return { signature };
+  }
+
   describe('Download Endpoint Security', () => {
     it('should reject download requests with expired timestamps', async () => {
       const expiredTime = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
       const requestId = 'req-1';
       const userId = 'user-1';
-
-      // Generate valid signature for expired time
-      const dataToSign = `${requestId}:${userId}:${expiredTime}`;
-      const signature = crypto
-        .createHmac('sha256', 'test-secret')
-        .update(dataToSign)
-        .digest('hex');
+      const token = 'sometoken';
+      const { signature } = buildSingleFileParams(
+        requestId,
+        userId,
+        expiredTime,
+        token,
+      );
 
       await expect(
         controller.download(
@@ -78,13 +112,14 @@ describe('DataExportController', () => {
           expiredTime.toString(),
           signature,
           undefined,
+          token,
           {} as any,
         ),
       ).rejects.toThrow(UnauthorizedException);
     });
 
     it('should reject download requests with invalid signatures', async () => {
-      const futureTime = Date.now() + 60 * 60 * 1000; // 1 hour from now
+      const futureTime = Date.now() + 60 * 60 * 1000;
       const requestId = 'req-1';
       const userId = 'user-1';
       const invalidSignature = 'invalid-signature';
@@ -96,6 +131,7 @@ describe('DataExportController', () => {
           futureTime.toString(),
           invalidSignature,
           undefined,
+          'any-token',
           {} as any,
         ),
       ).rejects.toThrow(UnauthorizedException);
@@ -104,33 +140,123 @@ describe('DataExportController', () => {
     it('should reject download requests with malformed timestamps', async () => {
       const requestId = 'req-1';
       const userId = 'user-1';
-      const malformedTime = 'not-a-number';
-      const signature = 'any-signature';
 
       await expect(
         controller.download(
           requestId,
           userId,
-          malformedTime,
+          'not-a-number',
+          'any-signature',
+          undefined,
+          'any-token',
+          {} as any,
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should reject single-file download when token is missing', async () => {
+      const futureTime = Date.now() + 60 * 60 * 1000;
+      const requestId = 'req-1';
+      const userId = 'user-1';
+      const token = 'valid-token';
+      const { signature } = buildSingleFileParams(
+        requestId,
+        userId,
+        futureTime,
+        token,
+      );
+
+      // Pass undefined token — should reject even with a valid signature.
+      await expect(
+        controller.download(
+          requestId,
+          userId,
+          futureTime.toString(),
           signature,
+          undefined,
           undefined,
           {} as any,
         ),
       ).rejects.toThrow(UnauthorizedException);
     });
 
+    it('should reject replayed single-file download after token consumed', async () => {
+      const futureTime = Date.now() + 60 * 60 * 1000;
+      const requestId = 'req-1';
+      const userId = 'user-1';
+      const token = 'used-token';
+      const { signature } = buildSingleFileParams(
+        requestId,
+        userId,
+        futureTime,
+        token,
+      );
+
+      // Simulate token already consumed.
+      mockExportService.validateAndConsumeToken.mockResolvedValue(false);
+
+      await expect(
+        controller.download(
+          requestId,
+          userId,
+          futureTime.toString(),
+          signature,
+          undefined,
+          token,
+          {} as any,
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should consume the token on first successful single-file download', async () => {
+      const futureTime = Date.now() + 60 * 60 * 1000;
+      const requestId = 'req-1';
+      const userId = 'user-1';
+      const token = 'fresh-token';
+      const { signature } = buildSingleFileParams(
+        requestId,
+        userId,
+        futureTime,
+        token,
+      );
+
+      mockExportService.validateAndConsumeToken.mockResolvedValue(true);
+      mockExportService.getExportFile.mockResolvedValue({
+        fileData: Buffer.from('zip content'),
+        isChunked: false,
+      } as any);
+
+      const mockRes = { set: jest.fn(), send: jest.fn() } as any;
+
+      await controller.download(
+        requestId,
+        userId,
+        futureTime.toString(),
+        signature,
+        undefined,
+        token,
+        mockRes,
+      );
+
+      expect(mockExportService.validateAndConsumeToken).toHaveBeenCalledWith(
+        requestId,
+        userId,
+        token,
+      );
+      expect(mockRes.send).toHaveBeenCalled();
+    });
+
     it('should handle chunked download signature validation', async () => {
-      const futureTime = Date.now() + 60 * 60 * 1000; // 1 hour from now
+      const futureTime = Date.now() + 60 * 60 * 1000;
       const requestId = 'req-1';
       const userId = 'user-1';
       const chunkIndex = '2';
-
-      // Generate valid signature
-      const dataToSign = `${requestId}:${userId}:${chunkIndex}:${futureTime}`;
-      const signature = crypto
-        .createHmac('sha256', 'test-secret')
-        .update(dataToSign)
-        .digest('hex');
+      const { signature } = buildChunkParams(
+        requestId,
+        userId,
+        2,
+        futureTime,
+      );
 
       const mockChunk = {
         fileData: Buffer.from('chunk data'),
@@ -140,10 +266,7 @@ describe('DataExportController', () => {
 
       mockExportService.getExportChunk.mockResolvedValue(mockChunk as any);
 
-      const mockRes = {
-        set: jest.fn(),
-        send: jest.fn(),
-      } as any;
+      const mockRes = { set: jest.fn(), send: jest.fn() } as any;
 
       await controller.download(
         requestId,
@@ -151,6 +274,7 @@ describe('DataExportController', () => {
         futureTime.toString(),
         signature,
         chunkIndex,
+        undefined,
         mockRes,
       );
 
@@ -173,11 +297,10 @@ describe('DataExportController', () => {
       const userId = 'user-1';
       const chunkIndex = '2';
 
-      // Generate signature without chunk (invalid for chunked request)
-      const dataToSign = `${requestId}:${userId}:${futureTime}`;
-      const signature = crypto
+      // Signature built without chunk index — invalid for a chunked request.
+      const badSig = crypto
         .createHmac('sha256', 'test-secret')
-        .update(dataToSign)
+        .update(`${requestId}:${userId}:${futureTime}`)
         .digest('hex');
 
       await expect(
@@ -185,8 +308,9 @@ describe('DataExportController', () => {
           requestId,
           userId,
           futureTime.toString(),
-          signature,
+          badSig,
           chunkIndex,
+          undefined,
           {} as any,
         ),
       ).rejects.toThrow(UnauthorizedException);
@@ -196,12 +320,13 @@ describe('DataExportController', () => {
       const futureTime = Date.now() + 60 * 60 * 1000;
       const requestId = 'req-1';
       const userId = 'user-1';
-
-      const dataToSign = `${requestId}:${userId}:${futureTime}`;
-      const signature = crypto
-        .createHmac('sha256', 'test-secret')
-        .update(dataToSign)
-        .digest('hex');
+      const token = 'tok';
+      const { signature } = buildSingleFileParams(
+        requestId,
+        userId,
+        futureTime,
+        token,
+      );
 
       const mockChunkedExport = {
         fileData: null,
@@ -215,19 +340,17 @@ describe('DataExportController', () => {
         mockChunkedExport as any,
       );
       mockExportService.generateSignedDownloadUrl
-        .mockReturnValueOnce(
+        .mockResolvedValueOnce(
           'https://backend.example.com/api/data-export/download/req-1?userId=user-1&expires=123&signature=abc&chunk=0',
         )
-        .mockReturnValueOnce(
+        .mockResolvedValueOnce(
           'https://backend.example.com/api/data-export/download/req-1?userId=user-1&expires=123&signature=def&chunk=1',
         )
-        .mockReturnValueOnce(
+        .mockResolvedValueOnce(
           'https://backend.example.com/api/data-export/download/req-1?userId=user-1&expires=123&signature=ghi&chunk=2',
         );
 
-      const mockRes = {
-        json: jest.fn(),
-      } as any;
+      const mockRes = { json: jest.fn() } as any;
 
       await controller.download(
         requestId,
@@ -235,6 +358,7 @@ describe('DataExportController', () => {
         futureTime.toString(),
         signature,
         undefined,
+        token,
         mockRes,
       );
 
@@ -255,12 +379,13 @@ describe('DataExportController', () => {
       const futureTime = Date.now() + 60 * 60 * 1000;
       const requestId = 'req-1';
       const userId = 'user-1';
-
-      const dataToSign = `${requestId}:${userId}:${futureTime}`;
-      const signature = crypto
-        .createHmac('sha256', 'test-secret')
-        .update(dataToSign)
-        .digest('hex');
+      const token = 'tok';
+      const { signature } = buildSingleFileParams(
+        requestId,
+        userId,
+        futureTime,
+        token,
+      );
 
       mockExportService.getExportFile.mockResolvedValue(null);
 
@@ -271,6 +396,7 @@ describe('DataExportController', () => {
           futureTime.toString(),
           signature,
           undefined,
+          token,
           {} as any,
         ),
       ).rejects.toThrow(BadRequestException);

--- a/xconfess-backend/src/data-export/data-export.controller.ts
+++ b/xconfess-backend/src/data-export/data-export.controller.ts
@@ -65,15 +65,17 @@ export class DataExportController {
   @Get('download/:id')
   async download(
     @Param('id') id: string,
-    @Res() res: Response,
     @Query('userId') userId: string,
     @Query('expires') expires: string,
     @Query('signature') signature: string,
-    @Query('chunk') chunk?: string,
+    @Query('chunk') chunk: string | undefined,
+    @Query('token') token: string | undefined,
+    @Res() res: Response,
   ) {
     // 1. Check Expiration
-    if (Date.now() > parseInt(expires)) {
-      throw new UnauthorizedException('Download link has expired (24h limit).');
+    const expiresMs = parseInt(expires);
+    if (isNaN(expiresMs) || Date.now() > expiresMs) {
+      throw new UnauthorizedException('Download link has expired.');
     }
 
     // 2. Verify Signature
@@ -83,7 +85,7 @@ export class DataExportController {
     const dataToVerify =
       chunkIndex !== undefined
         ? `${id}:${userId}:${chunkIndex}:${expires}`
-        : `${id}:${userId}:${expires}`;
+        : `${id}:${userId}:${expires}:${token}`;
 
     const expectedSignature = crypto
       .createHmac('sha256', secret || 'APP_SECRET_NOT_SET')
@@ -94,7 +96,24 @@ export class DataExportController {
       throw new UnauthorizedException('Invalid download signature.');
     }
 
-    // 3. Fetch from Service (Only if signature is valid)
+    // 3. Validate one-time token (single-file downloads only)
+    if (chunkIndex === undefined) {
+      if (!token) {
+        throw new UnauthorizedException('Download token missing.');
+      }
+      const valid = await this.exportService.validateAndConsumeToken(
+        id,
+        userId,
+        token,
+      );
+      if (!valid) {
+        throw new UnauthorizedException(
+          'Download link has already been used or is invalid. Request a new link.',
+        );
+      }
+    }
+
+    // 4. Fetch from Service
     if (chunkIndex !== undefined) {
       const exportChunk = await this.exportService.getExportChunk(
         id,
@@ -119,15 +138,18 @@ export class DataExportController {
     }
 
     if (exportReq.isChunked) {
-      // Return metadata and links for chunked export
+      // Return metadata and signed chunk URLs
+      const downloadUrls = await Promise.all(
+        Array.from({ length: exportReq.chunkCount }, (_, i) =>
+          this.exportService.generateSignedDownloadUrl(id, userId, i),
+        ),
+      );
       return res.json({
         message: 'This export is multi-part.',
         chunkCount: exportReq.chunkCount,
         totalSize: exportReq.totalSize,
         checksum: exportReq.combinedChecksum,
-        downloadUrls: Array.from({ length: exportReq.chunkCount }, (_, i) =>
-          this.exportService.generateSignedDownloadUrl(id, userId, i),
-        ),
+        downloadUrls,
       });
     }
 
@@ -135,18 +157,13 @@ export class DataExportController {
       throw new BadRequestException('File not found or expired.');
     }
 
-    // 4. Stream to User (Single file)
-    const fileData = exportReq.fileData;
-    if (!fileData) {
-      throw new BadRequestException('File not found or expired.');
-    }
-
+    // 5. Stream single file
     res.set({
       'Content-Type': 'application/zip',
       'Content-Disposition': `attachment; filename="xconfess-data-${userId}.zip"`,
-      'Content-Length': fileData.length,
+      'Content-Length': exportReq.fileData.length,
     });
 
-    res.send(fileData);
+    res.send(exportReq.fileData);
   }
 }

--- a/xconfess-backend/src/data-export/data-export.service.ts
+++ b/xconfess-backend/src/data-export/data-export.service.ts
@@ -162,19 +162,30 @@ export class DataExportService {
     });
   }
 
-  generateSignedDownloadUrl(
+  async generateSignedDownloadUrl(
     requestId: string,
     userId: string,
     chunkIndex?: number,
-  ): string {
-    const expires = Date.now() + 24 * 60 * 60 * 1000; // 24 hours from now
+  ): Promise<string> {
+    const ttlMs = this.configService.get<number>(
+      'app.exportDownloadTtlMs',
+      24 * 60 * 60 * 1000,
+    );
+    const expires = Date.now() + ttlMs;
     const secret = this.configService.get<string>('app.appSecret', '');
 
-    // Create a hash of the payload
+    // For single-file downloads generate and persist a one-time nonce so the
+    // link cannot be replayed after the first successful download.
+    let token: string | undefined;
+    if (chunkIndex === undefined) {
+      token = crypto.randomBytes(16).toString('hex');
+      await this.exportRepository.update(requestId, { downloadToken: token });
+    }
+
     const dataToSign =
       chunkIndex !== undefined
         ? `${requestId}:${userId}:${chunkIndex}:${expires}`
-        : `${requestId}:${userId}:${expires}`;
+        : `${requestId}:${userId}:${expires}:${token}`;
 
     const signature = crypto
       .createHmac('sha256', secret || 'APP_SECRET_NOT_SET')
@@ -197,7 +208,38 @@ export class DataExportService {
       .catch(() => undefined);
 
     const chunkParam = chunkIndex !== undefined ? `&chunk=${chunkIndex}` : '';
-    return `${baseUrl}/api/data-export/download/${requestId}?userId=${userId}&expires=${expires}&signature=${signature}${chunkParam}`;
+    const tokenParam = token !== undefined ? `&token=${token}` : '';
+    return `${baseUrl}/api/data-export/download/${requestId}?userId=${userId}&expires=${expires}&signature=${signature}${chunkParam}${tokenParam}`;
+  }
+
+  /**
+   * Invalidates the current download token after a successful download.
+   * Subsequent requests with the same token will be rejected.
+   */
+  async invalidateDownloadToken(requestId: string): Promise<void> {
+    await this.exportRepository.update(requestId, {
+      downloadToken: null,
+      downloadedAt: new Date(),
+    });
+  }
+
+  /**
+   * Validates that the supplied token matches the stored one-time nonce and,
+   * if so, atomically consumes it to prevent replay.
+   * Returns false if the token is missing, expired, or already used.
+   */
+  async validateAndConsumeToken(
+    requestId: string,
+    userId: string,
+    token: string,
+  ): Promise<boolean> {
+    const record = await this.exportRepository.findOne({
+      where: { id: requestId, userId },
+      select: ['downloadToken'] as any,
+    });
+    if (!record || record.downloadToken !== token) return false;
+    await this.invalidateDownloadToken(requestId);
+    return true;
   }
 
   async getExportFile(requestId: string, userId: string) {
@@ -273,17 +315,26 @@ export class DataExportService {
   }
 
   private getExpiryTimestamp(createdAt: Date): number {
-    return new Date(createdAt).getTime() + 24 * 60 * 60 * 1000;
+    const ttlMs = this.configService.get<number>(
+      'app.exportDownloadTtlMs',
+      24 * 60 * 60 * 1000,
+    );
+    return new Date(createdAt).getTime() + ttlMs;
   }
 
-  private isDownloadStillValid(
+  /** True when the underlying export file is still within its TTL window. */
+  private isFileAvailable(
     request: Pick<ExportRequest, 'status' | 'createdAt'>,
   ): boolean {
-    if (request.status !== 'READY') {
-      return false;
-    }
-
+    if (request.status !== 'READY') return false;
     return Date.now() <= this.getExpiryTimestamp(request.createdAt);
+  }
+
+  /** True when a valid one-time token exists and the file is still available. */
+  private hasActiveToken(
+    request: Pick<ExportRequest, 'status' | 'createdAt' | 'downloadToken'>,
+  ): boolean {
+    return this.isFileAvailable(request) && request.downloadToken !== null;
   }
 
   private buildProgress(request: Partial<ExportRequest>): ExportProgress {
@@ -298,7 +349,7 @@ export class DataExportService {
     };
   }
 
-  private toHistoryItem(
+  private async toHistoryItem(
     request: Pick<
       ExportRequest,
       | 'id'
@@ -312,15 +363,17 @@ export class DataExportService {
       | 'expiredAt'
       | 'retryCount'
       | 'lastFailureReason'
+      | 'downloadToken'
     >,
-  ): ExportHistoryItem {
+  ): Promise<ExportHistoryItem> {
     const expiresAt =
       request.status === 'READY'
         ? this.getExpiryTimestamp(request.createdAt)
         : null;
-    const canRedownload = this.isDownloadStillValid(request);
+    const fileAvailable = this.isFileAvailable(request);
+    const canRedownload = this.hasActiveToken(request);
     const normalizedStatus: ExportHistoryStatus =
-      request.status === 'READY' && !canRedownload
+      request.status === 'READY' && !fileAvailable
         ? 'EXPIRED'
         : (request.status as ExportHistoryStatus);
 
@@ -330,9 +383,10 @@ export class DataExportService {
       createdAt: request.createdAt,
       expiresAt,
       canRedownload,
-      canRequestNewLink: normalizedStatus === 'EXPIRED',
+      // Allow regeneration when the file is still available but the token was consumed.
+      canRequestNewLink: fileAvailable && !canRedownload,
       downloadUrl: canRedownload
-        ? this.generateSignedDownloadUrl(request.id, request.userId)
+        ? await this.generateSignedDownloadUrl(request.id, request.userId)
         : null,
       progress: this.buildProgress(request),
     };
@@ -351,6 +405,7 @@ export class DataExportService {
     'expiredAt',
     'retryCount',
     'lastFailureReason',
+    'downloadToken',
   ] as const;
 
   async getExportHistory(
@@ -364,7 +419,7 @@ export class DataExportService {
       select: this.lifecycleSelect as any,
     });
 
-    return requests.map((request) => this.toHistoryItem(request));
+    return Promise.all(requests.map((request) => this.toHistoryItem(request)));
   }
 
   async getLatestExport(userId: string): Promise<ExportHistoryItem | null> {
@@ -386,14 +441,17 @@ export class DataExportService {
       select: this.lifecycleSelect as any,
     });
 
-    if (!request || !this.isDownloadStillValid(request)) {
+    if (!request || !this.isFileAvailable(request)) {
       throw new BadRequestException(
         'Secure download link is no longer available. Request a new export.',
       );
     }
 
     return {
-      downloadUrl: this.generateSignedDownloadUrl(request.id, request.userId),
+      downloadUrl: await this.generateSignedDownloadUrl(
+        request.id,
+        request.userId,
+      ),
     };
   }
 

--- a/xconfess-backend/src/data-export/entities/export-request.entity.ts
+++ b/xconfess-backend/src/data-export/entities/export-request.entity.ts
@@ -67,4 +67,17 @@ export class ExportRequest {
   /** The error message from the most recent processor failure. */
   @Column({ type: 'text', nullable: true })
   lastFailureReason!: string | null;
+
+  // ── One-time download token ───────────────────────────────────────────────
+
+  /**
+   * Random hex nonce issued when a signed download URL is generated.
+   * Cleared after the first successful download to prevent replay.
+   */
+  @Column({ type: 'varchar', nullable: true })
+  downloadToken!: string | null;
+
+  /** Timestamp of the first (and only) successful download. */
+  @Column({ type: 'timestamp', nullable: true })
+  downloadedAt!: Date | null;
 }

--- a/xconfess-backend/src/migrations/20260422000000-add-download-token-to-export-requests.ts
+++ b/xconfess-backend/src/migrations/20260422000000-add-download-token-to-export-requests.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDownloadTokenToExportRequests20260422000000
+  implements MigrationInterface
+{
+  name = 'AddDownloadTokenToExportRequests20260422000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "export_requests"
+        ADD COLUMN IF NOT EXISTS "downloadToken"  VARCHAR(255) NULL,
+        ADD COLUMN IF NOT EXISTS "downloadedAt"   TIMESTAMP   NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "export_requests"
+        DROP COLUMN IF EXISTS "downloadToken",
+        DROP COLUMN IF EXISTS "downloadedAt";
+    `);
+  }
+}


### PR DESCRIPTION
Adds one-time download tokens to the data export flow. A hex nonce is generated when a signed URL is created, stored in the database, and invalidated after the first successful download — preventing replay attacks. Chunked downloads are unaffected. Users can request a new link if the token is consumed before the file expires. TTL is now config-driven instead of hardcoded.

Close #424 