### PR TITLE
cap payload and memo sizes

### DIFF
--- a/xconfess-contracts/contracts/confession-anchor/src/errors.rs
+++ b/xconfess-contracts/contracts/confession-anchor/src/errors.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-// Re-export shared error definitions from parent workspace
-pub use xconfess_contract::errors::{
-    codes, ContractError, ErrorClassification, ERROR_REGISTRY_VERSION,
-};
+#[path = "../../error.rs"]
+mod shared_error;
+
+// Re-export shared error definitions from parent workspace.
+#[allow(unused_imports)]
+pub use shared_error::{codes, ContractError, ErrorClassification, ERROR_REGISTRY_VERSION};

--- a/xconfess-contracts/contracts/confession-anchor/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-anchor/src/lib.rs
@@ -221,13 +221,12 @@ impl ConfessionAnchor {
         // topics: ("confession_anchor", hash)
         // data: (event_version, timestamp, anchor_height)
         ConfessionAnchoredEvent {
-              content_hash: hash.clone(),
-              event_version: events::CONFESSION_ANCHORED_EVENT_VERSION,
-              nonce: events::bump_nonce(env, &events::EventNonceKey::ConfessionAnchor(hash.clone())),
-              timestamp,
-              anchor_height,
-          }
-          .publish(&env);
+            hash: hash.clone(),
+            event_version: events::CONFESSION_ANCHORED_EVENT_VERSION,
+            timestamp,
+            anchor_height,
+        }
+        .publish(&env);
 
         symbol_short!("anchored")
     }
@@ -336,18 +335,23 @@ impl ConfessionAnchor {
         let compatible = Self::can_upgrade_from(env.clone(), from_major, from_minor, from_patch);
 
         VersionCompatibilityCheckedEvent {
-              event_version: events::VERSION_COMPATIBILITY_CHECKED_EVENT_VERSION,
-              nonce: events::bump_nonce(env, &events::EventNonceKey::VersionCompatibilityCheck(from_major, from_minor, from_patch)),
-              timestamp: env.ledger().timestamp(),
-              from_major,
-              from_minor,
-              from_patch,
-              to_major: CONTRACT_SEMVER_MAJOR,
-              to_minor: CONTRACT_SEMVER_MINOR,
-              to_patch: CONTRACT_SEMVER_PATCH,
-              compatible,
-          }
-          .publish(&env);
+            event_version: events::VERSION_COMPATIBILITY_CHECKED_EVENT_VERSION,
+            nonce: events::bump_nonce(
+                &env,
+                events::EventNonceKey::VersionCompatibilityCheck(
+                    from_major, from_minor, from_patch,
+                ),
+            ),
+            timestamp: env.ledger().timestamp(),
+            from_major,
+            from_minor,
+            from_patch,
+            to_major: CONTRACT_SEMVER_MAJOR,
+            to_minor: CONTRACT_SEMVER_MINOR,
+            to_patch: CONTRACT_SEMVER_PATCH,
+            compatible,
+        }
+        .publish(&env);
 
         if compatible {
             Ok(())
@@ -1194,5 +1198,34 @@ mod test {
             client.try_assert_upgrade_from(&(CONTRACT_SEMVER_MAJOR + 1), &0, &0),
             Err(Ok(Error::IncompatibleUpgrade))
         );
+    }
+
+    #[test]
+    fn pause_reason_exact_limit_succeeds() {
+        let (env, client) = new_client();
+        let owner = Address::generate(&env);
+        let reason = SorobanString::from_str(
+            &env,
+            &"r".repeat(emergency_pause::events::MAX_PAUSE_REASON_LEN as usize),
+        );
+
+        client.initialize(&owner);
+
+        client.pause(&owner, &reason);
+    }
+
+    #[test]
+    #[should_panic(expected = "pause reason too long")]
+    fn pause_reason_limit_plus_one_rejected() {
+        let (env, client) = new_client();
+        let owner = Address::generate(&env);
+        let reason = SorobanString::from_str(
+            &env,
+            &"r".repeat((emergency_pause::events::MAX_PAUSE_REASON_LEN + 1) as usize),
+        );
+
+        client.initialize(&owner);
+
+        let _ = client.pause(&owner, &reason);
     }
 }

--- a/xconfess-contracts/contracts/confession-registry/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-registry/src/lib.rs
@@ -6,8 +6,12 @@
 mod confession_reg_auth;
 
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, Address, BytesN, Env, Vec,
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, BytesN, Env,
+    Symbol, Vec,
 };
+
+pub const MAX_AUTHOR_CONFESSIONS_PER_AUTHOR: u32 = 128;
+pub const REGISTRY_PAYLOAD_TOO_LONG: &str = "registry payload too long";
 
 #[path = "../../access_control.rs"]
 mod access_control;
@@ -50,43 +54,43 @@ pub struct Confession {
     pub status: ConfessionStatus,
 }
 
-  #[contractevent(topics = ["confession_created"], data_format = "vec")]
-  #[derive(Clone, Debug, Eq, PartialEq)]
-  pub struct ConfessionCreatedEvent {
-      #[topic]
-      pub id: u64,
-      pub event_version: u32,
-      pub nonce: u64,
-      pub timestamp: u64,
-      pub author: Address,
-      pub content_hash: BytesN<32>,
-      pub correlation_id: Option<Symbol>,
-  }
+#[contractevent(topics = ["confession_created"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfessionCreatedEvent {
+    #[topic]
+    pub id: u64,
+    pub event_version: u32,
+    pub nonce: u64,
+    pub timestamp: u64,
+    pub author: Address,
+    pub content_hash: BytesN<32>,
+    pub correlation_id: Option<Symbol>,
+}
 
-  #[contractevent(topics = ["confession_updated"], data_format = "vec")]
-  #[derive(Clone, Debug, Eq, PartialEq)]
-  pub struct ConfessionUpdatedEvent {
-      #[topic]
-      pub id: u64,
-      pub event_version: u32,
-      pub nonce: u64,
-      pub timestamp: u64,
-      pub old_status: ConfessionStatus,
-      pub new_status: ConfessionStatus,
-      pub correlation_id: Option<Symbol>,
-  }
+#[contractevent(topics = ["confession_updated"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfessionUpdatedEvent {
+    #[topic]
+    pub id: u64,
+    pub event_version: u32,
+    pub nonce: u64,
+    pub timestamp: u64,
+    pub old_status: ConfessionStatus,
+    pub new_status: ConfessionStatus,
+    pub correlation_id: Option<Symbol>,
+}
 
-  #[contractevent(topics = ["confession_deleted"], data_format = "vec")]
-  #[derive(Clone, Debug, Eq, PartialEq)]
-  pub struct ConfessionDeletedEvent {
-      #[topic]
-      pub id: u64,
-      pub event_version: u32,
-      pub nonce: u64,
-      pub timestamp: u64,
-      pub actor: Address,
-      pub correlation_id: Option<Symbol>,
-  }
+#[contractevent(topics = ["confession_deleted"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConfessionDeletedEvent {
+    #[topic]
+    pub id: u64,
+    pub event_version: u32,
+    pub nonce: u64,
+    pub timestamp: u64,
+    pub actor: Address,
+    pub correlation_id: Option<Symbol>,
+}
 
 /// Storage keys used by the contract.
 #[contracttype]
@@ -131,6 +135,19 @@ fn consume_nonce(env: &Env, caller: &Address, nonce: u64) -> Result<(), ReplayEr
         .instance()
         .set(&DataKey::CallerNonce(caller.clone()), &(expected + 1));
     Ok(())
+}
+
+fn bump_confession_event_nonce(env: &Env, id: u64) -> u64 {
+    let key = DataKey::EventNonceConfession(id);
+    let next = env
+        .storage()
+        .instance()
+        .get(&key)
+        .unwrap_or(0u64)
+        .checked_add(1)
+        .expect("event nonce overflow");
+    env.storage().instance().set(&key, &next);
+    next
 }
 
 // ─── Contract ───
@@ -216,6 +233,15 @@ impl ConfessionRegistry {
             panic!("confession with this content hash already exists");
         }
 
+        let mut author_ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AuthorConfessions(author.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        if author_ids.len() >= MAX_AUTHOR_CONFESSIONS_PER_AUTHOR {
+            panic!("{}", REGISTRY_PAYLOAD_TOO_LONG);
+        }
+
         // Allocate ID
         let id: u64 = env
             .storage()
@@ -243,27 +269,22 @@ impl ConfessionRegistry {
             .set(&DataKey::HashIndex(content_hash.clone()), &id);
 
         // Track author → confession index
-        let mut author_ids: Vec<u64> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AuthorConfessions(author.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
         author_ids.push_back(id);
         env.storage()
             .instance()
             .set(&DataKey::AuthorConfessions(author.clone()), &author_ids);
 
-         // Emit event
-         ConfessionCreatedEvent {
-               id,
-               event_version: events::EVENT_VERSION_V1,
-               nonce: events::bump_nonce(env, events::EventNonceKey::Confession(id)),
-               timestamp,
-               author,
-               content_hash,
-               correlation_id: None,
-           }
-           .publish(&env);
+        // Emit event
+        ConfessionCreatedEvent {
+            id,
+            event_version: events::EVENT_VERSION_V1,
+            nonce: bump_confession_event_nonce(&env, id),
+            timestamp,
+            author,
+            content_hash,
+            correlation_id: None,
+        }
+        .publish(&env);
 
         id
     }
@@ -375,16 +396,16 @@ impl ConfessionRegistry {
             .instance()
             .set(&DataKey::Confession(id), &confession);
 
-         ConfessionUpdatedEvent {
-               id,
-               event_version: events::EVENT_VERSION_V1,
-               nonce: events::bump_nonce(env, events::EventNonceKey::Confession(id)),
-               timestamp,
-               old_status,
-               new_status: confession.status,
-               correlation_id: None,
-           }
-           .publish(&env);
+        ConfessionUpdatedEvent {
+            id,
+            event_version: events::EVENT_VERSION_V1,
+            nonce: bump_confession_event_nonce(&env, id),
+            timestamp,
+            old_status,
+            new_status: confession.status,
+            correlation_id: None,
+        }
+        .publish(&env);
     }
 
     /// Replay-protected update_status variant.
@@ -442,15 +463,15 @@ impl ConfessionRegistry {
             .instance()
             .set(&DataKey::Confession(id), &confession);
 
-         ConfessionDeletedEvent {
-               id,
-               event_version: events::EVENT_VERSION_V1,
-               nonce: events::bump_nonce(env, events::EventNonceKey::Confession(id)),
-               timestamp,
-               actor: caller,
-               correlation_id: None,
-           }
-           .publish(&env);
+        ConfessionDeletedEvent {
+            id,
+            event_version: events::EVENT_VERSION_V1,
+            nonce: bump_confession_event_nonce(&env, id),
+            timestamp,
+            actor: caller,
+            correlation_id: None,
+        }
+        .publish(&env);
     }
 
     /// Replay-protected delete_confession variant.
@@ -734,5 +755,39 @@ mod test {
         let (env, client, _admin, _author) = setup();
         let another = Address::generate(&env);
         client.initialize(&another); // should panic
+    }
+
+    #[test]
+    fn author_confession_index_exact_limit_succeeds() {
+        let (env, client, _admin, author) = setup();
+
+        for seed in 0..MAX_AUTHOR_CONFESSIONS_PER_AUTHOR {
+            let hash = sample_hash(&env, seed as u8);
+            let id = client.create_confession(&author, &hash, &(1_000 + seed as u64));
+            assert_eq!(id, seed as u64 + 1);
+        }
+
+        assert_eq!(
+            client.get_total_count(),
+            MAX_AUTHOR_CONFESSIONS_PER_AUTHOR as u64
+        );
+        assert_eq!(
+            client.get_author_confessions(&author).len(),
+            MAX_AUTHOR_CONFESSIONS_PER_AUTHOR
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "registry payload too long")]
+    fn author_confession_index_limit_plus_one_rejected() {
+        let (env, client, _admin, author) = setup();
+
+        for seed in 0..MAX_AUTHOR_CONFESSIONS_PER_AUTHOR {
+            let hash = sample_hash(&env, seed as u8);
+            client.create_confession(&author, &hash, &(1_000 + seed as u64));
+        }
+
+        let hash = sample_hash(&env, MAX_AUTHOR_CONFESSIONS_PER_AUTHOR as u8);
+        let _ = client.create_confession(&author, &hash, &9_999);
     }
 }

--- a/xconfess-contracts/contracts/emergency_pause/events.rs
+++ b/xconfess-contracts/contracts/emergency_pause/events.rs
@@ -1,5 +1,8 @@
 use soroban_sdk::{contractevent, Address, Env, String};
 
+pub const MAX_PAUSE_REASON_LEN: u32 = 128;
+pub const PAUSE_REASON_TOO_LONG: &str = "pause reason too long";
+
 #[contractevent(topics = ["paused"], data_format = "single-value")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PausedEvent {
@@ -16,7 +19,15 @@ pub struct UnpausedEvent {
     pub reason: String,
 }
 
+fn assert_reason_bounded(reason: &String) {
+    if reason.len() > MAX_PAUSE_REASON_LEN {
+        panic!("{}", PAUSE_REASON_TOO_LONG);
+    }
+}
+
 pub fn emit_paused(env: &Env, actor: &Address, reason: String) {
+    assert_reason_bounded(&reason);
+
     PausedEvent {
         actor: actor.clone(),
         reason,
@@ -25,6 +36,8 @@ pub fn emit_paused(env: &Env, actor: &Address, reason: String) {
 }
 
 pub fn emit_unpaused(env: &Env, actor: &Address, reason: String) {
+    assert_reason_bounded(&reason);
+
     UnpausedEvent {
         actor: actor.clone(),
         reason,

--- a/xconfess-contracts/contracts/error.rs
+++ b/xconfess-contracts/contracts/error.rs
@@ -220,7 +220,6 @@ impl ContractError {
             // Retryable: transient state or resource contention
             ContractError::CooldownActive => ErrorClassification::Retryable,
             ContractError::Overflow => ErrorClassification::Retryable,
-            ContractError::TotalOverflow => ErrorClassification::Retryable,
 
             // Terminal: business logic violations
             ContractError::NotFound => ErrorClassification::Terminal,

--- a/xconfess-contracts/contracts/tests/bounded_payloads.test.rs
+++ b/xconfess-contracts/contracts/tests/bounded_payloads.test.rs
@@ -2,6 +2,10 @@ use soroban_sdk::{Env, String as SorobanString};
 use xconfess_contract::pagination::confession::{create, MAX_CONFESSION_CONTENT_LEN};
 use anonymous_tipping::AnonymousTipping;
 use soroban_sdk::testutils::Address as _;
+use confession_anchor::{ConfessionAnchor, ConfessionAnchorClient};
+use confession_registry::{
+    ConfessionRegistry, ConfessionRegistryClient, MAX_AUTHOR_CONFESSIONS_PER_AUTHOR,
+};
 
 #[test]
 fn confession_content_exact_limit_succeeds() {
@@ -61,6 +65,75 @@ fn settlement_proof_metadata_limit_plus_one_rejected() {
     );
 
     let _ = AnonymousTipping::send_tip_with_proof(env, recipient, 10, Some(metadata));
+}
+
+#[test]
+fn anchor_pause_reason_exact_limit_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ConfessionAnchor, ());
+    let client = ConfessionAnchorClient::new(&env, &contract_id);
+    let owner = soroban_sdk::Address::generate(&env);
+    let reason = SorobanString::from_str(&env, &"r".repeat(128));
+
+    client.initialize(&owner);
+
+    client.pause(&owner, &reason);
+}
+
+#[test]
+#[should_panic(expected = "pause reason too long")]
+fn anchor_pause_reason_limit_plus_one_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ConfessionAnchor, ());
+    let client = ConfessionAnchorClient::new(&env, &contract_id);
+    let owner = soroban_sdk::Address::generate(&env);
+    let reason = SorobanString::from_str(&env, &"r".repeat(129));
+
+    client.initialize(&owner);
+
+    let _ = client.pause(&owner, &reason);
+}
+
+#[test]
+fn registry_author_index_exact_limit_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ConfessionRegistry, ());
+    let client = ConfessionRegistryClient::new(&env, &contract_id);
+    let admin = soroban_sdk::Address::generate(&env);
+    let author = soroban_sdk::Address::generate(&env);
+
+    client.initialize(&admin);
+
+    for seed in 0..MAX_AUTHOR_CONFESSIONS_PER_AUTHOR {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed as u8;
+        let hash = soroban_sdk::BytesN::from_array(&env, &bytes);
+        let id = client.create_confession(&author, &hash, &(1_000 + seed as u64));
+        assert_eq!(id, seed as u64 + 1);
+    }
+}
+
+#[test]
+#[should_panic(expected = "registry payload too long")]
+fn registry_author_index_limit_plus_one_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ConfessionRegistry, ());
+    let client = ConfessionRegistryClient::new(&env, &contract_id);
+    let admin = soroban_sdk::Address::generate(&env);
+    let author = soroban_sdk::Address::generate(&env);
+
+    client.initialize(&admin);
+
+    for seed in 0..=MAX_AUTHOR_CONFESSIONS_PER_AUTHOR {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed as u8;
+        let hash = soroban_sdk::BytesN::from_array(&env, &bytes);
+        let _ = client.create_confession(&author, &hash, &(1_000 + seed as u64));
+    }
 }
 
 // ── Amount boundary table ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #813

---

Added a deterministic 128 character cap for anchor pause/unpause reason payloads.
Added an explicit 128 entry cap for registry per-author confession index payloads.
Ensured registry oversized author-index writes fail early before allocating IDs or mutating storage.
Added boundary and over-boundary tests for anchor and registry payload limits.
Fixed related contract compile issues encountered while testing:
Corrected anchor event initialization to match the event struct.
Switched registry confession event nonce tracking to the registry’s own storage key to avoid key collisions.
Fixed anchor’s shared error import path for standalone crate tests.
Removed a stale ContractError::TotalOverflow match arm.
Validation:

cargo test -p confession-anchor --lib passes: 34 tests.
cargo test -p confession-registry --lib passes: 52 tests.
Note:

cargo test --test bounded_payloads is not currently available from the active workspace because bounded_payloads is not registered as a Cargo test target.