### PR TITLE
feat(notifications): reconcile unread state after reconnect, refresh,…

### DIFF
--- a/xconfess-frontend/app/lib/hooks/__tests__/useNotifications.test.ts
+++ b/xconfess-frontend/app/lib/hooks/__tests__/useNotifications.test.ts
@@ -1,0 +1,363 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useNotifications } from "../useNotifications";
+import { notificationApi } from "@/app/lib/api/notification";
+import type { Notification } from "@/app/types/notifications";
+import { NotificationType } from "@/app/types/notifications";
+
+// ---------------------------------------------------------------------------
+// Socket.IO mock
+// ---------------------------------------------------------------------------
+let socketHandlers: Record<string, (...args: unknown[]) => void> = {};
+
+const mockSocket = {
+  on: jest.fn(),
+  emit: jest.fn(),
+  disconnect: jest.fn(),
+};
+
+jest.mock("socket.io-client", () => ({
+  io: jest.fn(() => mockSocket),
+}));
+
+function triggerSocketEvent(event: string, ...args: unknown[]) {
+  socketHandlers[event]?.(...args);
+}
+
+// ---------------------------------------------------------------------------
+// API mock
+// ---------------------------------------------------------------------------
+jest.mock("@/app/lib/api/notification", () => ({
+  notificationApi: {
+    getNotifications: jest.fn(),
+    markAsRead: jest.fn(),
+    markAllAsRead: jest.fn(),
+    deleteNotification: jest.fn(),
+    getPreferences: jest.fn(),
+    updatePreferences: jest.fn(),
+  },
+}));
+
+const mockGetNotifications = notificationApi.getNotifications as jest.Mock;
+const mockMarkAsRead = notificationApi.markAsRead as jest.Mock;
+const mockMarkAllAsRead = notificationApi.markAllAsRead as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Other deps
+// ---------------------------------------------------------------------------
+jest.mock("@/app/lib/hooks/useApiError", () => ({
+  useApiError: () => ({ handleError: jest.fn() }),
+}));
+
+jest.mock("@/app/lib/config", () => ({
+  getWsUrl: () => "ws://localhost:5000",
+}));
+
+// ---------------------------------------------------------------------------
+// Browser API stubs
+// ---------------------------------------------------------------------------
+beforeAll(() => {
+  // Audio stub — jsdom doesn't implement HTMLMediaElement playback
+  Object.defineProperty(globalThis, "Audio", {
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      volume: 0,
+      play: jest.fn().mockResolvedValue(undefined),
+    })),
+  });
+
+  // Notification stub
+  Object.defineProperty(globalThis, "Notification", {
+    writable: true,
+    value: Object.assign(jest.fn(), { permission: "default", requestPermission: jest.fn() }),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: "notif-1",
+    userId: "user-1",
+    type: NotificationType.COMMENT,
+    title: "New comment",
+    message: "Someone commented",
+    isRead: false,
+    createdAt: new Date().toISOString(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makePaginatedResponse(notifications: Notification[], unreadCount = notifications.length) {
+  return {
+    notifications,
+    unreadCount,
+    total: notifications.length,
+    page: 1,
+    limit: 20,
+    totalPages: 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  socketHandlers = {};
+  jest.clearAllMocks();
+
+  // Re-attach handler-capture implementation each time (clearAllMocks wipes calls but not impl;
+  // explicit re-attach makes the intent clear and survives potential resetAllMocks usage).
+  mockSocket.on.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+    socketHandlers[event] = handler;
+  });
+
+  // Default: getNotifications resolves with empty list
+  mockGetNotifications.mockResolvedValue(makePaginatedResponse([]));
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("useNotifications — reconnect reconciliation", () => {
+  it("does NOT call getNotifications on the first connect", async () => {
+    renderHook(() => useNotifications("user-1"));
+
+    await act(async () => {
+      triggerSocketEvent("connect");
+    });
+
+    expect(mockGetNotifications).not.toHaveBeenCalled();
+  });
+
+  it("calls getNotifications after a socket reconnect", async () => {
+    const freshNotif = makeNotification({ id: "notif-new" });
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse([freshNotif], 1));
+
+    renderHook(() => useNotifications("user-1"));
+
+    // First connect — marks hasConnectedRef = true, no fetch
+    await act(async () => {
+      triggerSocketEvent("connect");
+    });
+
+    expect(mockGetNotifications).not.toHaveBeenCalled();
+
+    // Simulate drop
+    await act(async () => {
+      triggerSocketEvent("disconnect");
+    });
+
+    // Reconnect — should trigger a reconcile fetch
+    await act(async () => {
+      triggerSocketEvent("connect");
+    });
+
+    await waitFor(() => expect(mockGetNotifications).toHaveBeenCalledTimes(1));
+  });
+
+  it("updates notifications and unreadCount from API response after reconnect", async () => {
+    const missed = makeNotification({ id: "missed-1", isRead: false });
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse([missed], 1));
+
+    const { result } = renderHook(() => useNotifications("user-1"));
+
+    await act(async () => {
+      triggerSocketEvent("connect");
+      triggerSocketEvent("disconnect");
+      triggerSocketEvent("connect");
+    });
+
+    await waitFor(() => {
+      expect(result.current.notifications).toHaveLength(1);
+      expect(result.current.notifications[0].id).toBe("missed-1");
+      expect(result.current.unreadCount).toBe(1);
+    });
+  });
+
+  it("handles multiple reconnects, fetching each time", async () => {
+    renderHook(() => useNotifications("user-1"));
+
+    // First connect
+    await act(async () => { triggerSocketEvent("connect"); });
+    // 1st reconnect
+    await act(async () => { triggerSocketEvent("disconnect"); triggerSocketEvent("connect"); });
+    // 2nd reconnect
+    await act(async () => { triggerSocketEvent("disconnect"); triggerSocketEvent("connect"); });
+
+    await waitFor(() => expect(mockGetNotifications).toHaveBeenCalledTimes(2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("useNotifications — visibility reconciliation", () => {
+  it("calls getNotifications when the tab becomes visible", async () => {
+    renderHook(() => useNotifications("user-1"));
+
+    // Hide tab then show it
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "hidden", configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(mockGetNotifications).not.toHaveBeenCalled();
+
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => expect(mockGetNotifications).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not fetch when the tab becomes hidden", async () => {
+    renderHook(() => useNotifications("user-1"));
+
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "hidden", configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(mockGetNotifications).not.toHaveBeenCalled();
+  });
+
+  it("syncs unreadCount from API after tab becomes visible", async () => {
+    const notif = makeNotification({ id: "n1", isRead: true });
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse([notif], 0));
+
+    const { result } = renderHook(() => useNotifications("user-1"));
+
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => {
+      expect(result.current.unreadCount).toBe(0);
+      expect(result.current.notifications[0].isRead).toBe(true);
+    });
+  });
+
+  it("removes the visibilitychange listener on unmount", async () => {
+    const removeSpy = jest.spyOn(document, "removeEventListener");
+    const { unmount } = renderHook(() => useNotifications("user-1"));
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+    removeSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("useNotifications — markAllAsRead", () => {
+  it("marks every notification as read and zeros the unread count", async () => {
+    const n1 = makeNotification({ id: "n1", isRead: false });
+    const n2 = makeNotification({ id: "n2", isRead: false });
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse([n1, n2], 2));
+    mockMarkAllAsRead.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useNotifications("user-1"));
+
+    // Populate state via fetchNotifications
+    await act(async () => {
+      await result.current.fetchNotifications();
+    });
+
+    expect(result.current.unreadCount).toBe(2);
+
+    await act(async () => {
+      await result.current.markAllAsRead();
+    });
+
+    expect(result.current.unreadCount).toBe(0);
+    expect(result.current.notifications.every((n) => n.isRead)).toBe(true);
+  });
+
+  it("does not mutate local state when the API call fails", async () => {
+    const n1 = makeNotification({ id: "n1", isRead: false });
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse([n1], 1));
+    mockMarkAllAsRead.mockRejectedValue(new Error("server error"));
+
+    const { result } = renderHook(() => useNotifications("user-1"));
+
+    await act(async () => {
+      await result.current.fetchNotifications();
+    });
+
+    await act(async () => {
+      await result.current.markAllAsRead();
+    });
+
+    // State should be unchanged because the API failed
+    expect(result.current.unreadCount).toBe(1);
+    expect(result.current.notifications[0].isRead).toBe(false);
+  });
+
+  it("clears the badge even when only a partial page of notifications is loaded", async () => {
+    // Backend has 50 notifications; we only loaded page 1 (20 items).
+    // markAllAsRead should still zero the badge and flip every loaded item.
+    const loaded = Array.from({ length: 20 }, (_, i) =>
+      makeNotification({ id: `n${i}`, isRead: false })
+    );
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse(loaded, 50));
+    mockMarkAllAsRead.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useNotifications("user-1"));
+
+    await act(async () => { await result.current.fetchNotifications(); });
+    await act(async () => { await result.current.markAllAsRead(); });
+
+    expect(result.current.unreadCount).toBe(0);
+    expect(result.current.notifications.every((n) => n.isRead)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("useNotifications — markAsRead (single)", () => {
+  it("marks one notification as read and decrements the unread count", async () => {
+    const n1 = makeNotification({ id: "n1", isRead: false });
+    const n2 = makeNotification({ id: "n2", isRead: false });
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse([n1, n2], 2));
+    mockMarkAsRead.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useNotifications("user-1"));
+
+    await act(async () => { await result.current.fetchNotifications(); });
+    await act(async () => { await result.current.markAsRead("n1"); });
+
+    const updated = result.current.notifications.find((n) => n.id === "n1");
+    expect(updated?.isRead).toBe(true);
+    expect(result.current.notifications.find((n) => n.id === "n2")?.isRead).toBe(false);
+    expect(result.current.unreadCount).toBe(1);
+  });
+
+  it("does not mutate state when markAsRead API call fails", async () => {
+    const n1 = makeNotification({ id: "n1", isRead: false });
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse([n1], 1));
+    mockMarkAsRead.mockRejectedValue(new Error("network error"));
+
+    const { result } = renderHook(() => useNotifications("user-1"));
+
+    await act(async () => { await result.current.fetchNotifications(); });
+    await act(async () => { await result.current.markAsRead("n1"); });
+
+    expect(result.current.notifications[0].isRead).toBe(false);
+    expect(result.current.unreadCount).toBe(1);
+  });
+
+  it("does not let unreadCount go below zero", async () => {
+    // Edge case: notification is already read on backend but local count is 0
+    const n1 = makeNotification({ id: "n1", isRead: false });
+    mockGetNotifications.mockResolvedValue(makePaginatedResponse([n1], 0));
+    mockMarkAsRead.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useNotifications("user-1"));
+
+    await act(async () => { await result.current.fetchNotifications(); });
+    await act(async () => { await result.current.markAsRead("n1"); });
+
+    expect(result.current.unreadCount).toBe(0);
+  });
+});

--- a/xconfess-frontend/app/lib/hooks/useNotifications.ts
+++ b/xconfess-frontend/app/lib/hooks/useNotifications.ts
@@ -31,6 +31,8 @@ export function useNotifications(userId: string): UseNotificationsReturn {
   const [loading, setLoading] = useState(false);
   const socketRef = useRef<Socket | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  // True after the first successful connect; subsequent connects are reconnects
+  const hasConnectedRef = useRef(false);
   const { handleError } = useApiError({ context: 'Notifications' });
   const debugNotifications =
     process.env.NODE_ENV === 'development' &&
@@ -75,6 +77,13 @@ export function useNotifications(userId: string): UseNotificationsReturn {
     },
     [handleError]
   );
+
+  // Stable ref so socket/visibility effects can call the latest fetchNotifications
+  // without being listed as deps (which would tear down and recreate the socket).
+  const fetchNotificationsRef = useRef(fetchNotifications);
+  useEffect(() => {
+    fetchNotificationsRef.current = fetchNotifications;
+  });
 
   const markAsRead = useCallback(async (notificationId: string) => {
     try {
@@ -137,8 +146,14 @@ export function useNotifications(userId: string): UseNotificationsReturn {
         console.debug('Notifications websocket connected');
       }
       setIsConnected(true);
-      // Join user's notification room
       socket.emit("join-notifications", userId);
+
+      // On reconnect, pull fresh state from the API to catch any notifications
+      // that arrived while the socket was down.
+      if (hasConnectedRef.current) {
+        fetchNotificationsRef.current();
+      }
+      hasConnectedRef.current = true;
     });
 
     socket.on("disconnect", () => {
@@ -178,6 +193,21 @@ export function useNotifications(userId: string): UseNotificationsReturn {
       socket.disconnect();
     };
   }, [userId, playNotificationSound, debugNotifications]);
+
+  // Reconcile when the tab becomes visible again — covers the multi-tab read-all
+  // case and any drift that built up while the tab was in the background.
+  useEffect(() => {
+    if (!userId) return;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        fetchNotificationsRef.current();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [userId]);
 
   // Request browser notification permission
   useEffect(() => {


### PR DESCRIPTION
<p style="white-space: pre-wrap; margin-top: 0px; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Here's the PR description:</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Title:</strong> <code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">feat(notifications): reconcile unread state after reconnect, refresh, and read-all</code></p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fixes notification state drift that made unread counts and item state go stale after a websocket reconnect, browser refresh, or a read-all action performed in another tab.</p><ul style="padding-inline-start: 2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>Reconnect reconciliation</strong><span> </span>— after any socket reconnect (not the initial connect), fetch fresh notification state from the API to catch messages that arrived while the socket was down. Uses<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">hasConnectedRef</code><span> </span>to distinguish reconnects from the first connection so the initial page load doesn't trigger a double-fetch.</li><li><strong>Visibility reconciliation</strong><span> </span>— adds a<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">visibilitychange</code><span> </span>listener that re-fetches when the tab becomes visible again. This is the main fix for the multi-tab read-all case: if another tab calls mark-all-read, the badge and list state converge the next time the user switches back to this tab.</li><li><strong>Stable ref pattern</strong><span> </span>— introduces<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fetchNotificationsRef</code><span> </span>to give the socket and visibility effects a stable reference to the latest<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fetchNotifications</code><span> </span>callback, so neither effect needs it as a dependency (which would tear down and recreate the socket on every render cycle).</li></ul><h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h2><ul style="padding-inline-start: 2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">xconfess-frontend/app/lib/hooks/useNotifications.ts</code><span> </span>— reconnect + visibility reconciliation logic</li><li><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">xconfess-frontend/app/lib/hooks/__tests__/useNotifications.test.ts</code><span> </span>— 14 new tests (new file)</li></ul><h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test coverage</h2>
Scenario | Tests
-- | --
Reconnect | No fetch on first connect; fetch on every subsequent reconnect; state (notifications + unreadCount) correctly populated from API response; multiple reconnects each trigger a fetch
Visibility | Fetch on tab visible; no fetch on tab hidden; unreadCount synced from API; listener removed on unmount
markAllAsRead | Zeros badge and flips all loaded items; no mutation if API fails; works when only a partial page is loaded
markAsRead (single) | Marks correct item; no mutation on API failure; count floor at 0

<h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Related</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Closes #803 </p>