### PR TITLE
fix(contracts): enforce minimum-admin invariant for emergency pause

### DIFF
--- a/xconfess-contracts/contracts/emergency_pause/admin.rs
+++ b/xconfess-contracts/contracts/emergency_pause/admin.rs
@@ -3,6 +3,10 @@ use soroban_sdk::{Address, Env};
 use crate::emergency_pause::errors::PauseError;
 use crate::emergency_pause::storage::DataKey;
 
+/// Deprecated storage-backed admin setter.
+///
+/// NOTE: Newer flows should authorize pause/unpause via `access_control`
+/// (owner/admin) to avoid lockout if a dedicated pause admin key is lost.
 pub fn set_admin(env: &Env, admin: Address) {
     admin.require_auth();
 
@@ -16,13 +20,12 @@ pub fn get_admin(env: &Env) -> Address {
         .expect("Admin not set")
 }
 
-pub fn require_admin(env: &Env) -> Result<Address, PauseError> {
-    let admin: Address = env
-        .storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .ok_or(PauseError::Unauthorized)?;
-
-    admin.require_auth();
-    Ok(admin)
+/// Require an authorized actor for emergency pause actions.
+///
+/// This intentionally shares the same authorization surface as the rest of the
+/// contract (owner OR admin) so emergency pause cannot be stranded behind a
+/// separate, drift-prone "pause admin" key.
+pub fn require_pause_authority(env: &Env, caller: &Address) -> Result<Address, PauseError> {
+    crate::access_control::require_admin_or_owner(env, caller).map_err(|_| PauseError::Unauthorized)?;
+    Ok(caller.clone())
 }

--- a/xconfess-contracts/contracts/emergency_pause/pause.rs
+++ b/xconfess-contracts/contracts/emergency_pause/pause.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{Env, String};
 
 use crate::emergency_pause::{
-    admin::require_admin,
+    admin::require_pause_authority,
     errors::PauseError,
     events::{emit_paused, emit_unpaused},
     storage::DataKey,
@@ -21,8 +21,8 @@ pub fn assert_not_paused(env: &Env) -> Result<(), PauseError> {
     Ok(())
 }
 
-pub fn pause(env: Env, reason: String) -> Result<(), PauseError> {
-    let actor = require_admin(&env)?;
+pub fn pause(env: Env, caller: soroban_sdk::Address, reason: String) -> Result<(), PauseError> {
+    let actor = require_pause_authority(&env, &caller)?;
 
     if is_paused(&env) {
         return Err(PauseError::AlreadyPaused);
@@ -35,8 +35,8 @@ pub fn pause(env: Env, reason: String) -> Result<(), PauseError> {
     Ok(())
 }
 
-pub fn unpause(env: Env, reason: String) -> Result<(), PauseError> {
-    let actor = require_admin(&env)?;
+pub fn unpause(env: Env, caller: soroban_sdk::Address, reason: String) -> Result<(), PauseError> {
+    let actor = require_pause_authority(&env, &caller)?;
 
     if !is_paused(&env) {
         return Err(PauseError::NotPaused);

--- a/xconfess-contracts/contracts/tests/emergency_pause.test.rs
+++ b/xconfess-contracts/contracts/tests/emergency_pause.test.rs
@@ -1,25 +1,29 @@
 use soroban_sdk::{Env, String};
 
 use crate::emergency_pause::*;
+#[path = "../access_control.rs"]
+mod access_control;
 
 #[test]
 fn test_pause_flow() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let admin = env.accounts().generate();
-    set_admin(&env, admin.clone());
+    // Use shared access control so emergency pause cannot be stranded behind a
+    // separate pause-admin key.
+    let owner = env.accounts().generate();
+    access_control::init_owner(&env, &owner).unwrap();
 
     assert_eq!(is_paused(&env), false);
 
-    pause(env.clone(), String::from_str(&env, "incident")).unwrap();
+    pause(env.clone(), owner.clone(), String::from_str(&env, "incident")).unwrap();
 
     assert_eq!(is_paused(&env), true);
 
     let result = assert_not_paused(&env);
     assert!(result.is_err());
 
-    unpause(env.clone(), String::from_str(&env, "resolved")).unwrap();
+    unpause(env.clone(), owner, String::from_str(&env, "resolved")).unwrap();
 
     assert_eq!(is_paused(&env), false);
 }


### PR DESCRIPTION
## Overview
This PR hardens contract administration safety by enforcing the same minimum-admin authorization surface across emergency pause and governance/access-control paths. Emergency pause actions are now authorized through shared `access_control` (owner/admin) to avoid invariant drift and reduce the risk of administrative lockout.

## Related Issue
Closes #811

## Changes

### ⚙️ Minimum-admin invariant enforcement
- **[MODIFY]** `xconfess-contracts/contracts/emergency_pause/admin.rs`
  - Added `require_pause_authority` which authorizes pause/unpause via shared `access_control` (owner/admin).
  - Retained the legacy storage-backed pause admin helpers, but removed them from the pause/unpause authorization path.

- **[MODIFY]** `xconfess-contracts/contracts/emergency_pause/pause.rs`
  - Updated `pause` / `unpause` to require an explicit caller and validate authority via `require_pause_authority`.

### 🧪 Tests
- **[MODIFY]** `xconfess-contracts/contracts/tests/emergency_pause.test.rs`
  - Updated the pause flow test to initialize shared access-control ownership and assert pause/unpause work through the unified authorization path.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Emergency pause paths reject unauthorized transitions | ✅ |
| Emergency pause authorization cannot drift from access control | ✅ |
| Contract test suite passes | ✅ |

## How to Test

```bash
npm run contract:test
```

## Screenshots

### ✅ Contract tests pass
A screenshot of:

```bash
npm run contract:test
```

<img width="523" height="483" alt="image" src="https://github.com/user-attachments/assets/2256a185-11f3-40e6-9cb2-13f4ed3141e4" />
