### PR TITLE
fix(frontend): consolidate backend URL config to single canonical var

### DIFF
--- a/xconfess-frontend/README.md
+++ b/xconfess-frontend/README.md
@@ -40,15 +40,35 @@ npm run build --workspace=xconfess-frontend
 
 ## Environment
 
-Useful frontend environment variables:
+Copy `.env.example` to `.env.local` and fill in the values before starting the dev server.
 
-- `NEXT_PUBLIC_API_URL`
-- `BACKEND_API_URL`
-- `NEXT_PUBLIC_WS_URL`
-- `NEXT_PUBLIC_DEV_BYPASS_AUTH` for local development only
-- `NEXT_PUBLIC_STELLAR_NETWORK`
-- `NEXT_PUBLIC_STELLAR_HORIZON_URL`
-- `NEXT_PUBLIC_STELLAR_CONTRACT_ID`
+```bash
+cp .env.example .env.local
+```
+
+### Required
+
+| Variable | Description |
+|---|---|
+| `BACKEND_API_URL` | **Canonical** server-side URL for the NestJS API. Used by all App Router proxy routes. Never exposed to the browser. |
+| `NEXT_PUBLIC_API_URL` | Same backend host, baked into the browser bundle for client-side calls. |
+| `NEXT_PUBLIC_WS_URL` | WebSocket endpoint for real-time reactions and notifications. |
+
+### Optional
+
+| Variable | Default | Description |
+|---|---|---|
+| `NEXT_PUBLIC_APP_URL` | — | Public URL of this frontend (share links, OG meta). |
+| `NEXT_PUBLIC_DEV_BYPASS_AUTH` | `false` | Skip auth checks locally. Must be `false` in staging/production. |
+| `NEXT_PUBLIC_STELLAR_NETWORK` | `testnet` | `testnet` or `mainnet`. |
+| `NEXT_PUBLIC_STELLAR_HORIZON_URL` | — | Horizon REST endpoint. |
+| `NEXT_PUBLIC_STELLAR_SOROBAN_RPC_URL` | — | Soroban RPC endpoint. |
+| `NEXT_PUBLIC_STELLAR_CONTRACT_ID` | — | Deployed confession-anchor contract ID. |
+| `NEXT_PUBLIC_DEBUG_NOTIFICATIONS` | `false` | Verbose notification logs in the browser. |
+| `NEXT_PUBLIC_ENABLE_DEV_MOCK_ADMIN_LOGIN` | `false` | Show mock admin login button (dev only). |
+| `NEXT_PUBLIC_ERROR_TRACKING_URL` | — | Error tracking ingest URL (e.g. Sentry). |
+
+> **Note:** `BACKEND_URL` is not a valid variable in this project. All proxy routes use `BACKEND_API_URL` via `getApiBaseUrl()` in `app/lib/config.ts`. The startup validator (`instrumentation.ts`) will throw at boot if `BACKEND_API_URL` is missing.
 
 ## Error Handling & Resilience
 

--- a/xconfess-frontend/app/api/confessions/route.ts
+++ b/xconfess-frontend/app/api/confessions/route.ts
@@ -1,14 +1,10 @@
 import { normalizeConfession } from "../../lib/utils/normalizeConfession";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL = process.env.BACKEND_API_URL;
+const BASE_API_URL = getApiBaseUrl();
 
 export async function POST(request: Request) {
-  // Fail fast if backend URL is not configured
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {
@@ -79,11 +75,6 @@ export async function POST(request: Request) {
 }
 
 export async function GET(request: Request) {
-  // Fail fast if backend URL is not configured
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const { searchParams } = new URL(request.url);
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1") || 1);
   const limit = Math.max(1, parseInt(searchParams.get("limit") ?? "10") || 10);

--- a/xconfess-frontend/app/api/notifications/[id]/read/route.ts
+++ b/xconfess-frontend/app/api/notifications/[id]/read/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BACKEND_API_URL = getApiBaseUrl();
 
 export async function PATCH(
   request: NextRequest,
@@ -10,7 +13,7 @@ export async function PATCH(
     const token = request.headers.get("authorization")?.replace("Bearer ", "");
 
     const response = await fetch(
-      `${process.env.BACKEND_URL}/notifications/${id}/read`,
+      `${BACKEND_API_URL}/notifications/${id}/read`,
       {
         method: "PATCH",
         headers: {

--- a/xconfess-frontend/app/api/notifications/preference/route.ts
+++ b/xconfess-frontend/app/api/notifications/preference/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BACKEND_API_URL = getApiBaseUrl();
 
 export async function GET(request: NextRequest) {
   try {
     const token = request.headers.get("authorization")?.replace("Bearer ", "");
 
     const response = await fetch(
-      `${process.env.BACKEND_URL}/notifications/preferences`,
+      `${BACKEND_API_URL}/notifications/preferences`,
       {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -39,7 +42,7 @@ export async function PUT(request: NextRequest) {
     const body = await request.json();
 
     const response = await fetch(
-      `${process.env.BACKEND_URL}/notifications/preferences`,
+      `${BACKEND_API_URL}/notifications/preferences`,
       {
         method: "PUT",
         headers: {

--- a/xconfess-frontend/app/api/notifications/read-all/route.ts
+++ b/xconfess-frontend/app/api/notifications/read-all/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BACKEND_API_URL = getApiBaseUrl();
 
 export async function PATCH(request: NextRequest) {
   try {
     const token = request.headers.get("authorization")?.replace("Bearer ", "");
 
     const response = await fetch(
-      `${process.env.BACKEND_URL}/notifications/read-all`,
+      `${BACKEND_API_URL}/notifications/read-all`,
       {
         method: "PATCH",
         headers: {

--- a/xconfess-frontend/app/api/notifications/route.ts
+++ b/xconfess-frontend/app/api/notifications/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
+
+const BACKEND_API_URL = getApiBaseUrl();
 
 export async function GET(request: NextRequest) {
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
@@ -17,7 +20,7 @@ export async function GET(request: NextRequest) {
 
     // Call your backend API
     const response = await fetch(
-      `${process.env.BACKEND_URL}/notifications?type=${type || ""}&isRead=${isRead || ""}&page=${page}&limit=${limit}`,
+      `${BACKEND_API_URL}/notifications?type=${type || ""}&isRead=${isRead || ""}&page=${page}&limit=${limit}`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/xconfess-frontend/app/api/users/[id]/activities/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/activities/route.ts
@@ -1,9 +1,9 @@
-import { misconfiguredBackendResponse, internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+import { internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL = process.env.BACKEND_API_URL;
+const BASE_API_URL = getApiBaseUrl();
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
-  if (!BASE_API_URL) return misconfiguredBackendResponse();
 
   try {
     const { id } = params;

--- a/xconfess-frontend/app/api/users/[id]/confessions/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/confessions/route.ts
@@ -1,12 +1,9 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL = process.env.BACKEND_API_URL;
+const BASE_API_URL = getApiBaseUrl();
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {

--- a/xconfess-frontend/app/api/users/[id]/public-profile/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/public-profile/route.ts
@@ -1,12 +1,9 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL = process.env.BACKEND_API_URL;
+const BASE_API_URL = getApiBaseUrl();
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {

--- a/xconfess-frontend/app/api/users/privacy-settings/route.ts
+++ b/xconfess-frontend/app/api/users/privacy-settings/route.ts
@@ -1,12 +1,9 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL = process.env.BACKEND_API_URL;
+const BASE_API_URL = getApiBaseUrl();
 
 export async function GET(request: Request) {
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {
@@ -49,10 +46,6 @@ export async function GET(request: Request) {
 }
 
 export async function PATCH(request: Request) {
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {

--- a/xconfess-frontend/app/api/users/profile/route.ts
+++ b/xconfess-frontend/app/api/users/profile/route.ts
@@ -1,12 +1,9 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL = process.env.BACKEND_API_URL;
+const BASE_API_URL = getApiBaseUrl();
 
 export async function GET(request: Request) {
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {
@@ -50,10 +47,6 @@ export async function GET(request: Request) {
 }
 
 export async function PATCH(request: Request) {
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {

--- a/xconfess-frontend/app/api/users/register/route.ts
+++ b/xconfess-frontend/app/api/users/register/route.ts
@@ -1,12 +1,9 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL = process.env.BACKEND_API_URL;
+const BASE_API_URL = getApiBaseUrl();
 
 export async function POST(request: Request) {
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {

--- a/xconfess-frontend/app/api/users/stats/route.ts
+++ b/xconfess-frontend/app/api/users/stats/route.ts
@@ -1,12 +1,9 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getApiBaseUrl } from "@/app/lib/config";
 
-const BASE_API_URL = process.env.BACKEND_API_URL;
+const BASE_API_URL = getApiBaseUrl();
 
 export async function GET(request: Request) {
-  if (!BASE_API_URL) {
-    return createApiErrorResponse("BACKEND_API_URL is not set", { status: 503 });
-  }
-
   const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
 
   try {

--- a/xconfess-frontend/instrumentation.ts
+++ b/xconfess-frontend/instrumentation.ts
@@ -1,0 +1,56 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    validateEnv();
+  }
+}
+
+function validateEnv() {
+  const required: Array<{ name: string; description: string }> = [
+    {
+      name: "BACKEND_API_URL",
+      description: "Server-side base URL for the NestJS backend (e.g. http://localhost:5000)",
+    },
+  ];
+
+  const optional: Array<{ name: string; description: string }> = [
+    {
+      name: "NEXT_PUBLIC_API_URL",
+      description: "Client-side base URL for the NestJS backend (same host, public)",
+    },
+    {
+      name: "NEXT_PUBLIC_WS_URL",
+      description: "WebSocket URL for real-time updates (e.g. ws://localhost:5000)",
+    },
+    {
+      name: "NEXT_PUBLIC_APP_URL",
+      description: "Public URL of this frontend app (used for share links)",
+    },
+    {
+      name: "NEXT_PUBLIC_STELLAR_NETWORK",
+      description: "Stellar network: 'testnet' or 'mainnet' (default: testnet)",
+    },
+  ];
+
+  const missing = required.filter(({ name }) => !process.env[name]);
+
+  if (missing.length > 0) {
+    const lines = missing
+      .map(({ name, description }) => `  • ${name} — ${description}`)
+      .join("\n");
+    // Throw so the process fails immediately at boot rather than at the first request
+    throw new Error(
+      `Missing required environment variable(s):\n${lines}\n\nSee xconfess-frontend/.env.example for the full list.`
+    );
+  }
+
+  const missingOptional = optional.filter(({ name }) => !process.env[name]);
+  if (missingOptional.length > 0) {
+    const lines = missingOptional
+      .map(({ name, description }) => `  • ${name} — ${description}`)
+      .join("\n");
+    console.warn(
+      `[xconfess] Optional environment variable(s) not set:\n${lines}\n` +
+        `Some features may not work. See xconfess-frontend/.env.example for details.`
+    );
+  }
+}


### PR DESCRIPTION
## Problem

Closes #708 

Frontend proxy routes used two different env vars to reach the backend:

- `BACKEND_API_URL` — used in confessions, users, and analytics routes
- `BACKEND_URL` — used in all four notification routes (never documented, never set in any env file)

The notification routes were silently building URLs like `undefined/notifications/...` in any real environment, causing 503s.

## Changes

- **4 notification routes** (`/api/notifications`, `/read-all`, `/preference`, `/[id]/read`): replaced `process.env.BACKEND_URL` with `getApiBaseUrl()`
- **8 user/confession routes**: replaced inline `process.env.BACKEND_API_URL` reads with `getApiBaseUrl()`; removed redundant per-handler `if (!BASE_API_URL)` guards — the function throws at module init, which is earlier and cleaner
- **`instrumentation.ts`** (new): Next.js server startup hook — throws immediately at boot if `BACKEND_API_URL` is missing, warns for missing optional vars
- **`.env.example`** (new): documents every frontend env var with descriptions and local defaults
- **`README.md`**: replaced bare variable list with a required/optional table and a canonical variable note

## Rule going forward

`process.env.BACKEND_API_URL` is read in exactly one place: `app/lib/config.ts`. All routes call `getApiBaseUrl()`.

## Testing

- Verify notification endpoints return data (previously broken in any env without `BACKEND_URL` set)
- Remove `BACKEND_API_URL` from local env and confirm the dev server throws at startup with a clear message rather than failing at first request
