### PR TITLE
feat(auth): normalize authenticated profile routes to one payload sch…

### DIFF
--- a/xconfess-backend/src/auth/auth.service.ts
+++ b/xconfess-backend/src/auth/auth.service.ts
@@ -14,7 +14,7 @@ import { PasswordResetService } from './password-reset.service';
 import { AnonymousUserService } from '../user/anonymous-user.service';
 import * as bcrypt from 'bcryptjs';
 import * as crypto from 'crypto';
-import { UserResponse } from '../user/user.controller';
+import { UserResponse } from '../user/dto/user-response.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { CryptoUtil } from '../common/crypto.util';
 import { JwtPayload } from './interfaces/jwt-payload.interface';

--- a/xconfess-backend/src/user/dto/user-response.dto.ts
+++ b/xconfess-backend/src/user/dto/user-response.dto.ts
@@ -1,0 +1,25 @@
+import { UserRole } from '../entities/user.entity';
+
+/**
+ * Canonical response schema for an authenticated profile lookup.
+ *
+ * Both GET /api/auth/me and GET /api/users/profile MUST return exactly
+ * these fields — no more, no less.  Internal fields (password hash,
+ * reset tokens, raw email ciphertext) are intentionally excluded.
+ */
+export interface UserResponse {
+  id: number;
+  username: string;
+  role: UserRole;
+  is_active: boolean;
+  email: string;
+  notificationPreferences: Record<string, boolean>;
+  privacy: {
+    isDiscoverable: boolean;
+    canReceiveReplies: boolean;
+    showReactions: boolean;
+    dataProcessingConsent: boolean;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/xconfess-backend/src/user/user.controller.ts
+++ b/xconfess-backend/src/user/user.controller.ts
@@ -32,33 +32,13 @@ import {
   UpdatePrivacySettingsDto,
   PrivacySettingsResponseDto,
 } from './dto/update-privacy-settings.dto';
-import { ApiOperation, ApiResponse, ApiTags, ApiQuery } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags, ApiQuery, ApiParam } from '@nestjs/swagger';
 import { PaginatedUserActivityDto } from './dto/user-activity.dto';
 import { ConfessionService } from '../confession/confession.service';
 import { GetUserConfessionsDto } from '../confession/dto/get-user-confessions.dto';
-import { ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
-
-/**
- * Public user response contract.
- * Internal fields (resetPasswordToken, resetPasswordExpires, password hash,
- * raw email ciphertext) are intentionally omitted.
- */
-export interface UserResponse {
-  id: number;
-  username: string;
-  role: UserRole;
-  is_active: boolean;
-  email: string;
-  notificationPreferences: Record<string, boolean>;
-  privacy: {
-    isDiscoverable: boolean;
-    canReceiveReplies: boolean;
-    showReactions: boolean;
-    dataProcessingConsent: boolean;
-  };
-  createdAt: Date;
-  updatedAt: Date;
-}
+import { UserResponse } from './dto/user-response.dto';
+// Re-export so existing consumers that import UserResponse from this file keep working.
+export { UserResponse } from './dto/user-response.dto';
 
 export interface UserProfileResponse {
   id: number;
@@ -174,9 +154,14 @@ export class UserController {
   async getProfile(@GetUser('id') userId: number): Promise<UserResponse> {
     try {
       const user = await this.userService.findById(userId);
-      if (!user) throw new UnauthorizedException();
+      if (!user || !user.is_active) {
+        throw new UnauthorizedException('User not found');
+      }
       return this.formatUserResponse(user);
     } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : 'Unknown error';
       throw new BadRequestException('Failed to get profile: ' + message);
     }

--- a/xconfess-backend/test/login-profile-route-parity.e2e-spec.ts
+++ b/xconfess-backend/test/login-profile-route-parity.e2e-spec.ts
@@ -306,5 +306,93 @@ describe('Login and Profile Route Parity (e2e)', () => {
       expect(loginUser.email).toBe(usersProfileRes.body.email);
       expect(loginUser.email).toBe(authProfileRes.body.email);
     });
+
+    it('both routes return all canonical UserResponse fields with equal values', async () => {
+      const [usersRes, authRes] = await Promise.all([
+        getProfileViaUsersRoute(accessToken),
+        getProfileViaAuthRoute(accessToken),
+      ]);
+
+      // Every top-level field of the canonical schema must be present on both routes.
+      const topLevelFields = [
+        'id',
+        'username',
+        'role',
+        'is_active',
+        'email',
+        'notificationPreferences',
+        'privacy',
+        'createdAt',
+        'updatedAt',
+      ];
+      for (const field of topLevelFields) {
+        expect(usersRes.body).toHaveProperty(field);
+        expect(authRes.body).toHaveProperty(field);
+      }
+
+      // The privacy sub-object must contain every expected flag.
+      const privacyFields = [
+        'isDiscoverable',
+        'canReceiveReplies',
+        'showReactions',
+        'dataProcessingConsent',
+      ];
+      for (const field of privacyFields) {
+        expect(usersRes.body.privacy).toHaveProperty(field);
+        expect(authRes.body.privacy).toHaveProperty(field);
+      }
+
+      // Values must be identical across both routes for the same caller.
+      for (const field of topLevelFields) {
+        expect(usersRes.body[field]).toEqual(authRes.body[field]);
+      }
+    });
+
+    it('both routes return HTTP 401 when the user is deactivated after the token is issued', async () => {
+      // Token obtained in beforeEach while user was active; deactivate now.
+      await userRepository.update({ username: TEST_USERNAME }, { is_active: false });
+
+      const [usersRes, authRes] = await Promise.all([
+        getProfileViaUsersRoute(accessToken),
+        getProfileViaAuthRoute(accessToken),
+      ]);
+
+      expect(usersRes.status).toBe(401);
+      expect(authRes.status).toBe(401);
+    });
+
+    it('both routes return HTTP 401 when the user record is deleted after the token is issued', async () => {
+      // Token obtained in beforeEach while user existed; delete now.
+      await userRepository.delete({ username: TEST_USERNAME });
+
+      const [usersRes, authRes] = await Promise.all([
+        getProfileViaUsersRoute(accessToken),
+        getProfileViaAuthRoute(accessToken),
+      ]);
+
+      expect(usersRes.status).toBe(401);
+      expect(authRes.status).toBe(401);
+    });
+
+    it('neither route exposes internal fields (reset tokens, raw ciphertext)', async () => {
+      const [usersRes, authRes] = await Promise.all([
+        getProfileViaUsersRoute(accessToken),
+        getProfileViaAuthRoute(accessToken),
+      ]);
+
+      const internalFields = [
+        'password',
+        'resetPasswordToken',
+        'resetPasswordExpires',
+        'emailEncrypted',
+        'emailIv',
+        'emailTag',
+        'emailHash',
+      ];
+      for (const field of internalFields) {
+        expect(usersRes.body).not.toHaveProperty(field);
+        expect(authRes.body).not.toHaveProperty(field);
+      }
+    });
   });
 });


### PR DESCRIPTION
<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Title:</strong> <code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">feat(auth): normalize authenticated profile routes to one payload schema</code></p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><ul style="padding-inline-start: 2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Extracts<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">UserResponse</code><span> </span>from<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">user.controller.ts</code><span> </span>into<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/user/dto/user-response.dto.ts</code><span> </span>as the single canonical schema for authenticated profile lookups — both routes now share one definition instead of two copies that can silently drift</li><li>Fixes<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">auth.service.ts</code><span> </span>importing<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">UserResponse</code><span> </span>from a controller (service → controller is a circular anti-pattern)</li><li>Fixes two bugs in<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /api/users/profile</code><span> </span>that caused it to diverge from<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /api/auth/me</code><span> </span>on failure paths:<ul style="padding-inline-start: 2em;"><li><strong>Inactive user</strong><span> </span>—<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">profile</code><span> </span>was returning<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">200</code><span> </span>because it called<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">findById</code><span> </span>(no active check) then formatted the result;<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">me</code><span> </span>used<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">validateUserById</code><span> </span>which gates on<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">is_active</code>. Now both return<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">401</code></li><li><strong>Wrong status on not-found</strong><span> </span>—<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">profile</code>'s catch block swallowed<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">UnauthorizedException</code><span> </span>and re-threw it as<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">400 Bad Request</code>; now it re-throws auth errors as-is, matching<span> </span><code style="font-family: monospace; color: rgb(234, 205, 97); background-color: rgb(56, 51, 48); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">me</code>'s behaviour</li></ul></li><li>Adds four regression tests to the existing parity spec that will fail if either route gains or loses fields, or if the error semantics diverge again</li></ul><h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h2>
File | Change
-- | --
src/user/dto/user-response.dto.ts | New — canonical UserResponse interface
src/auth/auth.service.ts | Import moved to DTO file
src/user/user.controller.ts | Remove inline definition, fix getProfile error handling + active check, fix duplicate imports
test/login-profile-route-parity.e2e-spec.ts | 4 new regression tests

<h2 style="color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Related</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(154, 162, 203); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(13, 16, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Closes #775 </p>