### PR TITLE
Feat/contract admin version replay integration

### DIFF
--- a/xconfess-contracts/Cargo.lock
+++ b/xconfess-contracts/Cargo.lock
@@ -258,6 +258,8 @@ dependencies = [
 name = "confession-registry"
 version = "0.1.0"
 dependencies = [
+ "anonymous-tipping",
+ "reputation-badges",
  "soroban-sdk",
 ]
 

--- a/xconfess-contracts/contracts/access_control.rs
+++ b/xconfess-contracts/contracts/access_control.rs
@@ -140,7 +140,9 @@ pub fn init_owner(env: &Env, owner: &Address) -> Result<(), AccessError> {
     env.storage().instance().set(&AccessKey::Admins, &admins);
 
     let operators: Map<Address, ()> = Map::new(env);
-    env.storage().instance().set(&AccessKey::Operators, &operators);
+    env.storage()
+        .instance()
+        .set(&AccessKey::Operators, &operators);
 
     Ok(())
 }
@@ -411,7 +413,9 @@ pub fn grant_operator(env: &Env, caller: &Address, target: &Address) -> Result<(
         .unwrap_or_else(|| Map::new(env));
 
     operators.set(target.clone(), ());
-    env.storage().instance().set(&AccessKey::Operators, &operators);
+    env.storage()
+        .instance()
+        .set(&AccessKey::Operators, &operators);
 
     Ok(())
 }
@@ -432,7 +436,9 @@ pub fn revoke_operator(env: &Env, caller: &Address, target: &Address) -> Result<
         .unwrap_or_else(|| Map::new(env));
 
     operators.remove(target.clone());
-    env.storage().instance().set(&AccessKey::Operators, &operators);
+    env.storage()
+        .instance()
+        .set(&AccessKey::Operators, &operators);
 
     Ok(())
 }

--- a/xconfess-contracts/contracts/access_control.rs
+++ b/xconfess-contracts/contracts/access_control.rs
@@ -47,6 +47,15 @@ use soroban_sdk::{contractevent, contracttype, Address, Env, Map, String};
 pub enum AccessKey {
     Owner,
     Admins,
+    Operators,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Role {
+    Owner,
+    Admin,
+    Operator,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -77,6 +86,10 @@ pub enum AccessError {
     CannotRevokeLastAdmin = 7,
     /// Cannot transfer ownership to same address (code 8).
     InvalidOwnershipTransfer = 8,
+    /// Target address is already an operator (code 9).
+    AlreadyOperator = 9,
+    /// Target address is not an operator (cannot revoke) (code 10).
+    NotOperator = 10,
 }
 
 #[contractevent(topics = ["adm_grant"], data_format = "single-value")]
@@ -126,6 +139,9 @@ pub fn init_owner(env: &Env, owner: &Address) -> Result<(), AccessError> {
     let admins: Map<Address, ()> = Map::new(env);
     env.storage().instance().set(&AccessKey::Admins, &admins);
 
+    let operators: Map<Address, ()> = Map::new(env);
+    env.storage().instance().set(&AccessKey::Operators, &operators);
+
     Ok(())
 }
 
@@ -158,6 +174,25 @@ pub fn is_admin(env: &Env, addr: &Address) -> bool {
     admins.contains_key(addr.clone())
 }
 
+/// Returns `true` if `addr` is in the operator set.
+pub fn is_operator(env: &Env, addr: &Address) -> bool {
+    let operators: Map<Address, ()> = env
+        .storage()
+        .instance()
+        .get(&AccessKey::Operators)
+        .unwrap_or_else(|| Map::new(env));
+    operators.contains_key(addr.clone())
+}
+
+/// Return true when `addr` has the requested role.
+pub fn has_role(env: &Env, addr: &Address, role: Role) -> Result<bool, AccessError> {
+    match role {
+        Role::Owner => is_owner(env, addr),
+        Role::Admin => Ok(is_admin(env, addr)),
+        Role::Operator => Ok(is_operator(env, addr)),
+    }
+}
+
 /// Returns `true` if `addr` is the owner OR is an explicit admin.
 /// Use this as the guard predicate for moderation-level actions (e.g. `resolve`).
 pub fn is_authorized(env: &Env, addr: &Address) -> Result<bool, AccessError> {
@@ -173,6 +208,16 @@ pub fn count_admins(env: &Env) -> u32 {
         .get(&AccessKey::Admins)
         .unwrap_or_else(|| Map::new(env));
     admins.len()
+}
+
+/// Returns the total number of active operators.
+pub fn count_operators(env: &Env) -> u32 {
+    let operators: Map<Address, ()> = env
+        .storage()
+        .instance()
+        .get(&AccessKey::Operators)
+        .unwrap_or_else(|| Map::new(env));
+    operators.len()
 }
 
 /// Returns the total number of authorized addresses (owner + admins).
@@ -209,6 +254,17 @@ pub fn require_admin_or_owner(env: &Env, caller: &Address) -> Result<(), AccessE
     }
 
     Ok(())
+}
+
+/// Require owner OR admin OR operator role for operational routines.
+pub fn require_operator_or_admin_or_owner(env: &Env, caller: &Address) -> Result<(), AccessError> {
+    caller.require_auth();
+
+    if is_owner(env, caller)? || is_admin(env, caller) || is_operator(env, caller) {
+        return Ok(());
+    }
+
+    Err(AccessError::NotAuthorized)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -335,6 +391,48 @@ pub fn internal_transfer_ownership(env: &Env, new_owner: &Address) -> Result<(),
         previous_owner: old_owner,
     }
     .publish(env);
+
+    Ok(())
+}
+
+/// Grant `target` the operator role.
+/// Caller must be owner or admin.
+pub fn grant_operator(env: &Env, caller: &Address, target: &Address) -> Result<(), AccessError> {
+    require_admin_or_owner(env, caller)?;
+
+    if is_operator(env, target) {
+        return Err(AccessError::AlreadyOperator);
+    }
+
+    let mut operators: Map<Address, ()> = env
+        .storage()
+        .instance()
+        .get(&AccessKey::Operators)
+        .unwrap_or_else(|| Map::new(env));
+
+    operators.set(target.clone(), ());
+    env.storage().instance().set(&AccessKey::Operators, &operators);
+
+    Ok(())
+}
+
+/// Revoke `target`'s operator role.
+/// Caller must be owner or admin.
+pub fn revoke_operator(env: &Env, caller: &Address, target: &Address) -> Result<(), AccessError> {
+    require_admin_or_owner(env, caller)?;
+
+    if !is_operator(env, target) {
+        return Err(AccessError::NotOperator);
+    }
+
+    let mut operators: Map<Address, ()> = env
+        .storage()
+        .instance()
+        .get(&AccessKey::Operators)
+        .unwrap_or_else(|| Map::new(env));
+
+    operators.remove(target.clone());
+    env.storage().instance().set(&AccessKey::Operators, &operators);
 
     Ok(())
 }

--- a/xconfess-contracts/contracts/confession-anchor/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-anchor/src/lib.rs
@@ -86,6 +86,8 @@ pub enum Error {
     NotPaused = 10,
     Unauthorized = 11,
     ContractPaused = 12,
+    AlreadyOperator = 13,
+    NotOperator = 14,
 }
 
 impl From<access_control::AccessError> for Error {
@@ -99,6 +101,8 @@ impl From<access_control::AccessError> for Error {
             access_control::AccessError::CannotDemoteOwner => Self::CannotDemoteOwner,
             access_control::AccessError::CannotRevokeLastAdmin => Self::CannotRevokeLastAdmin,
             access_control::AccessError::InvalidOwnershipTransfer => Self::InvalidOwnershipTransfer,
+            access_control::AccessError::AlreadyOperator => Self::AlreadyOperator,
+            access_control::AccessError::NotOperator => Self::NotOperator,
         }
     }
 }
@@ -270,9 +274,19 @@ impl ConfessionAnchor {
         access_control::is_admin(&env, &address)
     }
 
+    /// Check if an address is an operator.
+    pub fn is_operator(env: Env, address: Address) -> bool {
+        access_control::is_operator(&env, &address)
+    }
+
     /// Get count of active admins (excluding the owner).
     pub fn get_admin_count(env: Env) -> u32 {
         access_control::count_admins(&env)
+    }
+
+    /// Get count of active operators.
+    pub fn get_operator_count(env: Env) -> u32 {
+        access_control::count_operators(&env)
     }
 
     /// Grant admin role to an address (owner-only).
@@ -290,21 +304,45 @@ impl ConfessionAnchor {
         access_control::transfer_ownership(&env, &caller, &new_owner).map_err(Into::into)
     }
 
+    /// Grant operator role to an address (owner or admin).
+    pub fn grant_operator(env: Env, caller: Address, target: Address) -> Result<(), Error> {
+        access_control::grant_operator(&env, &caller, &target).map_err(Into::into)
+    }
+
+    /// Revoke operator role from an address (owner or admin).
+    pub fn revoke_operator(env: Env, caller: Address, target: Address) -> Result<(), Error> {
+        access_control::revoke_operator(&env, &caller, &target).map_err(Into::into)
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Pause/Resume Management
     // ─────────────────────────────────────────────────────────────────────────
 
-    /// Pause the contract (owner-only). Blocks anchor_confession writes.
+    /// Pause the contract (owner/admin). Blocks anchor_confession writes.
     /// Read operations (verify, count) remain available.
     pub fn pause(env: Env, caller: Address, reason: String) -> Result<(), Error> {
-        access_control::require_owner(&env, &caller).map_err(Error::from)?;
-        emergency_pause::pause(env, reason).map_err(Into::into)
+        access_control::require_admin_or_owner(&env, &caller).map_err(Error::from)?;
+
+        if emergency_pause::is_paused(&env) {
+            return Err(Error::AlreadyPaused);
+        }
+
+        emergency_pause::set_paused_internal(&env, true);
+        emergency_pause::events::emit_paused(&env, &caller, reason);
+        Ok(())
     }
 
-    /// Unpause the contract (owner-only).
+    /// Unpause the contract (owner/admin).
     pub fn unpause(env: Env, caller: Address, reason: String) -> Result<(), Error> {
-        access_control::require_owner(&env, &caller).map_err(Error::from)?;
-        emergency_pause::unpause(env, reason).map_err(Into::into)
+        access_control::require_admin_or_owner(&env, &caller).map_err(Error::from)?;
+
+        if !emergency_pause::is_paused(&env) {
+            return Err(Error::NotPaused);
+        }
+
+        emergency_pause::set_paused_internal(&env, false);
+        emergency_pause::events::emit_unpaused(&env, &caller, reason);
+        Ok(())
     }
 
     /// Check if the contract is paused.
@@ -367,7 +405,7 @@ impl ConfessionAnchor {
 mod test {
     use super::*;
     use soroban_sdk::{
-        testutils::{Events, Ledger, LedgerInfo},
+        testutils::{Address as _, Events, Ledger, LedgerInfo},
         BytesN, Env, IntoVal, String as SorobanString,
     };
 
@@ -922,6 +960,85 @@ mod test {
         assert_eq!(
             client.get_error_registry_version(),
             errors::ERROR_REGISTRY_VERSION
+        );
+    }
+
+    // ── Group I: Role permission matrix ─────────────────────────────────────
+
+    #[test]
+    fn owner_admin_operator_permission_matrix_for_admin_actions() {
+        let (env, client) = new_client();
+        let owner = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let operator = Address::generate(&env);
+        let outsider = Address::generate(&env);
+
+        client.initialize(&owner);
+
+        // Owner can grant admin; admin can grant operator.
+        client.grant_admin(&owner, &admin);
+        client.grant_operator(&admin, &operator);
+        assert!(client.is_admin(&admin));
+        assert!(client.is_operator(&operator));
+
+        // Owner-only: admin management and ownership transfer.
+        assert_eq!(
+            client.try_grant_admin(&admin, &outsider),
+            Err(Ok(Error::NotOwner))
+        );
+        assert_eq!(
+            client.try_transfer_owner(&admin, &outsider),
+            Err(Ok(Error::NotOwner))
+        );
+
+        // Owner/admin only: pause and unpause.
+        let pause_reason = SorobanString::from_str(&env, "maintenance");
+        client.pause(&admin, &pause_reason);
+        client.unpause(&owner, &pause_reason);
+
+        // Operator cannot execute owner/admin-only actions.
+        assert_eq!(
+            client.try_pause(&operator, &pause_reason),
+            Err(Ok(Error::NotAuthorized))
+        );
+        assert_eq!(
+            client.try_grant_operator(&operator, &outsider),
+            Err(Ok(Error::NotAuthorized))
+        );
+        assert_eq!(
+            client.try_revoke_admin(&operator, &admin),
+            Err(Ok(Error::NotOwner))
+        );
+
+        // Outsider cannot run privileged actions.
+        assert_eq!(
+            client.try_pause(&outsider, &pause_reason),
+            Err(Ok(Error::NotAuthorized))
+        );
+    }
+
+    #[test]
+    fn operator_role_requires_admin_or_owner_assignment() {
+        let (env, client) = new_client();
+        let owner = Address::generate(&env);
+        let outsider = Address::generate(&env);
+        let operator = Address::generate(&env);
+
+        client.initialize(&owner);
+
+        assert_eq!(
+            client.try_grant_operator(&outsider, &operator),
+            Err(Ok(Error::NotAuthorized))
+        );
+        client.grant_operator(&owner, &operator);
+        assert_eq!(
+            client.try_grant_operator(&owner, &operator),
+            Err(Ok(Error::AlreadyOperator))
+        );
+        client.revoke_operator(&owner, &operator);
+        assert_eq!(
+            client.try_revoke_operator(&owner, &operator),
+            Err(Ok(Error::NotOperator))
         );
     }
 }

--- a/xconfess-contracts/contracts/confession-anchor/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-anchor/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(dead_code)]
 
 mod errors;
 mod events;
@@ -295,17 +296,23 @@ impl ConfessionAnchor {
     }
 
     /// Read-only compatibility predicate used by deployment automation.
-    pub fn can_upgrade_from(_env: Env, from_major: u32, from_minor: u32, from_patch: u32) -> bool {
+    pub fn can_upgrade_from(env: Env, from_major: u32, from_minor: u32, from_patch: u32) -> bool {
+        let policy = Self::get_upgrade_policy(env);
+
         if from_major != CONTRACT_SEMVER_MAJOR {
             return false;
         }
 
-        if from_minor < MIN_SUPPORTED_FROM_MINOR || from_minor > CONTRACT_SEMVER_MINOR {
+        if from_minor > policy.current_minor {
             return false;
         }
 
-        if from_minor == CONTRACT_SEMVER_MINOR {
-            return from_patch <= CONTRACT_SEMVER_PATCH;
+        if from_minor < policy.min_supported_from_minor {
+            return false;
+        }
+
+        if from_minor == policy.current_minor {
+            return from_patch <= policy.current_patch;
         }
 
         true
@@ -1152,7 +1159,11 @@ mod test {
         assert!(!client.can_upgrade_from(&(CONTRACT_SEMVER_MAJOR + 1), &0, &0));
         assert!(!client.can_upgrade_from(&(CONTRACT_SEMVER_MAJOR - 1), &0, &0));
         assert!(!client.can_upgrade_from(&CONTRACT_SEMVER_MAJOR, &(CONTRACT_SEMVER_MINOR + 1), &0));
-        assert!(!client.can_upgrade_from(&CONTRACT_SEMVER_MAJOR, &CONTRACT_SEMVER_MINOR, &(CONTRACT_SEMVER_PATCH + 1)));
+        assert!(!client.can_upgrade_from(
+            &CONTRACT_SEMVER_MAJOR,
+            &CONTRACT_SEMVER_MINOR,
+            &(CONTRACT_SEMVER_PATCH + 1)
+        ));
     }
 
     #[test]

--- a/xconfess-contracts/contracts/confession-anchor/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-anchor/src/lib.rs
@@ -18,6 +18,9 @@ pub const CONTRACT_SEMVER_MAJOR: u32 = 1;
 pub const CONTRACT_SEMVER_MINOR: u32 = 0;
 pub const CONTRACT_SEMVER_PATCH: u32 = 0;
 pub const CONTRACT_BUILD_METADATA: &str = "xconfess.confession-anchor+2026-03-23";
+pub const MIN_SUPPORTED_FROM_MAJOR: u32 = 1;
+pub const MIN_SUPPORTED_FROM_MINOR: u32 = 0;
+pub const UPGRADE_POLICY_VERSION: u32 = 1;
 
 const CAPABILITY_ANCHOR_V1: Symbol = symbol_short!("anchorv1");
 const CAPABILITY_VERIFY_V1: Symbol = symbol_short!("verifyv1");
@@ -61,6 +64,18 @@ pub struct ContractCapabilityInfo {
     pub error_registry_version: u32,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeCompatibilityPolicy {
+    pub policy_version: u32,
+    pub current_major: u32,
+    pub current_minor: u32,
+    pub current_patch: u32,
+    pub min_supported_from_major: u32,
+    pub min_supported_from_minor: u32,
+    pub allow_major_upgrade: bool,
+}
+
 #[contractevent(topics = ["confession_anchor"], data_format = "vec")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConfessionAnchoredEvent {
@@ -68,6 +83,18 @@ pub struct ConfessionAnchoredEvent {
     pub hash: BytesN<32>,
     pub timestamp: u64,
     pub anchor_height: u32,
+}
+
+#[contractevent(topics = ["ver_check"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VersionCompatibilityCheckedEvent {
+    pub from_major: u32,
+    pub from_minor: u32,
+    pub from_patch: u32,
+    pub to_major: u32,
+    pub to_minor: u32,
+    pub to_patch: u32,
+    pub compatible: bool,
 }
 
 #[contracterror]
@@ -88,6 +115,7 @@ pub enum Error {
     ContractPaused = 12,
     AlreadyOperator = 13,
     NotOperator = 14,
+    IncompatibleUpgrade = 15,
 }
 
 impl From<access_control::AccessError> for Error {
@@ -251,6 +279,63 @@ impl ConfessionAnchor {
 
     pub fn get_error_registry_version(_env: Env) -> u32 {
         errors::ERROR_REGISTRY_VERSION
+    }
+
+    /// Returns the currently enforced compatibility policy for upgrades.
+    pub fn get_upgrade_policy(_env: Env) -> UpgradeCompatibilityPolicy {
+        UpgradeCompatibilityPolicy {
+            policy_version: UPGRADE_POLICY_VERSION,
+            current_major: CONTRACT_SEMVER_MAJOR,
+            current_minor: CONTRACT_SEMVER_MINOR,
+            current_patch: CONTRACT_SEMVER_PATCH,
+            min_supported_from_major: MIN_SUPPORTED_FROM_MAJOR,
+            min_supported_from_minor: MIN_SUPPORTED_FROM_MINOR,
+            allow_major_upgrade: false,
+        }
+    }
+
+    /// Read-only compatibility predicate used by deployment automation.
+    pub fn can_upgrade_from(_env: Env, from_major: u32, from_minor: u32, from_patch: u32) -> bool {
+        if from_major != CONTRACT_SEMVER_MAJOR {
+            return false;
+        }
+
+        if from_minor < MIN_SUPPORTED_FROM_MINOR || from_minor > CONTRACT_SEMVER_MINOR {
+            return false;
+        }
+
+        if from_minor == CONTRACT_SEMVER_MINOR {
+            return from_patch <= CONTRACT_SEMVER_PATCH;
+        }
+
+        true
+    }
+
+    /// Enforced compatibility check that emits an audit event.
+    pub fn assert_upgrade_from(
+        env: Env,
+        from_major: u32,
+        from_minor: u32,
+        from_patch: u32,
+    ) -> Result<(), Error> {
+        let compatible = Self::can_upgrade_from(env.clone(), from_major, from_minor, from_patch);
+
+        VersionCompatibilityCheckedEvent {
+            from_major,
+            from_minor,
+            from_patch,
+            to_major: CONTRACT_SEMVER_MAJOR,
+            to_minor: CONTRACT_SEMVER_MINOR,
+            to_patch: CONTRACT_SEMVER_PATCH,
+            compatible,
+        }
+        .publish(&env);
+
+        if compatible {
+            Ok(())
+        } else {
+            Err(Error::IncompatibleUpgrade)
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -1039,6 +1124,48 @@ mod test {
         assert_eq!(
             client.try_revoke_operator(&owner, &operator),
             Err(Ok(Error::NotOperator))
+        );
+    }
+
+    // ── Group J: Upgrade compatibility policy ───────────────────────────────
+
+    #[test]
+    fn upgrade_policy_is_discoverable() {
+        let (_env, client) = new_client();
+        let policy = client.get_upgrade_policy();
+
+        assert_eq!(policy.policy_version, UPGRADE_POLICY_VERSION);
+        assert_eq!(policy.current_major, CONTRACT_SEMVER_MAJOR);
+        assert_eq!(policy.current_minor, CONTRACT_SEMVER_MINOR);
+        assert_eq!(policy.current_patch, CONTRACT_SEMVER_PATCH);
+        assert_eq!(policy.min_supported_from_major, MIN_SUPPORTED_FROM_MAJOR);
+        assert_eq!(policy.min_supported_from_minor, MIN_SUPPORTED_FROM_MINOR);
+        assert!(!policy.allow_major_upgrade);
+    }
+
+    #[test]
+    fn version_transition_matrix_enforces_upgrade_constraints() {
+        let (_env, client) = new_client();
+
+        assert!(client.can_upgrade_from(&CONTRACT_SEMVER_MAJOR, &CONTRACT_SEMVER_MINOR, &0));
+        assert!(client.can_upgrade_from(&CONTRACT_SEMVER_MAJOR, &MIN_SUPPORTED_FROM_MINOR, &0));
+        assert!(!client.can_upgrade_from(&(CONTRACT_SEMVER_MAJOR + 1), &0, &0));
+        assert!(!client.can_upgrade_from(&(CONTRACT_SEMVER_MAJOR - 1), &0, &0));
+        assert!(!client.can_upgrade_from(&CONTRACT_SEMVER_MAJOR, &(CONTRACT_SEMVER_MINOR + 1), &0));
+        assert!(!client.can_upgrade_from(&CONTRACT_SEMVER_MAJOR, &CONTRACT_SEMVER_MINOR, &(CONTRACT_SEMVER_PATCH + 1)));
+    }
+
+    #[test]
+    fn assert_upgrade_from_rejects_incompatible_versions() {
+        let (_env, client) = new_client();
+
+        assert_eq!(
+            client.assert_upgrade_from(&CONTRACT_SEMVER_MAJOR, &CONTRACT_SEMVER_MINOR, &0),
+            ()
+        );
+        assert_eq!(
+            client.try_assert_upgrade_from(&(CONTRACT_SEMVER_MAJOR + 1), &0, &0),
+            Err(Ok(Error::IncompatibleUpgrade))
         );
     }
 }

--- a/xconfess-contracts/contracts/confession-registry/Cargo.toml
+++ b/xconfess-contracts/contracts/confession-registry/Cargo.toml
@@ -12,3 +12,5 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+anonymous-tipping = { path = "../anonymous-tipping" }
+reputation-badges = { path = "../reputation-badges" }

--- a/xconfess-contracts/contracts/confession-registry/src/confession_reg_auth.rs
+++ b/xconfess-contracts/contracts/confession-registry/src/confession_reg_auth.rs
@@ -41,7 +41,7 @@
 
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
 
-use crate::{ConfessionRegistry, ConfessionRegistryClient, ConfessionStatus};
+use crate::{ConfessionRegistry, ConfessionRegistryClient, ConfessionStatus, ReplayError};
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -442,4 +442,38 @@ fn f5_author_index_unchanged_by_status_changes() {
         ids.iter().any(|x| x == id2),
         "id2 must remain in author index after delete"
     );
+}
+
+/// G1: sequenced operations reject replayed nonce values.
+#[test]
+fn g1_replay_attempt_with_duplicate_nonce_is_rejected() {
+    let (env, client, _admin, author) = setup();
+    let id = create(&client, &env, &author, 100);
+
+    assert_eq!(client.get_expected_nonce(&author), 1);
+    assert_eq!(
+        client.update_status_seq(&author, &id, &ConfessionStatus::Flagged, &2_000_000, &1),
+        ()
+    );
+    assert_eq!(client.get_expected_nonce(&author), 2);
+
+    let replay =
+        client.try_update_status_seq(&author, &id, &ConfessionStatus::Active, &3_000_000, &1);
+    assert_eq!(replay, Err(Ok(ReplayError::InvalidNonce)));
+}
+
+/// G2: stale nonce values are rejected after a successful sequenced mutation.
+#[test]
+fn g2_stale_nonce_is_rejected_for_delete() {
+    let (env, client, _admin, author) = setup();
+    let id = create(&client, &env, &author, 101);
+
+    assert_eq!(client.get_expected_nonce(&author), 1);
+    client.update_status_seq(&author, &id, &ConfessionStatus::Flagged, &2_000_000, &1);
+
+    let stale_delete = client.try_delete_confession_seq(&author, &id, &3_000_000, &1);
+    assert_eq!(stale_delete, Err(Ok(ReplayError::InvalidNonce)));
+
+    client.delete_confession_seq(&author, &id, &4_000_000, &2);
+    assert_eq!(client.get_confession(&id).status, ConfessionStatus::Deleted);
 }

--- a/xconfess-contracts/contracts/confession-registry/src/confession_reg_auth.rs
+++ b/xconfess-contracts/contracts/confession-registry/src/confession_reg_auth.rs
@@ -146,7 +146,7 @@ fn a4_double_delete_is_rejected() {
 #[test]
 #[should_panic(expected = "confession not found")]
 fn a5_delete_nonexistent_confession_panics() {
-    let (env, client, _admin, author) = setup();
+    let (_env, client, _admin, author) = setup();
     client.delete_confession(&author, &9_999, &1_000_000);
 }
 
@@ -209,7 +209,7 @@ fn b4_cannot_update_deleted_confession() {
 #[test]
 #[should_panic(expected = "confession not found")]
 fn b5_update_nonexistent_confession_panics() {
-    let (env, client, _admin, author) = setup();
+    let (_env, client, _admin, author) = setup();
     client.update_status(&author, &9_999, &ConfessionStatus::Flagged, &1_000_000);
 }
 

--- a/xconfess-contracts/contracts/confession-registry/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-registry/src/lib.rs
@@ -3,7 +3,9 @@
 #[path = "confession_reg_auth.rs"]
 mod confession_reg_auth;
 
-use soroban_sdk::{contract, contractevent, contractimpl, contracttype, Address, BytesN, Env, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, BytesN, Env, Vec,
+};
 
 #[path = "../../access_control.rs"]
 mod access_control;
@@ -88,6 +90,34 @@ pub enum DataKey {
     AuthorConfessions(Address),
     /// Contract admin address.
     Admin,
+    /// Per-caller sequencing nonce for replay protection.
+    CallerNonce(Address),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ReplayError {
+    InvalidNonce = 1,
+}
+
+fn expected_nonce(env: &Env, caller: &Address) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::CallerNonce(caller.clone()))
+        .unwrap_or(1u64)
+}
+
+fn consume_nonce(env: &Env, caller: &Address, nonce: u64) -> Result<(), ReplayError> {
+    let expected = expected_nonce(env, caller);
+    if nonce != expected {
+        return Err(ReplayError::InvalidNonce);
+    }
+
+    env.storage()
+        .instance()
+        .set(&DataKey::CallerNonce(caller.clone()), &(expected + 1));
+    Ok(())
 }
 
 // ─── Contract ───
@@ -258,6 +288,23 @@ impl ConfessionRegistry {
         next_id - 1
     }
 
+    /// Return the next valid nonce for a caller in sequenced mutation methods.
+    pub fn get_expected_nonce(env: Env, caller: Address) -> u64 {
+        expected_nonce(&env, &caller)
+    }
+
+    /// Replay-protected create_confession variant.
+    pub fn create_confession_seq(
+        env: Env,
+        author: Address,
+        content_hash: BytesN<32>,
+        timestamp: u64,
+        nonce: u64,
+    ) -> Result<u64, ReplayError> {
+        consume_nonce(&env, &author, nonce)?;
+        Ok(Self::create_confession(env, author, content_hash, timestamp))
+    }
+
     // ─── Update Status ───
 
     /// Update the status of a confession.
@@ -316,6 +363,20 @@ impl ConfessionRegistry {
         .publish(&env);
     }
 
+    /// Replay-protected update_status variant.
+    pub fn update_status_seq(
+        env: Env,
+        caller: Address,
+        id: u64,
+        new_status: ConfessionStatus,
+        timestamp: u64,
+        nonce: u64,
+    ) -> Result<(), ReplayError> {
+        consume_nonce(&env, &caller, nonce)?;
+        Self::update_status(env, caller, id, new_status, timestamp);
+        Ok(())
+    }
+
     // ─── Delete ───
 
     /// Soft-delete a confession (set status to Deleted).
@@ -363,6 +424,19 @@ impl ConfessionRegistry {
             timestamp,
         }
         .publish(&env);
+    }
+
+    /// Replay-protected delete_confession variant.
+    pub fn delete_confession_seq(
+        env: Env,
+        caller: Address,
+        id: u64,
+        timestamp: u64,
+        nonce: u64,
+    ) -> Result<(), ReplayError> {
+        consume_nonce(&env, &caller, nonce)?;
+        Self::delete_confession(env, caller, id, timestamp);
+        Ok(())
     }
 }
 

--- a/xconfess-contracts/contracts/confession-registry/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-registry/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+#![allow(dead_code)]
+#![allow(deprecated)]
 #[cfg(test)]
 #[path = "confession_reg_auth.rs"]
 mod confession_reg_auth;
@@ -302,7 +304,12 @@ impl ConfessionRegistry {
         nonce: u64,
     ) -> Result<u64, ReplayError> {
         consume_nonce(&env, &author, nonce)?;
-        Ok(Self::create_confession(env, author, content_hash, timestamp))
+        Ok(Self::create_confession(
+            env,
+            author,
+            content_hash,
+            timestamp,
+        ))
     }
 
     // ─── Update Status ───

--- a/xconfess-contracts/contracts/confession-registry/tests/cross_contract_harness.rs
+++ b/xconfess-contracts/contracts/confession-registry/tests/cross_contract_harness.rs
@@ -1,7 +1,5 @@
 use anonymous_tipping::{AnonymousTipping, AnonymousTippingClient};
-use confession_registry::{
-    ConfessionRegistry, ConfessionRegistryClient, ConfessionStatus,
-};
+use confession_registry::{ConfessionRegistry, ConfessionRegistryClient, ConfessionStatus};
 use reputation_badges::{BadgeType, ReputationBadges, ReputationBadgesClient};
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
 
@@ -93,7 +91,10 @@ fn flagged_confession_flow_keeps_cross_contract_state_consistent() {
     );
     assert_eq!(settlement_id, 1);
 
-    assert_eq!(registry.get_confession(&confession_id).status, ConfessionStatus::Flagged);
+    assert_eq!(
+        registry.get_confession(&confession_id).status,
+        ConfessionStatus::Flagged
+    );
     assert!(badges.has_badge(&author, &BadgeType::PopularVoice));
     assert_eq!(tipping.get_tips(&author), TIP_AMOUNT);
     assert_eq!(registry.get_total_count(), 1);

--- a/xconfess-contracts/contracts/confession-registry/tests/cross_contract_harness.rs
+++ b/xconfess-contracts/contracts/confession-registry/tests/cross_contract_harness.rs
@@ -1,0 +1,102 @@
+use anonymous_tipping::{AnonymousTipping, AnonymousTippingClient};
+use confession_registry::{
+    ConfessionRegistry, ConfessionRegistryClient, ConfessionStatus,
+};
+use reputation_badges::{BadgeType, ReputationBadges, ReputationBadgesClient};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+
+const TS_CREATE: u64 = 1_710_000_000;
+const TS_FLAG: u64 = 1_710_000_050;
+const TIP_AMOUNT: i128 = 500;
+
+fn fixture_hash(env: &Env, seed: u8) -> BytesN<32> {
+    let mut buf = [0u8; 32];
+    buf[0] = seed;
+    buf[31] = seed;
+    BytesN::from_array(env, &buf)
+}
+
+fn setup() -> (
+    Env,
+    ConfessionRegistryClient<'static>,
+    ReputationBadgesClient<'static>,
+    AnonymousTippingClient<'static>,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let registry_id = env.register(ConfessionRegistry, ());
+    let badges_id = env.register(ReputationBadges, ());
+    let tipping_id = env.register(AnonymousTipping, ());
+
+    let registry = ConfessionRegistryClient::new(&env, &registry_id);
+    let badges = ReputationBadgesClient::new(&env, &badges_id);
+    let tipping = AnonymousTippingClient::new(&env, &tipping_id);
+
+    let admin = Address::generate(&env);
+    let author = Address::generate(&env);
+
+    registry.initialize(&admin);
+    badges.initialize(&admin);
+    tipping.init();
+
+    (env, registry, badges, tipping, admin, author)
+}
+
+#[test]
+fn confession_reputation_tipping_happy_path_is_repeatable() {
+    let (env, registry, badges, tipping, admin, author) = setup();
+
+    let confession_id = registry.create_confession(&author, &fixture_hash(&env, 0x21), &TS_CREATE);
+    assert_eq!(confession_id, 1);
+
+    let badge_id = badges.award_badge(&author, &BadgeType::ConfessionStarter);
+    assert_eq!(badge_id, 1);
+    assert!(badges.has_badge(&author, &BadgeType::ConfessionStarter));
+
+    let new_rep = badges.adjust_reputation(
+        &author,
+        &100,
+        &String::from_str(&env, "first confession milestone"),
+    );
+    assert_eq!(new_rep, 100);
+
+    let settlement_id = tipping.send_tip(&author, &TIP_AMOUNT);
+    assert_eq!(settlement_id, 1);
+    assert_eq!(tipping.get_tips(&author), TIP_AMOUNT);
+
+    let confession = registry.get_confession(&confession_id);
+    assert_eq!(confession.status, ConfessionStatus::Active);
+    assert_eq!(registry.get_total_count(), 1);
+    assert_eq!(badges.get_total_badges(), 1);
+    assert_eq!(tipping.latest_settlement_nonce(), 1);
+
+    let _ = admin;
+}
+
+#[test]
+fn flagged_confession_flow_keeps_cross_contract_state_consistent() {
+    let (env, registry, badges, tipping, admin, author) = setup();
+
+    let confession_id = registry.create_confession(&author, &fixture_hash(&env, 0x41), &TS_CREATE);
+    registry.update_status(&admin, &confession_id, &ConfessionStatus::Flagged, &TS_FLAG);
+
+    let badge_id = badges.award_badge(&author, &BadgeType::PopularVoice);
+    assert_eq!(badge_id, 1);
+
+    let settlement_id = tipping.send_tip_with_proof(
+        &author,
+        &TIP_AMOUNT,
+        &Some(String::from_str(&env, "cross-contract moderation fixture")),
+    );
+    assert_eq!(settlement_id, 1);
+
+    assert_eq!(registry.get_confession(&confession_id).status, ConfessionStatus::Flagged);
+    assert!(badges.has_badge(&author, &BadgeType::PopularVoice));
+    assert_eq!(tipping.get_tips(&author), TIP_AMOUNT);
+    assert_eq!(registry.get_total_count(), 1);
+    assert_eq!(badges.get_total_badges(), 1);
+    assert_eq!(tipping.latest_settlement_nonce(), 1);
+}

--- a/xconfess-contracts/contracts/reputation-badges/src/lib.rs
+++ b/xconfess-contracts/contracts/reputation-badges/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+#![allow(dead_code)]
+#![allow(deprecated)]
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, Env, String, Symbol, Vec,


### PR DESCRIPTION
## Summary

Closes #744 
Closes #747 
Closes #748 
Closes #751 


- Introduced least-privilege role separation with owner/admin/operator and explicit permission enforcement for privileged admin operations, plus permission matrix tests.
- Added discoverable upgrade compatibility policy metadata, version compatibility checks, and transition tests that enforce upgrade constraints.
- Implemented nonce-based replay protection for sequenced signed mutation flows in confession registry, with replay/stale nonce attack tests.
- Added a deterministic cross-contract integration harness covering confession, reputation, and tipping interaction flows, now exercised in workspace test runs.
- Included lint/format compatibility adjustments required to keep strict contract CI green.