### PR TITLE
feat(health): liveness/readiness split and BullMQ queue-worker checks

### DIFF
--- a/xconfess-backend/src/app.controller.spec.ts
+++ b/xconfess-backend/src/app.controller.spec.ts
@@ -7,10 +7,6 @@ describe('AppController', () => {
   beforeEach(() => {
     appController = new AppController(
       new AppService(),
-      { check: jest.fn() } as any,
-      { pingCheck: jest.fn() } as any,
-      { isHealthy: jest.fn() } as any,
-      { isHealthy: jest.fn() } as any,
       { getDiagnostics: jest.fn() } as any,
     );
   });

--- a/xconfess-backend/src/app.controller.ts
+++ b/xconfess-backend/src/app.controller.ts
@@ -2,13 +2,6 @@ import { Controller, Get, UseGuards } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import {
-  HealthCheck,
-  HealthCheckService,
-  TypeOrmHealthIndicator,
-} from '@nestjs/terminus';
-import { RedisHealthIndicator } from './health/redis.health';
-import { SchemaReadinessHealthIndicator } from './health/schema-readiness.health';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { AdminGuard } from './auth/admin.guard';
 import { JobManagementService } from './notifications/services/job-management.service';
@@ -18,10 +11,6 @@ import { JobManagementService } from './notifications/services/job-management.se
 export class AppController {
   constructor(
     private readonly appService: AppService,
-    private health: HealthCheckService,
-    private db: TypeOrmHealthIndicator,
-    private redis: RedisHealthIndicator,
-    private readonly schemaReadiness: SchemaReadinessHealthIndicator,
     private readonly jobManagementService: JobManagementService,
   ) {}
 
@@ -35,32 +24,6 @@ export class AppController {
   })
   getHello(): string {
     return this.appService.getHello();
-  }
-
-  // ✅ HEALTH ENDPOINT
-  @Get('health')
-  @HealthCheck()
-  @ApiOperation({
-    summary: 'Application health check',
-    description:
-      'Liveness-style bundle: process, database ping, Redis, and confession-table schema readiness (required columns and FTS indexes on `anonymous_confessions`). Schema drift or failed verification makes the overall check fail (HTTP 503) with details under the `schema` key.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'All checks passed',
-  })
-  @ApiResponse({
-    status: 503,
-    description:
-      'One or more checks failed (e.g. schema drift, DB unreachable, Redis down)',
-  })
-  check() {
-    return this.health.check([
-      () => ({ app: { status: 'up' } }),
-      async () => this.db.pingCheck('database'),
-      async () => this.redis.isHealthy('redis'),
-      async () => this.schemaReadiness.isHealthy('schema'),
-    ]);
   }
 
   @Get('diagnostics/notifications')

--- a/xconfess-backend/src/app.module.ts
+++ b/xconfess-backend/src/app.module.ts
@@ -12,11 +12,9 @@ import { ConfessionModule } from './confession/confession.module';
 import { SearchDiscoveryModule } from './search-discovery/search-discovery.module';
 import { ReactionModule } from './reaction/reaction.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
-import { TerminusModule } from '@nestjs/terminus';
 import { APP_GUARD } from '@nestjs/core';
 import throttleConfig from './config/throttle.config';
-import { RedisHealthIndicator } from './health/redis.health';
-import { SchemaReadinessHealthIndicator } from './health/schema-readiness.health';
+import { HealthModule } from './health/health.module';
 import { MessagesModule } from './messages/messages.module';
 import { AdminModule } from './admin/admin.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
@@ -107,7 +105,7 @@ import { BullModule } from '@nestjs/bullmq';
     }),
     EventEmitterModule.forRoot(),
     ScheduleModule.forRoot(),
-    TerminusModule,
+    HealthModule,
     UserModule,
     AuthModule,
     ConfessionModule,
@@ -128,8 +126,6 @@ import { BullModule } from '@nestjs/bullmq';
   controllers: [AppController],
   providers: [
     AppService,
-    RedisHealthIndicator,
-    SchemaReadinessHealthIndicator,
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,

--- a/xconfess-backend/src/health/health.controller.spec.ts
+++ b/xconfess-backend/src/health/health.controller.spec.ts
@@ -7,27 +7,32 @@ import { QueueHealthIndicator } from './queue.health';
 
 const UP = (key: string) => ({ [key]: { status: 'up' } });
 
-function makeHealthService(pass: boolean) {
-  return {
-    check: jest.fn().mockImplementation(async (checks: Array<() => Promise<unknown>>) => {
-      if (!pass) throw new Error('unhealthy');
-      const results = await Promise.all(checks.map((fn) => fn()));
-      return { status: 'ok', details: Object.assign({}, ...results) };
-    }),
-  };
-}
-
 describe('HealthController', () => {
   let controller: HealthController;
-  let healthService: ReturnType<typeof makeHealthService>;
 
-  const dbIndicator = { pingCheck: jest.fn().mockResolvedValue(UP('database')) };
+  const healthService = {
+    check: jest
+      .fn()
+      .mockImplementation((checks: Array<() => Promise<unknown>>) =>
+        Promise.all(checks.map((fn) => fn())).then((results) => ({
+          status: 'ok',
+          details: Object.assign({}, ...results),
+        })),
+      ),
+  };
+  const dbIndicator = {
+    pingCheck: jest.fn().mockResolvedValue(UP('database')),
+  };
   const redisIndicator = { isHealthy: jest.fn().mockResolvedValue(UP('redis')) };
-  const schemaIndicator = { isHealthy: jest.fn().mockResolvedValue(UP('schema')) };
-  const queueIndicator = { isHealthy: jest.fn().mockResolvedValue(UP('queues')) };
+  const schemaIndicator = {
+    isHealthy: jest.fn().mockResolvedValue(UP('schema')),
+  };
+  const queueIndicator = {
+    isHealthy: jest.fn().mockResolvedValue(UP('queues')),
+  };
 
-  async function buildController(pass = true) {
-    healthService = makeHealthService(pass);
+  beforeEach(async () => {
+    jest.clearAllMocks();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
@@ -41,11 +46,10 @@ describe('HealthController', () => {
     }).compile();
 
     controller = module.get(HealthController);
-  }
+  });
 
   describe('GET /health/live', () => {
-    it('returns {status: ok} synchronously without calling any indicator', async () => {
-      await buildController();
+    it('returns {status: ok} without calling any indicator', () => {
       const result = controller.liveness();
       expect(result).toEqual({ status: 'ok' });
       expect(healthService.check).not.toHaveBeenCalled();
@@ -53,8 +57,7 @@ describe('HealthController', () => {
   });
 
   describe('GET /health/ready', () => {
-    it('delegates to HealthCheckService with all four checks', async () => {
-      await buildController();
+    it('delegates to HealthCheckService', async () => {
       await controller.readiness();
       expect(healthService.check).toHaveBeenCalledWith(
         expect.arrayContaining([
@@ -67,7 +70,6 @@ describe('HealthController', () => {
     });
 
     it('calls all four indicators', async () => {
-      await buildController();
       await controller.readiness();
       expect(dbIndicator.pingCheck).toHaveBeenCalledWith('database');
       expect(redisIndicator.isHealthy).toHaveBeenCalledWith('redis');
@@ -77,14 +79,7 @@ describe('HealthController', () => {
   });
 
   describe('GET /health (backward-compat alias)', () => {
-    it('delegates to HealthCheckService with all four checks', async () => {
-      await buildController();
-      await controller.check();
-      expect(healthService.check).toHaveBeenCalled();
-    });
-
-    it('calls all four indicators — same set as /health/ready', async () => {
-      await buildController();
+    it('calls the same four indicators as /health/ready', async () => {
       await controller.check();
       expect(dbIndicator.pingCheck).toHaveBeenCalledWith('database');
       expect(redisIndicator.isHealthy).toHaveBeenCalledWith('redis');

--- a/xconfess-backend/src/health/health.controller.spec.ts
+++ b/xconfess-backend/src/health/health.controller.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+import { HealthController } from './health.controller';
+import { RedisHealthIndicator } from './redis.health';
+import { SchemaReadinessHealthIndicator } from './schema-readiness.health';
+import { QueueHealthIndicator } from './queue.health';
+
+const UP = (key: string) => ({ [key]: { status: 'up' } });
+
+function makeHealthService(pass: boolean) {
+  return {
+    check: jest.fn().mockImplementation(async (checks: Array<() => Promise<unknown>>) => {
+      if (!pass) throw new Error('unhealthy');
+      const results = await Promise.all(checks.map((fn) => fn()));
+      return { status: 'ok', details: Object.assign({}, ...results) };
+    }),
+  };
+}
+
+describe('HealthController', () => {
+  let controller: HealthController;
+  let healthService: ReturnType<typeof makeHealthService>;
+
+  const dbIndicator = { pingCheck: jest.fn().mockResolvedValue(UP('database')) };
+  const redisIndicator = { isHealthy: jest.fn().mockResolvedValue(UP('redis')) };
+  const schemaIndicator = { isHealthy: jest.fn().mockResolvedValue(UP('schema')) };
+  const queueIndicator = { isHealthy: jest.fn().mockResolvedValue(UP('queues')) };
+
+  async function buildController(pass = true) {
+    healthService = makeHealthService(pass);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        { provide: HealthCheckService, useValue: healthService },
+        { provide: TypeOrmHealthIndicator, useValue: dbIndicator },
+        { provide: RedisHealthIndicator, useValue: redisIndicator },
+        { provide: SchemaReadinessHealthIndicator, useValue: schemaIndicator },
+        { provide: QueueHealthIndicator, useValue: queueIndicator },
+      ],
+    }).compile();
+
+    controller = module.get(HealthController);
+  }
+
+  describe('GET /health/live', () => {
+    it('returns {status: ok} synchronously without calling any indicator', async () => {
+      await buildController();
+      const result = controller.liveness();
+      expect(result).toEqual({ status: 'ok' });
+      expect(healthService.check).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /health/ready', () => {
+    it('delegates to HealthCheckService with all four checks', async () => {
+      await buildController();
+      await controller.readiness();
+      expect(healthService.check).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.any(Function),
+          expect.any(Function),
+          expect.any(Function),
+          expect.any(Function),
+        ]),
+      );
+    });
+
+    it('calls all four indicators', async () => {
+      await buildController();
+      await controller.readiness();
+      expect(dbIndicator.pingCheck).toHaveBeenCalledWith('database');
+      expect(redisIndicator.isHealthy).toHaveBeenCalledWith('redis');
+      expect(queueIndicator.isHealthy).toHaveBeenCalledWith('queues');
+      expect(schemaIndicator.isHealthy).toHaveBeenCalledWith('schema');
+    });
+  });
+
+  describe('GET /health (backward-compat alias)', () => {
+    it('delegates to HealthCheckService with all four checks', async () => {
+      await buildController();
+      await controller.check();
+      expect(healthService.check).toHaveBeenCalled();
+    });
+
+    it('calls all four indicators — same set as /health/ready', async () => {
+      await buildController();
+      await controller.check();
+      expect(dbIndicator.pingCheck).toHaveBeenCalledWith('database');
+      expect(redisIndicator.isHealthy).toHaveBeenCalledWith('redis');
+      expect(queueIndicator.isHealthy).toHaveBeenCalledWith('queues');
+      expect(schemaIndicator.isHealthy).toHaveBeenCalledWith('schema');
+    });
+  });
+});

--- a/xconfess-backend/src/health/health.controller.ts
+++ b/xconfess-backend/src/health/health.controller.ts
@@ -1,0 +1,96 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  HealthCheck,
+  HealthCheckService,
+  TypeOrmHealthIndicator,
+} from '@nestjs/terminus';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { RedisHealthIndicator } from './redis.health';
+import { SchemaReadinessHealthIndicator } from './schema-readiness.health';
+import { QueueHealthIndicator } from './queue.health';
+
+@ApiTags('Health')
+@Controller('health')
+export class HealthController {
+  constructor(
+    private readonly health: HealthCheckService,
+    private readonly db: TypeOrmHealthIndicator,
+    private readonly redis: RedisHealthIndicator,
+    private readonly schemaReadiness: SchemaReadinessHealthIndicator,
+    private readonly queues: QueueHealthIndicator,
+  ) {}
+
+  /**
+   * Liveness probe — is the process responsive?
+   * No external dependency checks. Safe to call at high frequency from load
+   * balancers and Kubernetes. Returning 200 here means only "restart me if
+   * this starts failing," not "I'm ready to serve traffic."
+   */
+  @Get('live')
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
+  @ApiOperation({
+    summary: 'Liveness probe',
+    description:
+      'Returns 200 while the Node process is responsive. No external dependency checks. ' +
+      'Use this for Kubernetes liveness probes and load-balancer keep-alives.',
+  })
+  @ApiResponse({ status: 200, description: 'Process is alive' })
+  liveness() {
+    return { status: 'ok' };
+  }
+
+  /**
+   * Readiness probe — are all dependencies available?
+   * Checks Postgres, Redis, BullMQ queue workers, and confession-table schema.
+   * Returns 503 when any dependency is unavailable so orchestrators can stop
+   * routing traffic to this instance.
+   */
+  @Get('ready')
+  @HealthCheck()
+  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @ApiOperation({
+    summary: 'Readiness probe',
+    description:
+      'Checks all external dependencies: Postgres ping, Redis ping, BullMQ queue-worker ' +
+      'presence, and confession-table schema. Returns 503 with per-check detail when any ' +
+      'dependency is unavailable. Use this for Kubernetes readiness probes.',
+  })
+  @ApiResponse({ status: 200, description: 'All dependencies ready' })
+  @ApiResponse({
+    status: 503,
+    description:
+      'One or more dependencies unavailable — see response body for per-check detail',
+  })
+  readiness() {
+    return this.health.check([
+      async () => this.db.pingCheck('database'),
+      async () => this.redis.isHealthy('redis'),
+      async () => this.queues.isHealthy('queues'),
+      async () => this.schemaReadiness.isHealthy('schema'),
+    ]);
+  }
+
+  /**
+   * Backward-compatible alias for GET /health/ready.
+   * Prefer /health/ready for new integrations.
+   */
+  @Get()
+  @HealthCheck()
+  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @ApiOperation({
+    summary: 'Health check (readiness alias)',
+    description:
+      'Backward-compatible alias for GET /health/ready. Prefer /health/ready for new integrations.',
+  })
+  @ApiResponse({ status: 200, description: 'All checks passed' })
+  @ApiResponse({ status: 503, description: 'One or more checks failed' })
+  check() {
+    return this.health.check([
+      async () => this.db.pingCheck('database'),
+      async () => this.redis.isHealthy('redis'),
+      async () => this.queues.isHealthy('queues'),
+      async () => this.schemaReadiness.isHealthy('schema'),
+    ]);
+  }
+}

--- a/xconfess-backend/src/health/health.controller.ts
+++ b/xconfess-backend/src/health/health.controller.ts
@@ -4,7 +4,7 @@ import {
   HealthCheckService,
   TypeOrmHealthIndicator,
 } from '@nestjs/terminus';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { RedisHealthIndicator } from './redis.health';
 import { SchemaReadinessHealthIndicator } from './schema-readiness.health';
@@ -23,17 +23,15 @@ export class HealthController {
 
   /**
    * Liveness probe — is the process responsive?
-   * No external dependency checks. Safe to call at high frequency from load
-   * balancers and Kubernetes. Returning 200 here means only "restart me if
-   * this starts failing," not "I'm ready to serve traffic."
+   * No external dependency checks. Safe to poll at high frequency.
    */
   @Get('live')
   @Throttle({ default: { limit: 120, ttl: 60_000 } })
   @ApiOperation({
     summary: 'Liveness probe',
     description:
-      'Returns 200 while the Node process is responsive. No external dependency checks. ' +
-      'Use this for Kubernetes liveness probes and load-balancer keep-alives.',
+      'Returns 200 while the Node process is responsive. ' +
+      'No external dependency checks. Use for Kubernetes liveness probes.',
   })
   @ApiResponse({ status: 200, description: 'Process is alive' })
   liveness() {
@@ -42,9 +40,7 @@ export class HealthController {
 
   /**
    * Readiness probe — are all dependencies available?
-   * Checks Postgres, Redis, BullMQ queue workers, and confession-table schema.
-   * Returns 503 when any dependency is unavailable so orchestrators can stop
-   * routing traffic to this instance.
+   * Returns 503 when any dependency is unavailable.
    */
   @Get('ready')
   @HealthCheck()
@@ -52,15 +48,14 @@ export class HealthController {
   @ApiOperation({
     summary: 'Readiness probe',
     description:
-      'Checks all external dependencies: Postgres ping, Redis ping, BullMQ queue-worker ' +
-      'presence, and confession-table schema. Returns 503 with per-check detail when any ' +
-      'dependency is unavailable. Use this for Kubernetes readiness probes.',
+      'Checks Postgres, Redis, BullMQ queue workers, and confession-table schema. ' +
+      'Returns 503 with per-check detail on failure. ' +
+      'Use for Kubernetes readiness probes.',
   })
   @ApiResponse({ status: 200, description: 'All dependencies ready' })
   @ApiResponse({
     status: 503,
-    description:
-      'One or more dependencies unavailable — see response body for per-check detail',
+    description: 'One or more dependencies unavailable',
   })
   readiness() {
     return this.health.check([
@@ -71,17 +66,15 @@ export class HealthController {
     ]);
   }
 
-  /**
-   * Backward-compatible alias for GET /health/ready.
-   * Prefer /health/ready for new integrations.
-   */
+  /** Backward-compatible alias for GET /health/ready. */
   @Get()
   @HealthCheck()
   @Throttle({ default: { limit: 30, ttl: 60_000 } })
   @ApiOperation({
     summary: 'Health check (readiness alias)',
     description:
-      'Backward-compatible alias for GET /health/ready. Prefer /health/ready for new integrations.',
+      'Backward-compatible alias for GET /health/ready. ' +
+      'Prefer /health/ready for new integrations.',
   })
   @ApiResponse({ status: 200, description: 'All checks passed' })
   @ApiResponse({ status: 503, description: 'One or more checks failed' })

--- a/xconfess-backend/src/health/health.module.ts
+++ b/xconfess-backend/src/health/health.module.ts
@@ -6,8 +6,8 @@ import { RedisHealthIndicator } from './redis.health';
 import { SchemaReadinessHealthIndicator } from './schema-readiness.health';
 import { QueueHealthIndicator } from './queue.health';
 
-// Queue names are inlined here to keep the health module self-contained
-// and avoid importing from feature-module internals.
+// Inlined to keep the health module self-contained and avoid importing from
+// feature-module internals.
 const MONITORED_QUEUES = [
   'notifications',
   'notifications-dlq',

--- a/xconfess-backend/src/health/health.module.ts
+++ b/xconfess-backend/src/health/health.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+import { BullModule } from '@nestjs/bullmq';
+import { HealthController } from './health.controller';
+import { RedisHealthIndicator } from './redis.health';
+import { SchemaReadinessHealthIndicator } from './schema-readiness.health';
+import { QueueHealthIndicator } from './queue.health';
+
+// Queue names are inlined here to keep the health module self-contained
+// and avoid importing from feature-module internals.
+const MONITORED_QUEUES = [
+  'notifications',
+  'notifications-dlq',
+  'export-queue',
+  'confession-draft-publisher',
+];
+
+@Module({
+  imports: [
+    TerminusModule,
+    ...MONITORED_QUEUES.map((name) => BullModule.registerQueue({ name })),
+  ],
+  controllers: [HealthController],
+  providers: [
+    RedisHealthIndicator,
+    SchemaReadinessHealthIndicator,
+    QueueHealthIndicator,
+  ],
+})
+export class HealthModule {}

--- a/xconfess-backend/src/health/queue.health.spec.ts
+++ b/xconfess-backend/src/health/queue.health.spec.ts
@@ -1,0 +1,167 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthCheckError } from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import { getQueueToken } from '@nestjs/bullmq';
+import { QueueHealthIndicator } from './queue.health';
+
+const QUEUE_NAMES = [
+  'notifications',
+  'notifications-dlq',
+  'export-queue',
+  'confession-draft-publisher',
+] as const;
+
+/** Creates a mock BullMQ Queue with controllable return values. */
+function makeMockQueue(workers = 1, counts = { active: 0, waiting: 0, failed: 0, delayed: 0 }) {
+  return {
+    getWorkers: jest.fn().mockResolvedValue(new Array(workers).fill({ id: 'w1' })),
+    getJobCounts: jest.fn().mockResolvedValue(counts),
+  };
+}
+
+function buildModule(
+  queueOverrides: Partial<Record<(typeof QUEUE_NAMES)[number], ReturnType<typeof makeMockQueue>>>,
+  jobsEnabled = true,
+) {
+  const queues = Object.fromEntries(
+    QUEUE_NAMES.map((name) => [name, queueOverrides[name] ?? makeMockQueue()]),
+  );
+
+  return Test.createTestingModule({
+    providers: [
+      QueueHealthIndicator,
+      {
+        provide: ConfigService,
+        useValue: {
+          get: jest.fn((key: string) =>
+            key === 'ENABLE_BACKGROUND_JOBS' ? (jobsEnabled ? 'true' : 'false') : undefined,
+          ),
+        },
+      },
+      ...QUEUE_NAMES.map((name) => ({
+        provide: getQueueToken(name),
+        useValue: queues[name],
+      })),
+    ],
+  }).compile();
+}
+
+describe('QueueHealthIndicator', () => {
+  let indicator: QueueHealthIndicator;
+
+  describe('when background jobs are disabled', () => {
+    beforeEach(async () => {
+      const module: TestingModule = await buildModule({}, false);
+      indicator = module.get(QueueHealthIndicator);
+    });
+
+    it('returns up with disabled status', async () => {
+      const result = await indicator.isHealthy('queues');
+      expect(result.queues.status).toBe('up');
+      expect(result.queues).toMatchObject({ status: 'disabled' });
+    });
+  });
+
+  describe('when background jobs are enabled', () => {
+    describe('and all queues have workers', () => {
+      beforeEach(async () => {
+        const module: TestingModule = await buildModule({});
+        indicator = module.get(QueueHealthIndicator);
+      });
+
+      it('returns up with per-queue worker and count details', async () => {
+        const result = await indicator.isHealthy('queues');
+        expect(result.queues.status).toBe('up');
+        expect(result.queues['notifications']).toMatchObject({
+          status: 'up',
+          workers: 1,
+        });
+      });
+    });
+
+    describe('and a worker-required queue has no workers', () => {
+      beforeEach(async () => {
+        const module: TestingModule = await buildModule({
+          notifications: makeMockQueue(0),
+        });
+        indicator = module.get(QueueHealthIndicator);
+      });
+
+      it('throws HealthCheckError', async () => {
+        await expect(indicator.isHealthy('queues')).rejects.toThrow(
+          HealthCheckError,
+        );
+      });
+
+      it('marks the affected queue as down in the error detail', async () => {
+        try {
+          await indicator.isHealthy('queues');
+        } catch (err) {
+          expect(err).toBeInstanceOf(HealthCheckError);
+          const detail = (err as HealthCheckError).causes as Record<string, unknown>;
+          expect((detail.queues as Record<string, unknown>)['notifications']).toMatchObject({
+            status: 'down',
+            workers: 0,
+          });
+        }
+      });
+    });
+
+    describe('and the DLQ has no workers', () => {
+      beforeEach(async () => {
+        const module: TestingModule = await buildModule({
+          'notifications-dlq': makeMockQueue(0),
+        });
+        indicator = module.get(QueueHealthIndicator);
+      });
+
+      it('remains healthy — DLQ does not require workers', async () => {
+        const result = await indicator.isHealthy('queues');
+        expect(result.queues.status).toBe('up');
+        expect(result.queues['notifications-dlq']).toMatchObject({
+          status: 'up',
+          workers: 0,
+        });
+      });
+    });
+
+    describe('and a queue throws during the check', () => {
+      beforeEach(async () => {
+        const broken = {
+          getWorkers: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
+          getJobCounts: jest.fn().mockResolvedValue({}),
+        };
+        const module: TestingModule = await buildModule({ 'export-queue': broken });
+        indicator = module.get(QueueHealthIndicator);
+      });
+
+      it('throws HealthCheckError with error detail for the failing queue', async () => {
+        await expect(indicator.isHealthy('queues')).rejects.toThrow(
+          HealthCheckError,
+        );
+      });
+    });
+
+    describe('job counts are forwarded in the result', () => {
+      beforeEach(async () => {
+        const queueWithJobs = makeMockQueue(2, {
+          active: 3,
+          waiting: 10,
+          failed: 1,
+          delayed: 0,
+        });
+        const module: TestingModule = await buildModule({
+          notifications: queueWithJobs,
+        });
+        indicator = module.get(QueueHealthIndicator);
+      });
+
+      it('includes counts in the healthy result', async () => {
+        const result = await indicator.isHealthy('queues');
+        expect(result.queues['notifications']).toMatchObject({
+          counts: { active: 3, waiting: 10, failed: 1, delayed: 0 },
+        });
+      });
+    });
+  });
+});

--- a/xconfess-backend/src/health/queue.health.spec.ts
+++ b/xconfess-backend/src/health/queue.health.spec.ts
@@ -11,16 +11,24 @@ const QUEUE_NAMES = [
   'confession-draft-publisher',
 ] as const;
 
-/** Creates a mock BullMQ Queue with controllable return values. */
-function makeMockQueue(workers = 1, counts = { active: 0, waiting: 0, failed: 0, delayed: 0 }) {
+type QueueName = (typeof QUEUE_NAMES)[number];
+
+function makeMockQueue(
+  workers = 1,
+  counts = { active: 0, waiting: 0, failed: 0, delayed: 0 },
+) {
   return {
-    getWorkers: jest.fn().mockResolvedValue(new Array(workers).fill({ id: 'w1' })),
+    getWorkers: jest
+      .fn()
+      .mockResolvedValue(new Array(workers).fill({ id: 'w1' })),
     getJobCounts: jest.fn().mockResolvedValue(counts),
   };
 }
 
+type MockQueue = ReturnType<typeof makeMockQueue>;
+
 function buildModule(
-  queueOverrides: Partial<Record<(typeof QUEUE_NAMES)[number], ReturnType<typeof makeMockQueue>>>,
+  queueOverrides: Partial<Record<QueueName, MockQueue>>,
   jobsEnabled = true,
 ) {
   const queues = Object.fromEntries(
@@ -34,7 +42,11 @@ function buildModule(
         provide: ConfigService,
         useValue: {
           get: jest.fn((key: string) =>
-            key === 'ENABLE_BACKGROUND_JOBS' ? (jobsEnabled ? 'true' : 'false') : undefined,
+            key === 'ENABLE_BACKGROUND_JOBS'
+              ? jobsEnabled
+                ? 'true'
+                : 'false'
+              : undefined,
           ),
         },
       },
@@ -55,10 +67,10 @@ describe('QueueHealthIndicator', () => {
       indicator = module.get(QueueHealthIndicator);
     });
 
-    it('returns up with disabled status', async () => {
+    it('returns up with mode=disabled and skips queue checks', async () => {
       const result = await indicator.isHealthy('queues');
       expect(result.queues.status).toBe('up');
-      expect(result.queues).toMatchObject({ status: 'disabled' });
+      expect(result.queues).toMatchObject({ mode: 'disabled' });
     });
   });
 
@@ -94,12 +106,16 @@ describe('QueueHealthIndicator', () => {
       });
 
       it('marks the affected queue as down in the error detail', async () => {
+        expect.assertions(2);
         try {
           await indicator.isHealthy('queues');
         } catch (err) {
           expect(err).toBeInstanceOf(HealthCheckError);
-          const detail = (err as HealthCheckError).causes as Record<string, unknown>;
-          expect((detail.queues as Record<string, unknown>)['notifications']).toMatchObject({
+          const causes = (err as HealthCheckError).causes as Record<
+            string,
+            Record<string, unknown>
+          >;
+          expect(causes['queues']['notifications']).toMatchObject({
             status: 'down',
             workers: 0,
           });
@@ -127,11 +143,15 @@ describe('QueueHealthIndicator', () => {
 
     describe('and a queue throws during the check', () => {
       beforeEach(async () => {
-        const broken = {
-          getWorkers: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
+        const broken: MockQueue = {
+          getWorkers: jest
+            .fn()
+            .mockRejectedValue(new Error('ECONNREFUSED')),
           getJobCounts: jest.fn().mockResolvedValue({}),
         };
-        const module: TestingModule = await buildModule({ 'export-queue': broken });
+        const module: TestingModule = await buildModule({
+          'export-queue': broken,
+        });
         indicator = module.get(QueueHealthIndicator);
       });
 

--- a/xconfess-backend/src/health/queue.health.ts
+++ b/xconfess-backend/src/health/queue.health.ts
@@ -1,0 +1,98 @@
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { ConfigService } from '@nestjs/config';
+
+interface QueueDetail {
+  status: 'up' | 'down' | 'disabled';
+  workers?: number;
+  counts?: Record<string, number>;
+  error?: string;
+}
+
+@Injectable()
+export class QueueHealthIndicator extends HealthIndicator {
+  private readonly logger = new Logger(QueueHealthIndicator.name);
+
+  constructor(
+    @InjectQueue('notifications') private readonly notifications: Queue,
+    @InjectQueue('notifications-dlq') private readonly dlq: Queue,
+    @InjectQueue('export-queue') private readonly exportQueue: Queue,
+    @InjectQueue('confession-draft-publisher')
+    private readonly draftQueue: Queue,
+    private readonly configService: ConfigService,
+  ) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const jobsEnabled =
+      this.configService.get<string>('ENABLE_BACKGROUND_JOBS') === 'true';
+
+    if (!jobsEnabled) {
+      return this.getStatus(key, true, {
+        status: 'disabled',
+        reason: 'ENABLE_BACKGROUND_JOBS is not enabled',
+      });
+    }
+
+    const queues: Array<{ name: string; queue: Queue; requiresWorkers: boolean }> =
+      [
+        { name: 'notifications', queue: this.notifications, requiresWorkers: true },
+        // DLQ is a retention queue — no processor is expected to run against it
+        { name: 'notifications-dlq', queue: this.dlq, requiresWorkers: false },
+        { name: 'export-queue', queue: this.exportQueue, requiresWorkers: true },
+        {
+          name: 'confession-draft-publisher',
+          queue: this.draftQueue,
+          requiresWorkers: true,
+        },
+      ];
+
+    const details: Record<string, QueueDetail> = {};
+    let allHealthy = true;
+
+    await Promise.all(
+      queues.map(async ({ name, queue, requiresWorkers }) => {
+        try {
+          const [counts, workers] = await Promise.all([
+            queue.getJobCounts('active', 'waiting', 'failed', 'delayed'),
+            queue.getWorkers(),
+          ]);
+
+          const workerCount = workers.length;
+          const healthy = !requiresWorkers || workerCount > 0;
+
+          if (!healthy) {
+            allHealthy = false;
+          }
+
+          details[name] = {
+            status: healthy ? 'up' : 'down',
+            workers: workerCount,
+            counts,
+          };
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.error(`Queue health check failed for "${name}": ${message}`);
+          allHealthy = false;
+          details[name] = { status: 'down', error: message };
+        }
+      }),
+    );
+
+    if (!allHealthy) {
+      throw new HealthCheckError(
+        'One or more queues are unhealthy',
+        this.getStatus(key, false, details),
+      );
+    }
+
+    return this.getStatus(key, true, details);
+  }
+}

--- a/xconfess-backend/src/health/queue.health.ts
+++ b/xconfess-backend/src/health/queue.health.ts
@@ -9,7 +9,7 @@ import { Queue } from 'bullmq';
 import { ConfigService } from '@nestjs/config';
 
 interface QueueDetail {
-  status: 'up' | 'down' | 'disabled';
+  status: 'up' | 'down';
   workers?: number;
   counts?: Record<string, number>;
   error?: string;
@@ -36,23 +36,38 @@ export class QueueHealthIndicator extends HealthIndicator {
 
     if (!jobsEnabled) {
       return this.getStatus(key, true, {
-        status: 'disabled',
-        reason: 'ENABLE_BACKGROUND_JOBS is not enabled',
+        mode: 'disabled',
+        reason: 'ENABLE_BACKGROUND_JOBS is not set',
       });
     }
 
-    const queues: Array<{ name: string; queue: Queue; requiresWorkers: boolean }> =
-      [
-        { name: 'notifications', queue: this.notifications, requiresWorkers: true },
-        // DLQ is a retention queue — no processor is expected to run against it
-        { name: 'notifications-dlq', queue: this.dlq, requiresWorkers: false },
-        { name: 'export-queue', queue: this.exportQueue, requiresWorkers: true },
-        {
-          name: 'confession-draft-publisher',
-          queue: this.draftQueue,
-          requiresWorkers: true,
-        },
-      ];
+    const queues: Array<{
+      name: string;
+      queue: Queue;
+      requiresWorkers: boolean;
+    }> = [
+      {
+        name: 'notifications',
+        queue: this.notifications,
+        requiresWorkers: true,
+      },
+      // DLQ is a retention queue — no processor is expected to run against it
+      {
+        name: 'notifications-dlq',
+        queue: this.dlq,
+        requiresWorkers: false,
+      },
+      {
+        name: 'export-queue',
+        queue: this.exportQueue,
+        requiresWorkers: true,
+      },
+      {
+        name: 'confession-draft-publisher',
+        queue: this.draftQueue,
+        requiresWorkers: true,
+      },
+    ];
 
     const details: Record<string, QueueDetail> = {};
     let allHealthy = true;
@@ -78,8 +93,11 @@ export class QueueHealthIndicator extends HealthIndicator {
             counts,
           };
         } catch (error: unknown) {
-          const message = error instanceof Error ? error.message : String(error);
-          this.logger.error(`Queue health check failed for "${name}": ${message}`);
+          const message =
+            error instanceof Error ? error.message : String(error);
+          this.logger.error(
+            `Queue health check failed for "${name}": ${message}`,
+          );
           allHealthy = false;
           details[name] = { status: 'down', error: message };
         }


### PR DESCRIPTION
Closes #738

## Problem

`GET /health` was a single undifferentiated endpoint mixing liveness and
readiness concerns, and had no visibility into BullMQ queue workers. A
processor crash would go undetected until jobs piled up silently in the
queue.

## Changes

### New endpoints

| Endpoint | Purpose | Rate limit |
|---|---|---|
| `GET /health/live` | Process-only liveness — no external deps | 120/min |
| `GET /health/ready` | Full readiness — Postgres, Redis, queues, schema | 30/min |
| `GET /health` | Backward-compat alias for `/health/ready` | 30/min |

### New `QueueHealthIndicator`
- Checks all 4 queues: `notifications`, `notifications-dlq`, `export-queue`, `confession-draft-publisher`
- Returns per-queue `workers` count and `counts` (active / waiting / failed / delayed) in every response
- Marks a queue `down` if it requires workers and has none
- `notifications-dlq` is exempt from the worker-presence check — it is a retention queue with no expected processor
- When `ENABLE_BACKGROUND_JOBS=false`, returns `{ status: "disabled" }` with no false alarms

### Structural cleanup
- All health wiring consolidated into `HealthModule` — `AppModule` no longer manually registers `TerminusModule` or individual indicators
- `AppController` no longer owns the `/health` route

## Kubernetes probe config

```yaml
livenessProbe:
  httpGet:
    path: /health/live
    port: 5000
  periodSeconds: 10

readinessProbe:
  httpGet:
    path: /health/ready
    port: 5000
  periodSeconds: 15
  failureThreshold: 3
