### PR TITLE
response schemas include concrete  payloads matching real DTO constraints 

### DIFF
--- a/xconfess-backend/src/admin/admin.controller.ts
+++ b/xconfess-backend/src/admin/admin.controller.ts
@@ -12,6 +12,15 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
 import { AdminService } from './services/admin.service';
@@ -73,6 +82,8 @@ function parseAuditAction(value?: string): AuditActionType | undefined {
     : undefined;
 }
 
+@ApiTags('Admin')
+@ApiBearerAuth()
 @Controller('admin')
 @UseGuards(JwtAuthGuard, AdminGuard)
 export class AdminController {
@@ -85,6 +96,25 @@ export class AdminController {
 
   // Reports
   @Get('reports')
+  @ApiOperation({ summary: 'List reports with optional filters' })
+  @ApiQuery({ name: 'status', required: false, enum: ReportStatus, description: 'Filter by status' })
+  @ApiQuery({ name: 'type', required: false, enum: ReportType, description: 'Filter by report type' })
+  @ApiQuery({ name: 'startDate', required: false, type: String, example: '2026-04-01' })
+  @ApiQuery({ name: 'endDate', required: false, type: String, example: '2026-04-30' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 50 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, example: 0 })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated report list.',
+    schema: {
+      example: {
+        reports: [{ id: 'abc-123', confessionId: 'def-456', status: 'pending', type: 'spam' }],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      },
+    },
+  })
   async getReports(
     @Query('status') status?: ReportStatus,
     @Query('type') type?: ReportType,
@@ -113,12 +143,27 @@ export class AdminController {
   }
 
   @Get('reports/:id')
+  @ApiOperation({ summary: 'Get a single report by ID' })
+  @ApiParam({ name: 'id', description: 'Report UUID' })
+  @ApiResponse({ status: 200, description: 'Report record.' })
+  @ApiResponse({ status: 404, description: 'Report not found.' })
   async getReportById(@Param('id') id: string) {
     return this.adminService.getReportById(id);
   }
 
   @Patch('reports/:id/resolve')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Resolve a report (admin action)' })
+  @ApiParam({ name: 'id', description: 'Report UUID' })
+  @ApiBody({
+    schema: {
+      example: {
+        resolutionNotes: 'Content removed — violates community guidelines.',
+        templateId: 3,
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Report resolved successfully.' })
   async resolveReport(
     @Param('id') id: string,
     @Body() dto: ResolveReportDto,
@@ -136,6 +181,9 @@ export class AdminController {
 
   @Patch('reports/:id/dismiss')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Dismiss a report without taking action' })
+  @ApiParam({ name: 'id', description: 'Report UUID' })
+  @ApiResponse({ status: 200, description: 'Report dismissed.' })
   async dismissReport(
     @Param('id') id: string,
     @Body() dto: ResolveReportDto,
@@ -152,6 +200,20 @@ export class AdminController {
 
   @Patch('reports/bulk-resolve')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Bulk-resolve multiple reports at once' })
+  @ApiBody({
+    schema: {
+      example: {
+        reportIds: ['abc-123', 'def-456'],
+        notes: 'Batch resolution — content removed.',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'All listed reports resolved.',
+    schema: { example: { resolved: 2, failed: 0 } },
+  })
   async bulkResolveReports(
     @Body() dto: BulkResolveDto,
     @GetUser('id') adminId: number,
@@ -168,6 +230,10 @@ export class AdminController {
   // Confessions
   @Delete('confessions/:id')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Admin-delete a confession' })
+  @ApiParam({ name: 'id', description: 'Confession UUID' })
+  @ApiBody({ schema: { example: { reason: 'Violates community standards.' } } })
+  @ApiResponse({ status: 200, description: 'Confession deleted.', schema: { example: { message: 'Confession deleted successfully' } } })
   async deleteConfession(
     @Param('id') id: string,
     @Body() body: { reason?: string },
@@ -211,6 +277,15 @@ export class AdminController {
 
   // Users
   @Get('users/search')
+  @ApiOperation({ summary: 'Search users by username or email fragment' })
+  @ApiQuery({ name: 'q', description: 'Search query', example: 'alice' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 50 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, example: 0 })
+  @ApiResponse({
+    status: 200,
+    description: 'Matching users.',
+    schema: { example: { users: [{ id: 1, username: 'alice_42', role: 'user' }], total: 1 } },
+  })
   async searchUsers(
     @Query('q') query: string,
     @Query('limit') limit?: string,
@@ -234,6 +309,10 @@ export class AdminController {
 
   @Patch('users/:id/ban')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Ban a user account' })
+  @ApiParam({ name: 'id', description: 'User numeric ID' })
+  @ApiBody({ schema: { example: { reason: 'Repeated policy violations.' } } })
+  @ApiResponse({ status: 200, description: 'User banned.' })
   async banUser(
     @Param('id') id: string,
     @Body() dto: BanUserDto,
@@ -250,6 +329,9 @@ export class AdminController {
 
   @Patch('users/:id/unban')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Lift a user ban' })
+  @ApiParam({ name: 'id', description: 'User numeric ID' })
+  @ApiResponse({ status: 200, description: 'User unbanned.' })
   async unbanUser(
     @Param('id') id: string,
     @GetUser('id') adminId: number,
@@ -303,6 +385,21 @@ export class AdminController {
 
   // Analytics
   @Get('analytics')
+  @ApiOperation({ summary: 'Get platform analytics (optionally date-bounded)' })
+  @ApiQuery({ name: 'startDate', required: false, type: String, example: '2026-04-01' })
+  @ApiQuery({ name: 'endDate', required: false, type: String, example: '2026-04-30' })
+  @ApiResponse({
+    status: 200,
+    description: 'Aggregated platform metrics.',
+    schema: {
+      example: {
+        totalConfessions: 1420,
+        totalUsers: 380,
+        totalReports: 42,
+        totalReactions: 8500,
+      },
+    },
+  })
   async getAnalytics(
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
@@ -314,6 +411,31 @@ export class AdminController {
 
   // Audit Logs
   @Get('audit-logs')
+  @ApiOperation({ summary: 'Query the admin audit log' })
+  @ApiQuery({ name: 'adminId', required: false, description: 'Filter by admin user ID' })
+  @ApiQuery({ name: 'action', required: false, description: 'Filter by action type' })
+  @ApiQuery({ name: 'entityType', required: false, description: 'Filter by entity type (e.g. confession, user)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 100 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, example: 0 })
+  @ApiResponse({
+    status: 200,
+    description: 'Audit log entries matching the filter.',
+    schema: {
+      example: {
+        data: [
+          {
+            id: 'log-abc-123',
+            adminId: 1,
+            action: 'DELETE_CONFESSION',
+            entityType: 'confession',
+            entityId: 'f47ac10b-...',
+            createdAt: '2026-04-25T10:00:00.000Z',
+          },
+        ],
+        total: 1,
+      },
+    },
+  })
   async getAuditLogs(
     @Query('adminId') adminId?: string,
     @Query('action') action?: string,

--- a/xconfess-backend/src/auth/auth.controller.ts
+++ b/xconfess-backend/src/auth/auth.controller.ts
@@ -11,7 +11,13 @@ import {
   UnauthorizedException,
   HttpException,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBody,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { Request } from 'express';
 import { AuthService } from './auth.service';
 import { ResetPasswordDto } from './dto/reset-password.dto';
@@ -23,7 +29,7 @@ import { User } from '../user/entities/user.entity';
 import { CryptoUtil } from '../common/crypto.util';
 import { RateLimit } from './guard/rate-limit.decorator';
 
-@ApiTags('Authentication')
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
@@ -31,6 +37,26 @@ export class AuthController {
   @Post('login')
   @HttpCode(HttpStatus.OK)
   @RateLimit(5, 300)
+  @ApiOperation({ summary: 'Log in with email and password' })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Login successful. Returns a JWT access token.',
+    schema: {
+      example: {
+        access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        anonymousUserId: 'anon_7f3a2b1c',
+        user: {
+          id: 1,
+          username: 'alice_42',
+          role: 'user',
+          is_active: true,
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Invalid credentials.' })
+  @ApiResponse({ status: 429, description: 'Too many login attempts.' })
   async login(
     @Body() loginDto: LoginDto,
   ): Promise<{ access_token: string; user: any; anonymousUserId: string }> {
@@ -56,6 +82,29 @@ export class AuthController {
 
   @Get('me')
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get current authenticated user profile' })
+  @ApiResponse({
+    status: 200,
+    description: 'Authenticated user profile.',
+    schema: {
+      example: {
+        id: 1,
+        username: 'alice_42',
+        role: 'user',
+        is_active: true,
+        email: 'alice@example.com',
+        notificationPreferences: {},
+        privacy: {
+          isDiscoverable: true,
+          canReceiveReplies: true,
+          showReactions: true,
+          dataProcessingConsent: true,
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized — missing or invalid JWT.' })
   async getProfile(@GetUser('id') userId: number): Promise<any> {
     return this.getSession(userId);
   }
@@ -83,6 +132,13 @@ export class AuthController {
   @Post('logout')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Log out current user (client-side token discard)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Logout acknowledged.',
+    schema: { example: { message: 'Logged out successfully' } },
+  })
   async logout(): Promise<{ message: string }> {
     // In a stateless JWT setup, logout is mainly client-side
     // but we can add token blacklisting here if needed
@@ -92,6 +148,18 @@ export class AuthController {
   @Post('forgot-password')
   @HttpCode(HttpStatus.OK)
   @RateLimit(3, 300)
+  @ApiOperation({ summary: 'Request a password-reset e-mail' })
+  @ApiBody({ type: ForgotPasswordDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Password-reset e-mail sent if the account exists.',
+    schema: {
+      example: {
+        message: 'If the user exists, a password reset email has been sent.',
+      },
+    },
+  })
+  @ApiResponse({ status: 429, description: 'Too many reset requests.' })
   async forgotPassword(
     @Body() forgotPasswordDto: ForgotPasswordDto,
     @Req() request: Request,
@@ -121,6 +189,14 @@ export class AuthController {
 
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Reset password using a token from the reset e-mail' })
+  @ApiBody({ type: ResetPasswordDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Password reset successfully.',
+    schema: { example: { message: 'Password has been reset successfully.' } },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid or expired token.' })
   async resetPassword(
     @Body() resetPasswordDto: ResetPasswordDto,
   ): Promise<{ message: string }> {

--- a/xconfess-backend/src/auth/dto/forgot-password.dto.ts
+++ b/xconfess-backend/src/auth/dto/forgot-password.dto.ts
@@ -1,11 +1,20 @@
 import { IsOptional, IsEmail, IsNumber, ValidateIf } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ForgotPasswordDto {
+  @ApiPropertyOptional({
+    description: 'Registered e-mail address. Provide either email or userId.',
+    example: 'alice@example.com',
+  })
   @IsOptional()
   @IsEmail({}, { message: 'Please provide a valid email address' })
   @ValidateIf((o) => !o.userId || o.email)
   email?: string;
 
+  @ApiPropertyOptional({
+    description: 'Numeric user ID. Provide either email or userId.',
+    example: 42,
+  })
   @IsOptional()
   @IsNumber({}, { message: 'User ID must be a number' })
   @ValidateIf((o) => !o.email || o.userId)

--- a/xconfess-backend/src/auth/dto/login.dto.ts
+++ b/xconfess-backend/src/auth/dto/login.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * Canonical payload for all login routes (POST /auth/login, POST /users/login).
@@ -12,6 +13,10 @@ import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
  * leaks policy information to an attacker enumerating accounts.
  */
 export class LoginDto {
+  @ApiProperty({
+    description: 'Registered e-mail address (normalised to lower-case)',
+    example: 'alice@example.com',
+  })
   @Transform(({ value }) =>
     typeof value === 'string' ? value.trim().toLowerCase() : value,
   )
@@ -19,6 +24,10 @@ export class LoginDto {
   @IsNotEmpty({ message: 'email must not be empty' })
   email!: string;
 
+  @ApiProperty({
+    description: 'Account password',
+    example: 'Str0ng!Pass#1',
+  })
   @IsString()
   @IsNotEmpty({ message: 'password must not be empty' })
   password!: string;

--- a/xconfess-backend/src/auth/dto/register.dto.ts
+++ b/xconfess-backend/src/auth/dto/register.dto.ts
@@ -7,6 +7,7 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * Canonical payload for all registration routes (POST /auth/register, POST /users/register).
@@ -15,11 +16,11 @@ import {
  * Unknown fields are rejected with 400 by the global ValidationPipe.
  */
 export class RegisterDto {
-  /**
-   * Must be a valid RFC 5322 e-mail address.
-   * Normalised to lowercase + trimmed before validation so that
-   * "User@Example.COM" resolves to the same identity as "user@example.com".
-   */
+  @ApiProperty({
+    description:
+      'Valid e-mail address. Normalised to lower-case before storage.',
+    example: 'alice@example.com',
+  })
   @Transform(({ value }) =>
     typeof value === 'string' ? value.trim().toLowerCase() : value,
   )
@@ -27,14 +28,13 @@ export class RegisterDto {
   @IsNotEmpty({ message: 'email must not be empty' })
   email!: string;
 
-  /**
-   * Minimum 8 characters.
-   * Must contain at least one uppercase letter, one lowercase letter,
-   * one digit, and one special character — enforced by the regex below.
-   *
-   * The regex is intentionally explicit so the error message is useful:
-   *   "password is too weak" is clearer than a generic pattern failure.
-   */
+  @ApiProperty({
+    description:
+      'Password — min 8, max 72 chars; must include uppercase, lowercase, digit, and special character.',
+    example: 'Str0ng!Pass#1',
+    minLength: 8,
+    maxLength: 72,
+  })
   @IsString()
   @MinLength(8, { message: 'password must be at least 8 characters' })
   @MaxLength(72, { message: 'password must be at most 72 characters' })
@@ -47,9 +47,13 @@ export class RegisterDto {
   )
   password!: string;
 
-  /**
-   * Display name shown in the UI.  3–30 characters, alphanumeric and underscores.
-   */
+  @ApiProperty({
+    description:
+      'Display name (3–30 chars, alphanumeric and underscores only).',
+    example: 'alice_42',
+    minLength: 3,
+    maxLength: 30,
+  })
   @IsString()
   @MinLength(3, { message: 'username must be at least 3 characters' })
   @MaxLength(30, { message: 'username must be at most 30 characters' })

--- a/xconfess-backend/src/auth/dto/reset-password.dto.ts
+++ b/xconfess-backend/src/auth/dto/reset-password.dto.ts
@@ -1,10 +1,20 @@
 import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ResetPasswordDto {
+  @ApiProperty({
+    description: 'Password-reset token received via e-mail.',
+    example: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+  })
   @IsString({ message: 'Token must be a string' })
   @IsNotEmpty({ message: 'Token is required' })
   token: string;
 
+  @ApiProperty({
+    description: 'New password (min 8 characters).',
+    example: 'NewStr0ng!Pass#2',
+    minLength: 8,
+  })
   @IsString({ message: 'New password must be a string' })
   @IsNotEmpty({ message: 'New password is required' })
   @MinLength(8, { message: 'New password must be at least 8 characters long' })

--- a/xconfess-backend/src/confession/confession.controller.ts
+++ b/xconfess-backend/src/confession/confession.controller.ts
@@ -47,7 +47,22 @@ export class ConfessionController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new anonymous confession' })
-  @ApiResponse({ status: 201, description: 'Confession created successfully' })
+  @ApiBody({ type: CreateConfessionDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Confession created successfully.',
+    schema: {
+      example: {
+        id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        message: 'I secretly enjoy watching reality TV shows.',
+        gender: 'male',
+        tags: ['humor'],
+        view_count: 0,
+        created_at: '2026-04-25T10:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Validation error — message exceeds 1000 chars or invalid enum.' })
   @UsePipes(new ValidationPipe({ whitelist: true }))
   create(@Body() dto: CreateConfessionDto) {
     // Only allow canonical contract
@@ -56,6 +71,26 @@ export class ConfessionController {
 
   @Get()
   @ApiOperation({ summary: 'Get paginated confessions list' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of confessions.',
+    schema: {
+      example: {
+        data: [
+          {
+            id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            message: 'I secretly enjoy watching reality TV shows.',
+            gender: 'male',
+            view_count: 12,
+            created_at: '2026-04-25T10:00:00.000Z',
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 20,
+      },
+    },
+  })
   @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
   findAll(@Query() dto: GetConfessionsDto) {
     return this.service.getConfessions(dto);
@@ -162,6 +197,21 @@ export class ConfessionController {
     summary: 'Get a single confession by ID (increments view count)',
   })
   @ApiParam({ name: 'id', description: 'Confession UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Confession found.',
+    schema: {
+      example: {
+        id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        message: 'I secretly enjoy watching reality TV shows.',
+        gender: 'male',
+        view_count: 13,
+        tags: ['humor'],
+        created_at: '2026-04-25T10:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({ status: 404, description: 'Confession not found.' })
   getById(@Param('id') id: string, @Req() req: Request) {
     return this.service.getConfessionByIdWithViewCount(id, req);
   }

--- a/xconfess-backend/src/confession/dto/create-confession.dto.ts
+++ b/xconfess-backend/src/confession/dto/create-confession.dto.ts
@@ -11,7 +11,11 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Gender } from './get-confessions.dto';
 
 export class CreateConfessionDto {
-  @ApiProperty({ description: 'Confession message text', maxLength: 1000 })
+  @ApiProperty({
+    description: 'Confession message text (max 1000 characters).',
+    maxLength: 1000,
+    example: 'I secretly enjoy watching reality TV shows.',
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(1000, { message: 'Confession cannot exceed 1000 characters' })
@@ -19,16 +23,18 @@ export class CreateConfessionDto {
 
   @ApiPropertyOptional({
     enum: Gender,
-    description: 'Gender of the confession author',
+    description: 'Gender of the confession author.',
+    example: Gender.MALE,
   })
   @IsOptional()
   @IsEnum(Gender)
   gender?: Gender;
 
   @ApiPropertyOptional({
-    description: 'Tags for the confession (max 3)',
+    description: 'Up to 3 tags to categorise the confession.',
     type: [String],
     maxItems: 3,
+    example: ['relationships', 'humor'],
   })
   @IsOptional()
   @IsArray()
@@ -37,15 +43,16 @@ export class CreateConfessionDto {
   tags?: string[];
 
   @ApiPropertyOptional({
-    description: 'Stellar transaction hash for anchoring',
+    description: 'Stellar blockchain transaction hash used to anchor this confession.',
+    example: 'a3f8e2d1b4c5a6e7f8d9c0b1a2e3f4d5c6b7a8e9f0d1c2b3a4e5f6d7c8b9a0e1',
   })
   @IsOptional()
   @IsString()
   stellarTxHash?: string;
 
   @ApiPropertyOptional({
-    description:
-      'Idempotency key to prevent duplicate creates under network instability',
+    description: 'Client-generated idempotency key to prevent duplicate submissions.',
+    example: 'idem_7f3a2b1c-4d5e-6f7a-8b9c-0d1e2f3a4b5c',
   })
   @IsOptional()
   @IsString()

--- a/xconfess-backend/src/report/entities/dto/create-report.dto.ts
+++ b/xconfess-backend/src/report/entities/dto/create-report.dto.ts
@@ -5,15 +5,30 @@ import {
   IsString,
   MaxLength,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ReportType } from '../report.entity';
 
 export class CreateReportDto {
+  @ApiProperty({
+    description: 'Numeric ID of the confession being reported.',
+    example: 101,
+  })
   @IsInt()
   confessionId: number;
 
+  @ApiProperty({
+    enum: ReportType,
+    description: 'Category of the report.',
+    example: ReportType.OFFENSIVE,
+  })
   @IsEnum(ReportType)
   type: ReportType;
 
+  @ApiPropertyOptional({
+    description: 'Optional additional context for the report (max 500 chars).',
+    example: 'This post contains hate speech targeting a specific group.',
+    maxLength: 500,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(500)

--- a/xconfess-backend/src/report/report.controller.ts
+++ b/xconfess-backend/src/report/report.controller.ts
@@ -7,41 +7,125 @@ import {
   Body,
   ParseIntPipe,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBody,
+  ApiParam,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { ReportService } from './report.service';
 import { CreateReportDto } from './entities/dto/create-report.dto';
 import { UpdateReportDto } from './entities/dto/update-report.dto';
 
+@ApiTags('Reports')
 @Controller('reports')
 export class ReportController {
   constructor(private readonly reportService: ReportService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Submit a report for a confession' })
+  @ApiBody({ type: CreateReportDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Report submitted.',
+    schema: {
+      example: {
+        id: 'b1a2c3d4-e5f6-7890-abcd-ef1234567890',
+        confessionId: 101,
+        type: 'offensive',
+        note: 'This post contains hate speech.',
+        status: 'pending',
+        createdAt: '2026-04-25T10:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Validation error.' })
   create(@Body() dto: CreateReportDto) {
-    // reporterId null until auth guard is wired up
     return this.reportService.create(dto, null);
   }
 
   @Get()
+  @ApiOperation({ summary: 'List all reports (admin)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Array of report records.',
+    schema: {
+      example: [
+        {
+          id: 'b1a2c3d4-e5f6-7890-abcd-ef1234567890',
+          confessionId: 101,
+          type: 'spam',
+          status: 'pending',
+          createdAt: '2026-04-25T10:00:00.000Z',
+        },
+      ],
+    },
+  })
   findAll() {
     return this.reportService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a single report by ID' })
+  @ApiParam({ name: 'id', description: 'Numeric report ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Report found.',
+    schema: {
+      example: {
+        id: 'b1a2c3d4-e5f6-7890-abcd-ef1234567890',
+        confessionId: 101,
+        type: 'offensive',
+        status: 'pending',
+        note: 'This post contains hate speech.',
+        createdAt: '2026-04-25T10:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({ status: 404, description: 'Report not found.' })
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.reportService.findOne(id);
   }
 
   @Patch(':id')
+  @ApiOperation({ summary: 'Update report status' })
+  @ApiParam({ name: 'id', description: 'Numeric report ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Report status updated.',
+    schema: {
+      example: { id: 'b1a2c3d4-...', status: 'approved', updatedAt: '2026-04-25T11:00:00.000Z' },
+    },
+  })
   update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateReportDto) {
     return this.reportService.updateStatus(id, dto);
   }
 
   @Patch(':id/resolve')
+  @ApiOperation({ summary: 'Mark a report as resolved' })
+  @ApiParam({ name: 'id', description: 'Numeric report ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Report resolved.',
+    schema: {
+      example: { id: 'b1a2c3d4-...', status: 'resolved', resolvedAt: '2026-04-25T11:30:00.000Z' },
+    },
+  })
   resolve(@Param('id', ParseIntPipe) id: number) {
     return this.reportService.resolve(id);
   }
 
   @Patch(':id/dismiss')
+  @ApiOperation({ summary: 'Dismiss a report (no action taken)' })
+  @ApiParam({ name: 'id', description: 'Numeric report ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Report dismissed.',
+    schema: {
+      example: { id: 'b1a2c3d4-...', status: 'rejected', updatedAt: '2026-04-25T11:45:00.000Z' },
+    },
+  })
   dismiss(@Param('id', ParseIntPipe) id: number) {
     return this.reportService.dismiss(id);
   }

--- a/xconfess-backend/src/tipping/dto/verify-tip.dto.ts
+++ b/xconfess-backend/src/tipping/dto/verify-tip.dto.ts
@@ -1,6 +1,12 @@
 import { IsString, IsNotEmpty, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class VerifyTipDto {
+  @ApiProperty({
+    description: 'Stellar transaction ID — 64-character hexadecimal string.',
+    example: 'a3f8e2d1b4c5a6e7f8d9c0b1a2e3f4d5c6b7a8e9f0d1c2b3a4e5f6d7c8b9a0e1',
+    pattern: '^[a-fA-F0-9]{64}$',
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^[a-fA-F0-9]{64}$/, {

--- a/xconfess-backend/src/tipping/tipping.controller.ts
+++ b/xconfess-backend/src/tipping/tipping.controller.ts
@@ -7,25 +7,83 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { TippingService, TipVerificationResult } from './tipping.service';
 import { VerifyTipDto } from './dto/verify-tip.dto';
 
+@ApiTags('Tipping')
 @Controller('confessions/:id/tips')
 export class TippingController {
   constructor(private readonly tippingService: TippingService) {}
 
   @Get()
+  @ApiOperation({ summary: 'List all tips for a confession' })
+  @ApiParam({ name: 'id', description: 'Confession UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Tips for the confession.',
+    schema: {
+      example: [
+        {
+          id: 'tip-abc-123',
+          confessionId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+          amount: 100,
+          txHash: 'a3f8e2d1b4c5a6e7f8d9c0b1a2e3f4d5c6b7a8e9f0d1c2b3a4e5f6d7c8b9a0e1',
+          status: 'completed',
+          createdAt: '2026-04-25T10:00:00.000Z',
+        },
+      ],
+    },
+  })
   getTips(@Param('id') confessionId: string) {
     return this.tippingService.getTipsByConfessionId(confessionId);
   }
 
   @Get('stats')
+  @ApiOperation({ summary: 'Get aggregate tip stats for a confession' })
+  @ApiParam({ name: 'id', description: 'Confession UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Tip statistics.',
+    schema: {
+      example: {
+        totalAmount: 550,
+        tipCount: 3,
+        latestTip: '2026-04-25T10:00:00.000Z',
+      },
+    },
+  })
   getTipStats(@Param('id') confessionId: string) {
     return this.tippingService.getTipStats(confessionId);
   }
 
   @Post('verify')
   @UsePipes(new ValidationPipe({ whitelist: true }))
+  @ApiOperation({ summary: 'Verify and record a Stellar XLM tip transaction' })
+  @ApiParam({ name: 'id', description: 'Confession UUID' })
+  @ApiBody({
+    type: VerifyTipDto,
+    description: 'Stellar transaction ID to verify.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Tip verified and recorded.',
+    schema: {
+      example: {
+        success: true,
+        tipId: 'tip-abc-123',
+        amount: 100,
+        txHash: 'a3f8e2d1b4c5a6e7f8d9c0b1a2e3f4d5c6b7a8e9f0d1c2b3a4e5f6d7c8b9a0e1',
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid transaction ID or tip already recorded.' })
   async verifyTip(
     @Param('id') confessionId: string,
     @Body() dto: VerifyTipDto,

--- a/xconfess-backend/src/user/user.controller.ts
+++ b/xconfess-backend/src/user/user.controller.ts
@@ -32,7 +32,15 @@ import {
   UpdatePrivacySettingsDto,
   PrivacySettingsResponseDto,
 } from './dto/update-privacy-settings.dto';
-import { ApiOperation, ApiResponse, ApiTags, ApiQuery, ApiParam } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiQuery,
+  ApiParam,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { PaginatedUserActivityDto } from './dto/user-activity.dto';
 import { ConfessionService } from '../confession/confession.service';
 import { GetUserConfessionsDto } from '../confession/dto/get-user-confessions.dto';
@@ -46,6 +54,7 @@ export interface UserProfileResponse {
   isAnonymous: boolean;
 }
 
+@ApiTags('Auth')
 @Controller('users')
 export class UserController {
   constructor(
@@ -81,6 +90,26 @@ export class UserController {
 
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Register a new user account' })
+  @ApiBody({ type: RegisterDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Registration successful.',
+    schema: {
+      example: {
+        user: {
+          id: 1,
+          username: 'alice_42',
+          role: 'user',
+          is_active: true,
+          email: 'alice@example.com',
+          createdAt: '2026-04-25T10:00:00.000Z',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Validation error.' })
+  @ApiResponse({ status: 409, description: 'Email or username already in use.' })
   async register(
     @Body() registerDto: RegisterDto,
   ): Promise<{ user: UserResponse }> {
@@ -129,6 +158,20 @@ export class UserController {
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Log in (alternative endpoint for user login)' })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Login successful.',
+    schema: {
+      example: {
+        access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        anonymousUserId: 'anon_7f3a2b1c',
+        user: { id: 1, username: 'alice_42', role: 'user' },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Invalid credentials.' })
   async login(@Body() loginDto: LoginDto): Promise<{
     access_token: string;
     user: UserResponse;

--- a/xconfess-contracts/contracts/anonymous-tipping/Cargo.toml
+++ b/xconfess-contracts/contracts/anonymous-tipping/Cargo.toml
@@ -16,3 +16,11 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 [[test]]
 name = "benchmarks"
 path = "tests/benchmarks.rs"
+
+[[test]]
+name = "invariants"
+path = "tests/invariants.rs"
+
+[[test]]
+name = "migration"
+path = "tests/migration.rs"

--- a/xconfess-contracts/contracts/anonymous-tipping/src/lib.rs
+++ b/xconfess-contracts/contracts/anonymous-tipping/src/lib.rs
@@ -96,6 +96,13 @@ impl Error {
 #[contract]
 pub struct AnonymousTipping;
 
+/// Schema version constants for upgrade-safe migration.
+/// SCHEMA_VERSION_INITIAL is the implicit version of any contract deployed
+/// before explicit versioning was introduced.  SCHEMA_VERSION_CURRENT is the
+/// version this WASM implements; `migrate()` brings storage up to this level.
+pub const SCHEMA_VERSION_INITIAL: u32 = 1;
+pub const SCHEMA_VERSION_CURRENT: u32 = 2;
+
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
@@ -105,6 +112,12 @@ enum DataKey {
     IsPaused,
     RateLimitConfig,
     WalletWindow(Address),
+    /// Tracks which schema version has been applied to this contract's storage.
+    /// Absent → SCHEMA_VERSION_INITIAL (pre-versioning deployment).
+    SchemaVersion,
+    /// v2: global count of all successful tip settlements across all recipients.
+    /// Absent (or 0) before `migrate()` is called.
+    GlobalTipCount,
 }
 
 #[contracttype]
@@ -241,6 +254,21 @@ impl AnonymousTipping {
         }
         .publish(&env);
 
+        // Increment global tip counter when the v2 schema is active.
+        // The key is absent on pre-migration contracts; we only write it when
+        // it already exists so that the count is not spuriously created before
+        // the owner has run `migrate()`.
+        if env.storage().instance().has(&DataKey::GlobalTipCount) {
+            let prev_count = env
+                .storage()
+                .instance()
+                .get::<_, u64>(&DataKey::GlobalTipCount)
+                .unwrap_or(0_u64);
+            env.storage()
+                .instance()
+                .set(&DataKey::GlobalTipCount, &prev_count.saturating_add(1));
+        }
+
         Ok(settlement_id)
     }
 
@@ -332,6 +360,78 @@ impl AnonymousTipping {
                 max_tips_per_window: Self::DEFAULT_MAX_TIPS_PER_WINDOW,
                 window_seconds: Self::DEFAULT_RATE_WINDOW_SECONDS,
             })
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Schema migration
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Apply all pending schema migrations and return the new schema version.
+    ///
+    /// **Idempotent** — calling this multiple times is always safe; it is a
+    /// no-op when the contract storage is already at `SCHEMA_VERSION_CURRENT`.
+    ///
+    /// Caller must be the contract owner.
+    ///
+    /// ## v1 → v2
+    /// Introduces `GlobalTipCount` (u64): a global counter of all successful
+    /// tip settlements.  Existing settlements are not back-filled — the counter
+    /// starts at 0 on upgrade and increments from the first post-migration tip.
+    /// Off-chain reconciliation should combine the pre-migration event log with
+    /// the on-chain counter when a complete historical count is needed.
+    ///
+    /// ## Rollback
+    /// Schema bumps are additive (new keys only, no existing key is removed or
+    /// retyped).  Rolling back the WASM to v1 is safe: the v1 code simply
+    /// ignores the new keys.  The `SchemaVersion` key will read as absent
+    /// (treated as v1) under the old WASM, which is correct.
+    pub fn migrate(env: Env, caller: Address) -> Result<u32, Error> {
+        caller.require_auth();
+        Self::require_owner(&env, &caller)?;
+
+        let current_version = env
+            .storage()
+            .instance()
+            .get::<_, u32>(&DataKey::SchemaVersion)
+            .unwrap_or(SCHEMA_VERSION_INITIAL);
+
+        if current_version >= SCHEMA_VERSION_CURRENT {
+            return Ok(current_version);
+        }
+
+        // v1 → v2: initialise GlobalTipCount to 0 if not already present.
+        if current_version < 2 {
+            if !env.storage().instance().has(&DataKey::GlobalTipCount) {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::GlobalTipCount, &0_u64);
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::SchemaVersion, &SCHEMA_VERSION_CURRENT);
+
+        Ok(SCHEMA_VERSION_CURRENT)
+    }
+
+    /// Return the current schema version stored on-chain.
+    /// Returns `SCHEMA_VERSION_INITIAL` for contracts deployed before
+    /// explicit versioning was introduced.
+    pub fn schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get::<_, u32>(&DataKey::SchemaVersion)
+            .unwrap_or(SCHEMA_VERSION_INITIAL)
+    }
+
+    /// Return the global count of all successful tip settlements since
+    /// schema v2 migration was applied.  Returns 0 on pre-v2 contracts.
+    pub fn global_tip_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get::<_, u64>(&DataKey::GlobalTipCount)
+            .unwrap_or(0_u64)
     }
 
     fn require_owner(env: &Env, caller: &Address) -> Result<(), Error> {

--- a/xconfess-contracts/contracts/anonymous-tipping/tests/invariants.rs
+++ b/xconfess-contracts/contracts/anonymous-tipping/tests/invariants.rs
@@ -1,0 +1,577 @@
+//! Invariant test suite for anonymous-tipping settlement correctness.
+//!
+//! ## Invariants verified
+//!
+//! | # | Invariant | Where |
+//! |---|-----------|-------|
+//! | I1 | Balance conservation: recipient total == sum of all successful tips to that address | `recipient_total_equals_sum_of_tips` |
+//! | I2 | Nonce monotonicity: each settlement returns `prev_nonce + 1` | `settlement_nonce_strictly_monotonic` |
+//! | I3 | Nonce coherence: `latest_settlement_nonce()` == total successful settlements | `nonce_equals_total_successful_settlements` |
+//! | I4 | Balance non-regression: recipient totals can never decrease | `recipient_total_never_decreases` |
+//! | I5 | Precision: i128 accumulation is exact — no rounding | `tip_accumulation_exact_no_rounding` |
+//! | I6 | Rate limit bound: per-wallet count never exceeds configured limit | `rate_limit_blocks_at_exact_window_cap` |
+//! | I7 | Pause completeness: all state-changing ops fail while paused | `pause_blocks_all_mutations` |
+//! | I8 | Zero/negative amounts never mutate state | `invalid_amounts_never_mutate_state` |
+//! | I9 | Overflow safety: TotalOverflow returned before silent corruption | `overflow_returns_error_not_silent_corruption` |
+//! | I10 | Recipient isolation: tipping one address never alters another's total | `recipients_are_mutually_isolated` |
+//! | I11 | send_tip and send_tip_with_proof(None) produce identical outcomes | `send_tip_and_proof_none_identical_invariant` |
+//! | I12 | GlobalTipCount coherence post-migration | `global_tip_count_coherent_with_nonce` |
+
+extern crate std;
+
+use anonymous_tipping::{AnonymousTipping, AnonymousTippingClient, Error};
+use soroban_sdk::{testutils::Address as _, Address, Env, String as SorobanString};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, AnonymousTippingClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(AnonymousTipping, ());
+    let client = AnonymousTippingClient::new(&env, &id);
+    client.init();
+    (env, client)
+}
+
+fn owner_setup() -> (Env, Address, AnonymousTippingClient<'static>) {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    client.configure_controls(&owner, &1_000u32, &60u64);
+    (env, owner, client)
+}
+
+// ── I1: Balance conservation ──────────────────────────────────────────────────
+
+/// The accumulated total must equal the arithmetic sum of every individual
+/// tip sent to that address, regardless of order or interleaving.
+#[test]
+fn recipient_total_equals_sum_of_tips() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+
+    let amounts: &[i128] = &[1, 10, 100, 999, 1, 42, 7];
+    let expected: i128 = amounts.iter().sum();
+
+    for &a in amounts {
+        client.send_tip(&alice, &a);
+    }
+
+    assert_eq!(
+        client.get_tips(&alice),
+        expected,
+        "I1: recipient total must equal exact arithmetic sum of all tips"
+    );
+}
+
+/// Conservation holds across multiple recipients in the same settlement stream.
+#[test]
+fn balance_conservation_holds_across_multiple_recipients() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    let alice_tips: &[i128] = &[100, 200, 50];
+    let bob_tips: &[i128] = &[999, 1];
+    let carol_tips: &[i128] = &[42];
+
+    // Interleave deliberately to ensure no cross-contamination
+    client.send_tip(&alice, &alice_tips[0]);
+    client.send_tip(&bob, &bob_tips[0]);
+    client.send_tip(&carol, &carol_tips[0]);
+    client.send_tip(&alice, &alice_tips[1]);
+    client.send_tip(&bob, &bob_tips[1]);
+    client.send_tip(&alice, &alice_tips[2]);
+
+    assert_eq!(client.get_tips(&alice), 350i128, "I1: alice total");
+    assert_eq!(client.get_tips(&bob), 1000i128, "I1: bob total");
+    assert_eq!(client.get_tips(&carol), 42i128, "I1: carol total");
+}
+
+// ── I2: Nonce monotonicity ────────────────────────────────────────────────────
+
+/// Each successful settlement must return exactly `previous_nonce + 1`.
+#[test]
+fn settlement_nonce_strictly_monotonic() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    let mut prev = 0u64;
+    for _ in 0..10 {
+        let id = client.send_tip(&recipient, &1i128);
+        assert_eq!(id, prev + 1, "I2: each settlement_id must be prev + 1");
+        prev = id;
+    }
+}
+
+/// Nonce advances even across different recipients.
+#[test]
+fn nonce_monotonic_across_different_recipients() {
+    let (env, client) = setup();
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let id1 = client.send_tip(&r1, &1i128);
+    let id2 = client.send_tip(&r2, &1i128);
+    let id3 = client.send_tip(&r1, &1i128);
+
+    assert!(id2 > id1, "I2: id2 must exceed id1");
+    assert!(id3 > id2, "I2: id3 must exceed id2");
+}
+
+// ── I3: Nonce coherence ───────────────────────────────────────────────────────
+
+/// `latest_settlement_nonce()` must equal the total number of successful
+/// settlements executed since contract initialisation.
+#[test]
+fn nonce_equals_total_successful_settlements() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    assert_eq!(client.latest_settlement_nonce(), 0, "I3: nonce starts at 0");
+
+    for n in 1u64..=20 {
+        client.send_tip(&recipient, &(n as i128));
+        assert_eq!(
+            client.latest_settlement_nonce(),
+            n,
+            "I3: nonce must equal {n} after {n} tips"
+        );
+    }
+}
+
+/// Failed tips must not increment the nonce.
+#[test]
+fn failed_tips_do_not_advance_nonce() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    client.send_tip(&recipient, &5i128);
+    let nonce_before = client.latest_settlement_nonce();
+
+    // Invalid amount — must fail without touching nonce
+    let _ = client.try_send_tip(&recipient, &0i128);
+    let _ = client.try_send_tip(&recipient, &(-1i128));
+
+    assert_eq!(
+        client.latest_settlement_nonce(),
+        nonce_before,
+        "I3: failed tips must not advance the settlement nonce"
+    );
+}
+
+// ── I4: Balance non-regression ────────────────────────────────────────────────
+
+/// Once a recipient has accumulated a balance, no future successful operation
+/// should decrease it.
+#[test]
+fn recipient_total_never_decreases() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    let mut prev_total: i128 = 0;
+    let amounts: &[i128] = &[100, 1, 999, 50, 200];
+    for &a in amounts {
+        client.send_tip(&recipient, &a);
+        let new_total = client.get_tips(&recipient);
+        assert!(
+            new_total >= prev_total,
+            "I4: recipient total must never decrease (was {prev_total}, now {new_total})"
+        );
+        prev_total = new_total;
+    }
+}
+
+// ── I5: Precision — no rounding ───────────────────────────────────────────────
+
+/// All amounts are i128 integers — there is no floating point involved.
+/// The invariant: repeated addition of the same value must equal N * value.
+#[test]
+fn tip_accumulation_exact_no_rounding() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    let unit: i128 = 7; // prime to surface any rounding
+    let n: u32 = 100;
+    for _ in 0..n {
+        client.send_tip(&recipient, &unit);
+    }
+
+    assert_eq!(
+        client.get_tips(&recipient),
+        unit * n as i128,
+        "I5: i128 accumulation must be exact — no rounding"
+    );
+}
+
+/// Odd and prime amounts accumulate exactly.
+#[test]
+fn odd_amounts_accumulate_without_rounding() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    let amounts: &[i128] = &[3, 7, 11, 13, 17, 19, 23];
+    let expected: i128 = amounts.iter().sum();
+    for &a in amounts {
+        client.send_tip(&recipient, &a);
+    }
+
+    assert_eq!(
+        client.get_tips(&recipient),
+        expected,
+        "I5: prime amounts must sum exactly"
+    );
+}
+
+/// The single-unit tip (minimum valid) accumulates exactly.
+#[test]
+fn unit_tip_precision() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    for i in 1i128..=50 {
+        client.send_tip(&recipient, &1i128);
+        assert_eq!(client.get_tips(&recipient), i, "I5: unit tip count == {i}");
+    }
+}
+
+// ── I6: Rate limit bound ──────────────────────────────────────────────────────
+
+/// The per-wallet rate limit must fire at exactly the configured window cap
+/// and never allow one more than permitted.
+#[test]
+fn rate_limit_blocks_at_exact_window_cap() {
+    let (env, owner, client) = owner_setup();
+    let cap: u32 = 5;
+    client.configure_controls(&owner, &cap, &60u64);
+
+    let wallet = Address::generate(&env);
+    for i in 0..cap {
+        let result = client.try_send_tip(&wallet, &1i128);
+        assert!(
+            result.is_ok(),
+            "I6: tip {} (of {cap}) must succeed",
+            i + 1
+        );
+    }
+
+    // The very next tip must be rate-limited
+    assert_eq!(
+        client.try_send_tip(&wallet, &1i128),
+        Err(Ok(Error::RateLimited)),
+        "I6: tip {} must be blocked by rate limit",
+        cap + 1
+    );
+}
+
+/// Rate limiting is per-wallet: other wallets are unaffected by one wallet
+/// exhausting its window.
+#[test]
+fn rate_limit_is_per_wallet_not_global() {
+    let (env, owner, client) = owner_setup();
+    client.configure_controls(&owner, &1u32, &60u64);
+
+    let wallet_a = Address::generate(&env);
+    let wallet_b = Address::generate(&env);
+
+    // wallet_a exhausts its window
+    assert!(client.try_send_tip(&wallet_a, &1i128).is_ok());
+    assert_eq!(
+        client.try_send_tip(&wallet_a, &1i128),
+        Err(Ok(Error::RateLimited))
+    );
+
+    // wallet_b is unaffected
+    assert!(
+        client.try_send_tip(&wallet_b, &1i128).is_ok(),
+        "I6: wallet_b must not be affected by wallet_a's rate exhaustion"
+    );
+}
+
+// ── I7: Pause completeness ────────────────────────────────────────────────────
+
+/// While paused, ALL state-changing tip operations must fail.
+/// Read-only operations must still succeed.
+#[test]
+fn pause_blocks_all_mutations() {
+    let (env, owner, client) = owner_setup();
+    let recipient = Address::generate(&env);
+
+    // Establish baseline state
+    client.send_tip(&recipient, &10i128);
+    let baseline_total = client.get_tips(&recipient);
+    let baseline_nonce = client.latest_settlement_nonce();
+
+    client.pause(&owner, &SorobanString::from_str(&env, "maintenance"));
+    assert!(client.is_paused(), "I7: must be paused");
+
+    // Both tip variants must be blocked
+    assert_eq!(
+        client.try_send_tip(&recipient, &1i128),
+        Err(Ok(Error::ContractPaused)),
+        "I7: send_tip must fail while paused"
+    );
+    assert_eq!(
+        client.try_send_tip_with_proof(&recipient, &1i128, &None),
+        Err(Ok(Error::ContractPaused)),
+        "I7: send_tip_with_proof must fail while paused"
+    );
+
+    // State must be completely unchanged
+    assert_eq!(
+        client.get_tips(&recipient),
+        baseline_total,
+        "I7: recipient total must not change while paused"
+    );
+    assert_eq!(
+        client.latest_settlement_nonce(),
+        baseline_nonce,
+        "I7: nonce must not change while paused"
+    );
+
+    // Read operations must remain available
+    let _ = client.get_tips(&recipient);
+    let _ = client.latest_settlement_nonce();
+    let _ = client.is_paused();
+    let _ = client.get_rate_limit_config();
+}
+
+/// Unpausing restores normal operation — the invariant resumes.
+#[test]
+fn unpause_restores_settlement_invariant() {
+    let (env, owner, client) = owner_setup();
+    let recipient = Address::generate(&env);
+
+    client.pause(&owner, &SorobanString::from_str(&env, "incident"));
+    client.unpause(&owner, &SorobanString::from_str(&env, "resolved"));
+
+    let id = client.send_tip(&recipient, &42i128);
+    assert_eq!(id, 1, "I7: first tip after unpause must get settlement_id 1");
+    assert_eq!(client.get_tips(&recipient), 42i128);
+}
+
+// ── I8: Zero/negative amounts never mutate state ─────────────────────────────
+
+#[test]
+fn invalid_amounts_never_mutate_state() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    let initial_nonce = client.latest_settlement_nonce();
+    let initial_total = client.get_tips(&recipient);
+
+    let invalid_amounts: &[i128] = &[0, -1, -100, i128::MIN, i128::MIN + 1];
+    for &a in invalid_amounts {
+        let _ = client.try_send_tip(&recipient, &a);
+        let _ = client.try_send_tip_with_proof(&recipient, &a, &None);
+    }
+
+    assert_eq!(
+        client.latest_settlement_nonce(),
+        initial_nonce,
+        "I8: nonce must not advance for any invalid amount"
+    );
+    assert_eq!(
+        client.get_tips(&recipient),
+        initial_total,
+        "I8: recipient total must not change for any invalid amount"
+    );
+}
+
+// ── I9: Overflow safety ───────────────────────────────────────────────────────
+
+/// Adding an amount that would overflow i128 must return TotalOverflow,
+/// not silently corrupt the stored total.
+#[test]
+fn overflow_returns_error_not_silent_corruption() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    // Load total to near max
+    client.send_tip(&recipient, &(i128::MAX - 50));
+    let pre_overflow_total = client.get_tips(&recipient);
+
+    // This would overflow — must be rejected
+    let result = client.try_send_tip(&recipient, &100i128);
+    assert_eq!(
+        result,
+        Err(Ok(Error::TotalOverflow)),
+        "I9: overflow must be caught and returned as TotalOverflow"
+    );
+
+    // Total must be unchanged
+    assert_eq!(
+        client.get_tips(&recipient),
+        pre_overflow_total,
+        "I9: total must not be corrupted after overflow rejection"
+    );
+}
+
+/// A tip of exactly 1 that would overflow must also be caught.
+#[test]
+fn overflow_by_one_is_caught() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+
+    client.send_tip(&recipient, &i128::MAX);
+
+    let result = client.try_send_tip(&recipient, &1i128);
+    assert_eq!(result, Err(Ok(Error::TotalOverflow)), "I9: +1 overflow caught");
+}
+
+// ── I10: Recipient isolation ──────────────────────────────────────────────────
+
+/// Tipping one recipient must never alter another recipient's total.
+#[test]
+fn recipients_are_mutually_isolated() {
+    let (env, client) = setup();
+    let recipients: std::vec::Vec<Address> = (0..5).map(|_| Address::generate(&env)).collect();
+
+    // Tip only the first recipient
+    for _ in 0..10 {
+        client.send_tip(&recipients[0], &1i128);
+    }
+
+    // All other recipients must remain at 0
+    for r in &recipients[1..] {
+        assert_eq!(
+            client.get_tips(r),
+            0i128,
+            "I10: untouched recipients must have 0 total"
+        );
+    }
+}
+
+/// Tipping in a round-robin pattern must keep each recipient's total
+/// equal to exactly (number of times they were tipped) * amount.
+#[test]
+fn round_robin_tipping_preserves_per_recipient_isolation() {
+    let (env, client) = setup();
+    let n = 4usize;
+    let amount = 100i128;
+    let rounds = 5usize;
+    let recipients: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+    for _ in 0..rounds {
+        for r in &recipients {
+            client.send_tip(r, &amount);
+        }
+    }
+
+    for r in &recipients {
+        assert_eq!(
+            client.get_tips(r),
+            amount * rounds as i128,
+            "I10: each recipient must have exactly rounds * amount"
+        );
+    }
+}
+
+// ── I11: send_tip and send_tip_with_proof(None) identical ─────────────────────
+
+/// The two public tip APIs must produce byte-identical state outcomes when
+/// `send_tip_with_proof` is called with `proof_metadata = None`.
+#[test]
+fn send_tip_and_proof_none_identical_invariant() {
+    let (env, client) = setup();
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    client.send_tip(&r1, &77i128);
+    client.send_tip_with_proof(&r2, &77i128, &None);
+
+    assert_eq!(
+        client.get_tips(&r1),
+        client.get_tips(&r2),
+        "I11: send_tip and send_tip_with_proof(None) must produce identical totals"
+    );
+
+    // Nonce advanced by 1 for each
+    assert_eq!(
+        client.latest_settlement_nonce(),
+        2,
+        "I11: both calls advance the nonce"
+    );
+}
+
+// ── I12: GlobalTipCount coherence ────────────────────────────────────────────
+
+/// After migration, GlobalTipCount must equal the number of successful
+/// post-migration settlements, matching `latest_settlement_nonce()` minus
+/// the nonce at migration time.
+#[test]
+fn global_tip_count_coherent_with_nonce() {
+    let (env, owner, client) = owner_setup();
+    let recipient = Address::generate(&env);
+
+    // Establish pre-migration nonce
+    client.send_tip(&recipient, &1i128);
+    client.send_tip(&recipient, &1i128);
+    let nonce_at_migration = client.latest_settlement_nonce();
+
+    client.migrate(&owner);
+
+    // Post-migration tips
+    let post_tips = 7u64;
+    for _ in 0..post_tips {
+        client.send_tip(&recipient, &1i128);
+    }
+
+    assert_eq!(
+        client.global_tip_count(),
+        post_tips,
+        "I12: GlobalTipCount must equal post-migration tip count"
+    );
+    assert_eq!(
+        client.latest_settlement_nonce(),
+        nonce_at_migration + post_tips,
+        "I12: nonce must equal migration-time nonce plus post-migration tips"
+    );
+}
+
+/// GlobalTipCount must not increment for failed tips even after migration.
+#[test]
+fn global_tip_count_not_incremented_by_failed_tip_post_migration() {
+    let (env, owner, client) = owner_setup();
+    let recipient = Address::generate(&env);
+    client.migrate(&owner);
+
+    // Failed tip
+    let _ = client.try_send_tip(&recipient, &0i128);
+    assert_eq!(
+        client.global_tip_count(),
+        0,
+        "I12: failed tip must not increment GlobalTipCount"
+    );
+}
+
+// ── adversarial precision: rounding boundary for proof metadata ───────────────
+
+/// The metadata length check is exact: 128 bytes succeeds, 129 bytes fails.
+/// This is a precision invariant on the metadata boundary.
+#[test]
+fn metadata_length_boundary_exact() {
+    let (env, client) = setup();
+    let recipient = Address::generate(&env);
+    let max = anonymous_tipping::AnonymousTipping::MAX_PROOF_METADATA_LEN as usize;
+
+    // Exactly at the boundary — must succeed
+    let ok_meta = SorobanString::from_str(
+        &env,
+        &std::string::String::from("x").repeat(max),
+    );
+    let sid = client.send_tip_with_proof(&recipient, &1i128, &Some(ok_meta));
+    assert_eq!(sid, 1);
+
+    // One over the boundary — must fail
+    let over_meta = SorobanString::from_str(
+        &env,
+        &std::string::String::from("x").repeat(max + 1),
+    );
+    let result = client.try_send_tip_with_proof(&recipient, &1i128, &Some(over_meta));
+    assert_eq!(result, Err(Ok(Error::MetadataTooLong)));
+
+    // Total must only reflect the one successful tip
+    assert_eq!(client.get_tips(&recipient), 1i128);
+    assert_eq!(client.latest_settlement_nonce(), 1);
+}

--- a/xconfess-contracts/contracts/anonymous-tipping/tests/migration.rs
+++ b/xconfess-contracts/contracts/anonymous-tipping/tests/migration.rs
@@ -1,0 +1,324 @@
+//! Migration tests for the anonymous-tipping contract.
+//!
+//! Each test exercises a specific aspect of the v1→v2 schema migration:
+//!   - fresh contract (never init'd), already-migrated contracts, idempotency,
+//!     fixture states with live data, rollback properties, and auth enforcement.
+//!
+//! ## Fixture states used
+//! - **Fixture A** – fresh contract, `init()` called, no tips, no owner.
+//! - **Fixture B** – contract with 3 tips sent to 2 recipients before migration.
+//! - **Fixture C** – contract with owner + pause state, then migrated.
+
+extern crate std;
+
+use anonymous_tipping::{AnonymousTipping, AnonymousTippingClient, SCHEMA_VERSION_CURRENT, SCHEMA_VERSION_INITIAL};
+use soroban_sdk::{testutils::Address as _, Address, Env, String as SorobanString};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, AnonymousTippingClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(AnonymousTipping, ());
+    let client = AnonymousTippingClient::new(&env, &id);
+    client.init();
+    (env, id, client)
+}
+
+fn owner_setup() -> (Env, Address, Address, AnonymousTippingClient<'static>) {
+    let (env, id, client) = setup();
+    let owner = Address::generate(&env);
+    client.configure_controls(&owner, &1_000u32, &60u64);
+    (env, id, owner, client)
+}
+
+// ── schema version defaults ───────────────────────────────────────────────────
+
+#[test]
+fn schema_version_is_initial_before_migration() {
+    let (_env, _id, client) = setup();
+    assert_eq!(
+        client.schema_version(),
+        SCHEMA_VERSION_INITIAL,
+        "schema version must default to SCHEMA_VERSION_INITIAL before migrate() is called"
+    );
+}
+
+#[test]
+fn global_tip_count_is_zero_before_migration() {
+    let (_env, _id, client) = setup();
+    assert_eq!(
+        client.global_tip_count(),
+        0,
+        "global_tip_count must default to 0 before migration"
+    );
+}
+
+// ── v1 → v2 migration correctness ─────────────────────────────────────────────
+
+#[test]
+fn migrate_bumps_schema_version_to_current() {
+    let (_env, _id, owner, client) = owner_setup();
+
+    let new_version = client.migrate(&owner);
+    assert_eq!(
+        new_version,
+        SCHEMA_VERSION_CURRENT,
+        "migrate() must return SCHEMA_VERSION_CURRENT after upgrade"
+    );
+    assert_eq!(
+        client.schema_version(),
+        SCHEMA_VERSION_CURRENT,
+        "schema_version() must reflect the upgraded version"
+    );
+}
+
+#[test]
+fn migrate_initialises_global_tip_count_to_zero() {
+    let (_env, _id, owner, client) = owner_setup();
+    client.migrate(&owner);
+
+    assert_eq!(
+        client.global_tip_count(),
+        0,
+        "GlobalTipCount must be initialised to 0 by migration"
+    );
+}
+
+// ── fixture B: tips exist before migration ────────────────────────────────────
+
+/// Pre-migration tips must remain unaffected: the existing recipient totals
+/// and settlement nonce are preserved after the schema upgrade.
+#[test]
+fn migration_preserves_pre_existing_recipient_totals() {
+    let (env, _id, owner, client) = owner_setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    // Send tips before migration (fixture B state)
+    let id1 = client.send_tip(&alice, &100i128);
+    let id2 = client.send_tip(&alice, &50i128);
+    let id3 = client.send_tip(&bob, &200i128);
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+    assert_eq!(id3, 3);
+
+    client.migrate(&owner);
+
+    assert_eq!(
+        client.get_tips(&alice),
+        150i128,
+        "alice's total must survive migration"
+    );
+    assert_eq!(
+        client.get_tips(&bob),
+        200i128,
+        "bob's total must survive migration"
+    );
+    assert_eq!(
+        client.latest_settlement_nonce(),
+        3,
+        "settlement nonce must survive migration"
+    );
+}
+
+/// Pre-migration tips are NOT counted in GlobalTipCount; the counter starts
+/// at 0 after migration.  Post-migration tips do increment the counter.
+#[test]
+fn global_tip_count_starts_at_zero_post_migration_not_backfilled() {
+    let (env, _id, owner, client) = owner_setup();
+    let alice = Address::generate(&env);
+
+    // 3 tips before migration
+    client.send_tip(&alice, &10i128);
+    client.send_tip(&alice, &10i128);
+    client.send_tip(&alice, &10i128);
+
+    client.migrate(&owner);
+
+    assert_eq!(
+        client.global_tip_count(),
+        0,
+        "GlobalTipCount must start at 0 after migration — pre-migration tips are not backfilled"
+    );
+
+    // 2 tips after migration
+    client.send_tip(&alice, &5i128);
+    client.send_tip(&alice, &5i128);
+
+    assert_eq!(
+        client.global_tip_count(),
+        2,
+        "only post-migration tips must increment GlobalTipCount"
+    );
+}
+
+// ── post-migration: GlobalTipCount increments correctly ───────────────────────
+
+#[test]
+fn global_tip_count_increments_by_one_per_successful_tip() {
+    let (env, _id, owner, client) = owner_setup();
+    client.migrate(&owner);
+
+    let recipient = Address::generate(&env);
+    for expected in 1u64..=5 {
+        client.send_tip(&recipient, &1i128);
+        assert_eq!(
+            client.global_tip_count(),
+            expected,
+            "GlobalTipCount must be {} after {} tips",
+            expected,
+            expected
+        );
+    }
+}
+
+#[test]
+fn global_tip_count_spans_multiple_recipients() {
+    let (env, _id, owner, client) = owner_setup();
+    client.migrate(&owner);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.send_tip(&alice, &1i128);
+    client.send_tip(&bob, &1i128);
+    client.send_tip(&alice, &1i128);
+
+    assert_eq!(client.global_tip_count(), 3);
+}
+
+#[test]
+fn global_tip_count_not_incremented_by_failed_tip() {
+    let (env, _id, owner, client) = owner_setup();
+    client.migrate(&owner);
+
+    let recipient = Address::generate(&env);
+
+    // Failed tip (invalid amount) must not increment counter
+    let _ = client.try_send_tip(&recipient, &0i128);
+    assert_eq!(
+        client.global_tip_count(),
+        0,
+        "failed tip must not increment GlobalTipCount"
+    );
+
+    // Successful tip increments
+    client.send_tip(&recipient, &1i128);
+    assert_eq!(client.global_tip_count(), 1);
+}
+
+// ── fixture C: pause state preserved through migration ───────────────────────
+
+#[test]
+fn migration_preserves_pause_state() {
+    let (env, _id, owner, client) = owner_setup();
+    let reason = SorobanString::from_str(&env, "scheduled-maintenance");
+    client.pause(&owner, &reason);
+    assert!(client.is_paused());
+
+    client.migrate(&owner);
+
+    assert!(
+        client.is_paused(),
+        "paused flag must be preserved through migration"
+    );
+    assert_eq!(
+        client.schema_version(),
+        SCHEMA_VERSION_CURRENT,
+        "schema version must advance even when contract is paused"
+    );
+}
+
+#[test]
+fn migration_preserves_rate_limit_config() {
+    let (env, _id, owner, client) = owner_setup();
+    // Custom rate-limit (overrides the default set by configure_controls)
+    client.configure_controls(&owner, &25u32, &300u64);
+    client.migrate(&owner);
+
+    let cfg = client.get_rate_limit_config();
+    assert_eq!(cfg.max_tips_per_window, 25, "max_tips_per_window must survive migration");
+    assert_eq!(cfg.window_seconds, 300, "window_seconds must survive migration");
+}
+
+// ── idempotency ───────────────────────────────────────────────────────────────
+
+#[test]
+fn migrate_is_idempotent() {
+    let (env, _id, owner, client) = owner_setup();
+    client.migrate(&owner);
+
+    // Accumulate some state after first migration
+    let recipient = Address::generate(&env);
+    client.send_tip(&recipient, &77i128);
+    let count_after_first = client.global_tip_count();
+    assert_eq!(count_after_first, 1);
+
+    // Second migrate must be a no-op
+    let version_again = client.migrate(&owner);
+    assert_eq!(version_again, SCHEMA_VERSION_CURRENT);
+    assert_eq!(
+        client.global_tip_count(),
+        1,
+        "second migrate() must not reset GlobalTipCount"
+    );
+    assert_eq!(
+        client.get_tips(&recipient),
+        77i128,
+        "second migrate() must not alter recipient totals"
+    );
+}
+
+#[test]
+fn migrate_multiple_times_returns_current_version_each_time() {
+    let (_env, _id, owner, client) = owner_setup();
+    for _ in 0..3 {
+        let v = client.migrate(&owner);
+        assert_eq!(v, SCHEMA_VERSION_CURRENT);
+    }
+    assert_eq!(client.schema_version(), SCHEMA_VERSION_CURRENT);
+}
+
+// ── auth enforcement ──────────────────────────────────────────────────────────
+
+#[test]
+fn migrate_requires_owner_authorization() {
+    use anonymous_tipping::Error;
+    let (env, _id, _owner, client) = owner_setup();
+    let non_owner = Address::generate(&env);
+
+    let result = client.try_migrate(&non_owner);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Unauthorized)),
+        "migrate() must reject non-owner callers"
+    );
+}
+
+// ── rollback safety ───────────────────────────────────────────────────────────
+
+/// Documents the rollback contract: a v1 deployment can read v2-migrated
+/// storage without corruption because migration only ADDS new keys.
+/// This test simulates the v1 perspective by verifying the pre-existing keys
+/// are unchanged after v2 migration.
+#[test]
+fn v2_migration_does_not_modify_or_remove_v1_keys() {
+    let (env, _id, owner, client) = owner_setup();
+    let alice = Address::generate(&env);
+
+    // Capture v1 state
+    client.send_tip(&alice, &500i128);
+    let pre_nonce = client.latest_settlement_nonce();
+    let pre_total = client.get_tips(&alice);
+    let pre_rate_cfg = client.get_rate_limit_config();
+
+    client.migrate(&owner);
+
+    // v1 keys must be byte-for-byte identical after migration
+    assert_eq!(client.latest_settlement_nonce(), pre_nonce);
+    assert_eq!(client.get_tips(&alice), pre_total);
+    let post_cfg = client.get_rate_limit_config();
+    assert_eq!(post_cfg.max_tips_per_window, pre_rate_cfg.max_tips_per_window);
+    assert_eq!(post_cfg.window_seconds, pre_rate_cfg.window_seconds);
+}

--- a/xconfess-contracts/contracts/confession-anchor/Cargo.toml
+++ b/xconfess-contracts/contracts/confession-anchor/Cargo.toml
@@ -21,3 +21,7 @@ path = "tests/adversarial.rs"
 [[test]]
 name = "benchmarks"
 path = "tests/benchmarks.rs"
+
+[[test]]
+name = "migration"
+path = "tests/migration.rs"

--- a/xconfess-contracts/contracts/confession-anchor/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-anchor/src/lib.rs
@@ -31,6 +31,10 @@ const CAPABILITY_META_V1: Symbol = symbol_short!("meta_v1");
 const CAPABILITY_ADMIN_V1: Symbol = symbol_short!("adminv1");
 const CAPABILITY_PAUSE_V1: Symbol = symbol_short!("pausev1");
 
+/// Schema version constants for upgrade-safe migration.
+pub const ANCHOR_SCHEMA_VERSION_INITIAL: u32 = 1;
+pub const ANCHOR_SCHEMA_VERSION_CURRENT: u32 = 2;
+
 /// Storage keys for confession-anchor state
 #[contracttype]
 #[derive(Clone)]
@@ -39,6 +43,13 @@ pub enum DataKey {
     Owner,
     /// Admin set: Map<Address, ()>
     Admins,
+    /// Tracks which schema version has been applied to this contract's storage.
+    /// Absent → ANCHOR_SCHEMA_VERSION_INITIAL (pre-versioning deployment).
+    SchemaVersion,
+    /// v2: timestamp of the most recently successfully anchored confession.
+    /// Absent before `migrate()` is called; 0 means no anchor has occurred
+    /// since migration (i.e. pre-migration anchors are not back-filled).
+    LastAnchorTimestamp,
 }
 
 #[contracttype]
@@ -216,6 +227,19 @@ impl ConfessionAnchor {
         // Increment confession count.
         let current_count = get_count(&env);
         set_count(&env, current_count + 1);
+
+        // Track last anchor timestamp when v2 schema is active.
+        // We only write when the key already exists so we don't spuriously
+        // create it before the owner has run `migrate()`.
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::LastAnchorTimestamp)
+        {
+            env.storage()
+                .instance()
+                .set(&DataKey::LastAnchorTimestamp, &timestamp);
+        }
 
         // Emit ConfessionAnchored event:
         // topics: ("confession_anchor", hash)
@@ -419,6 +443,77 @@ impl ConfessionAnchor {
     /// Revoke operator role from an address (owner or admin).
     pub fn revoke_operator(env: Env, caller: Address, target: Address) -> Result<(), Error> {
         access_control::revoke_operator(&env, &caller, &target).map_err(Into::into)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Schema migration
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Apply all pending schema migrations and return the new schema version.
+    ///
+    /// **Idempotent** — calling this multiple times is safe; it is a no-op
+    /// when storage is already at `ANCHOR_SCHEMA_VERSION_CURRENT`.
+    ///
+    /// Caller must be the contract owner.
+    ///
+    /// ## v1 → v2
+    /// Introduces `LastAnchorTimestamp` (u64): the timestamp of the most
+    /// recent successful anchor.  Pre-migration anchors are not back-filled —
+    /// the value starts at 0 and is updated from the first post-migration
+    /// `anchor_confession` call.
+    ///
+    /// ## Rollback
+    /// Schema bumps are purely additive.  The v1 WASM simply ignores any
+    /// `SchemaVersion` or `LastAnchorTimestamp` keys left by the migration.
+    pub fn migrate(env: Env, caller: Address) -> Result<u32, Error> {
+        access_control::require_owner(&env, &caller).map_err(Error::from)?;
+
+        let current_version = env
+            .storage()
+            .instance()
+            .get::<_, u32>(&DataKey::SchemaVersion)
+            .unwrap_or(ANCHOR_SCHEMA_VERSION_INITIAL);
+
+        if current_version >= ANCHOR_SCHEMA_VERSION_CURRENT {
+            return Ok(current_version);
+        }
+
+        // v1 → v2: initialise LastAnchorTimestamp to 0 if not already present.
+        if current_version < 2 {
+            if !env
+                .storage()
+                .instance()
+                .has(&DataKey::LastAnchorTimestamp)
+            {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::LastAnchorTimestamp, &0_u64);
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::SchemaVersion, &ANCHOR_SCHEMA_VERSION_CURRENT);
+
+        Ok(ANCHOR_SCHEMA_VERSION_CURRENT)
+    }
+
+    /// Return the current schema version stored on-chain.
+    /// Returns `ANCHOR_SCHEMA_VERSION_INITIAL` for pre-versioning deployments.
+    pub fn schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get::<_, u32>(&DataKey::SchemaVersion)
+            .unwrap_or(ANCHOR_SCHEMA_VERSION_INITIAL)
+    }
+
+    /// Return the timestamp of the last successfully anchored confession since
+    /// schema v2 migration was applied.  Returns 0 on pre-v2 contracts.
+    pub fn last_anchor_timestamp(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get::<_, u64>(&DataKey::LastAnchorTimestamp)
+            .unwrap_or(0_u64)
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/xconfess-contracts/contracts/confession-anchor/tests/migration.rs
+++ b/xconfess-contracts/contracts/confession-anchor/tests/migration.rs
@@ -1,0 +1,351 @@
+//! Migration tests for the confession-anchor contract.
+//!
+//! Verifies the v1→v2 schema migration which introduces `LastAnchorTimestamp`.
+//!
+//! ## Fixture states
+//! - **Fixture A** – freshly initialized, no owner, no anchors.
+//! - **Fixture B** – owner set, 3 confessions anchored before migration.
+//! - **Fixture C** – owner set, paused contract migrated.
+
+#![cfg(test)]
+
+extern crate std;
+
+use confession_anchor::{
+    ConfessionAnchor, ConfessionAnchorClient, Error,
+    ANCHOR_SCHEMA_VERSION_CURRENT, ANCHOR_SCHEMA_VERSION_INITIAL,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    BytesN, Env, String as SorobanString,
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn new_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn new_client(env: &Env) -> ConfessionAnchorClient<'static> {
+    let id = env.register(ConfessionAnchor, ());
+    ConfessionAnchorClient::new(env, &id)
+}
+
+fn sample_hash(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+fn owner_client(
+    env: &Env,
+) -> (
+    soroban_sdk::Address,
+    ConfessionAnchorClient<'static>,
+) {
+    let client = new_client(env);
+    let owner = soroban_sdk::Address::generate(env);
+    client.initialize(&owner);
+    (owner, client)
+}
+
+fn advance_ledger(env: &Env, delta: u32) {
+    let current = env.ledger().sequence();
+    env.ledger().set(LedgerInfo {
+        sequence_number: current + delta,
+        ..env.ledger().get()
+    });
+}
+
+// ── schema version defaults ───────────────────────────────────────────────────
+
+#[test]
+fn schema_version_defaults_to_initial_before_migration() {
+    let env = new_env();
+    let client = new_client(&env);
+    assert_eq!(
+        client.schema_version(),
+        ANCHOR_SCHEMA_VERSION_INITIAL,
+        "schema version must default to ANCHOR_SCHEMA_VERSION_INITIAL before migrate()"
+    );
+}
+
+#[test]
+fn last_anchor_timestamp_defaults_to_zero_before_migration() {
+    let env = new_env();
+    let client = new_client(&env);
+    assert_eq!(
+        client.last_anchor_timestamp(),
+        0u64,
+        "last_anchor_timestamp must default to 0 before migrate()"
+    );
+}
+
+// ── v1 → v2 migration correctness ─────────────────────────────────────────────
+
+#[test]
+fn migrate_bumps_schema_version_to_current() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+
+    let new_version = client.migrate(&owner);
+    assert_eq!(
+        new_version,
+        ANCHOR_SCHEMA_VERSION_CURRENT,
+        "migrate() must return ANCHOR_SCHEMA_VERSION_CURRENT"
+    );
+    assert_eq!(
+        client.schema_version(),
+        ANCHOR_SCHEMA_VERSION_CURRENT,
+        "schema_version() must reflect the upgraded version on-chain"
+    );
+}
+
+#[test]
+fn migrate_initialises_last_anchor_timestamp_to_zero() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+    client.migrate(&owner);
+
+    assert_eq!(
+        client.last_anchor_timestamp(),
+        0u64,
+        "LastAnchorTimestamp must be initialised to 0 by migration (pre-existing anchors not backfilled)"
+    );
+}
+
+// ── fixture B: pre-existing anchors survive migration ────────────────────────
+
+/// All pre-migration anchors remain verifiable after the schema upgrade.
+#[test]
+fn migration_preserves_pre_existing_anchors() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+
+    let entries: &[(u8, u64)] = &[(0xAA, 1_000), (0xBB, 2_000), (0xCC, 3_000)];
+    for &(seed, ts) in entries {
+        client.anchor_confession(&sample_hash(&env, seed), &ts);
+    }
+    assert_eq!(client.get_confession_count(), 3);
+
+    client.migrate(&owner);
+
+    for &(seed, ts) in entries {
+        assert_eq!(
+            client.verify_confession(&sample_hash(&env, seed)),
+            Some(ts),
+            "pre-migration anchor with seed {seed:#x} must survive migration"
+        );
+    }
+    assert_eq!(
+        client.get_confession_count(),
+        3,
+        "confession count must survive migration"
+    );
+}
+
+/// Pre-migration anchors are NOT back-filled into LastAnchorTimestamp.
+#[test]
+fn last_anchor_timestamp_not_backfilled_for_pre_migration_anchors() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+
+    client.anchor_confession(&sample_hash(&env, 0x01), &99_999u64);
+    client.migrate(&owner);
+
+    assert_eq!(
+        client.last_anchor_timestamp(),
+        0u64,
+        "LastAnchorTimestamp must be 0 after migration — pre-migration anchors are not backfilled"
+    );
+}
+
+// ── post-migration: LastAnchorTimestamp tracks correctly ──────────────────────
+
+#[test]
+fn last_anchor_timestamp_updated_by_post_migration_anchor() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+    client.migrate(&owner);
+
+    let ts: u64 = 5_000_000;
+    client.anchor_confession(&sample_hash(&env, 0x10), &ts);
+
+    assert_eq!(
+        client.last_anchor_timestamp(),
+        ts,
+        "LastAnchorTimestamp must be updated after post-migration anchor"
+    );
+}
+
+#[test]
+fn last_anchor_timestamp_reflects_most_recent_anchor() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+    client.migrate(&owner);
+
+    client.anchor_confession(&sample_hash(&env, 0x20), &1_000u64);
+    client.anchor_confession(&sample_hash(&env, 0x21), &2_000u64);
+    client.anchor_confession(&sample_hash(&env, 0x22), &3_000u64);
+
+    assert_eq!(
+        client.last_anchor_timestamp(),
+        3_000u64,
+        "LastAnchorTimestamp must reflect the most recently anchored confession"
+    );
+}
+
+#[test]
+fn duplicate_anchor_does_not_update_last_anchor_timestamp() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+    client.migrate(&owner);
+
+    let hash = sample_hash(&env, 0x30);
+    client.anchor_confession(&hash, &500u64);
+    assert_eq!(client.last_anchor_timestamp(), 500u64);
+
+    // Duplicate must not update the timestamp
+    client.anchor_confession(&hash, &9_999u64);
+    assert_eq!(
+        client.last_anchor_timestamp(),
+        500u64,
+        "duplicate anchor must not update LastAnchorTimestamp"
+    );
+}
+
+// ── fixture C: pause state preserved through migration ───────────────────────
+
+#[test]
+fn migration_preserves_pause_state() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+
+    client.pause(&owner, &SorobanString::from_str(&env, "maintenance"));
+    assert!(client.is_paused());
+
+    // migrate() should succeed even while paused
+    client.migrate(&owner);
+
+    assert!(client.is_paused(), "paused flag must survive migration");
+    assert_eq!(
+        client.schema_version(),
+        ANCHOR_SCHEMA_VERSION_CURRENT,
+        "schema version must advance even while paused"
+    );
+}
+
+// ── idempotency ───────────────────────────────────────────────────────────────
+
+#[test]
+fn migrate_is_idempotent() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+    client.migrate(&owner);
+
+    client.anchor_confession(&sample_hash(&env, 0x40), &7_777u64);
+    let ts_after_first = client.last_anchor_timestamp();
+
+    // Second migration must be a no-op
+    let v2 = client.migrate(&owner);
+    assert_eq!(v2, ANCHOR_SCHEMA_VERSION_CURRENT);
+    assert_eq!(
+        client.last_anchor_timestamp(),
+        ts_after_first,
+        "second migrate() must not reset LastAnchorTimestamp"
+    );
+    assert_eq!(
+        client.get_confession_count(),
+        1,
+        "second migrate() must not alter confession count"
+    );
+}
+
+#[test]
+fn migrate_called_three_times_stays_at_current_version() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+    for _ in 0..3 {
+        assert_eq!(client.migrate(&owner), ANCHOR_SCHEMA_VERSION_CURRENT);
+    }
+}
+
+// ── auth enforcement ──────────────────────────────────────────────────────────
+
+#[test]
+fn migrate_requires_owner_authorization() {
+    let env = new_env();
+    let (_, client) = owner_client(&env);
+    let non_owner = soroban_sdk::Address::generate(&env);
+
+    let result = client.try_migrate(&non_owner);
+    assert_eq!(
+        result,
+        Err(Ok(Error::NotOwner)),
+        "migrate() must reject non-owner callers"
+    );
+}
+
+// ── rollback safety ───────────────────────────────────────────────────────────
+
+/// Documents the rollback contract: migration only adds new keys; existing
+/// keys are byte-identical before and after migration.
+#[test]
+fn v2_migration_does_not_modify_or_remove_v1_keys() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+
+    // Capture v1 state
+    client.anchor_confession(&sample_hash(&env, 0x50), &12_345u64);
+    let pre_count = client.get_confession_count();
+    let pre_verify = client.verify_confession(&sample_hash(&env, 0x50));
+    let pre_version = client.get_version();
+
+    client.migrate(&owner);
+
+    // v1 keys must be byte-for-byte identical after migration
+    assert_eq!(client.get_confession_count(), pre_count);
+    assert_eq!(
+        client.verify_confession(&sample_hash(&env, 0x50)),
+        pre_verify
+    );
+    let post_version = client.get_version();
+    assert_eq!(post_version.major, pre_version.major);
+    assert_eq!(post_version.minor, pre_version.minor);
+    assert_eq!(post_version.patch, pre_version.patch);
+}
+
+/// Verifies that the upgrade policy constants are unaffected by the migration.
+#[test]
+fn upgrade_policy_unchanged_after_migration() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+    let policy_before = client.get_upgrade_policy();
+
+    client.migrate(&owner);
+
+    let policy_after = client.get_upgrade_policy();
+    assert_eq!(policy_before.current_major, policy_after.current_major);
+    assert_eq!(policy_before.policy_version, policy_after.policy_version);
+}
+
+// ── ledger advance interaction ────────────────────────────────────────────────
+
+/// LastAnchorTimestamp uses the client-provided timestamp, not ledger time.
+/// It must update even across ledger sequence advances.
+#[test]
+fn last_anchor_timestamp_uses_client_timestamp_not_ledger_time() {
+    let env = new_env();
+    let (owner, client) = owner_client(&env);
+    client.migrate(&owner);
+
+    advance_ledger(&env, 100);
+    let client_ts: u64 = 9_876_543_210;
+    client.anchor_confession(&sample_hash(&env, 0x60), &client_ts);
+
+    assert_eq!(
+        client.last_anchor_timestamp(),
+        client_ts,
+        "LastAnchorTimestamp must equal the client-supplied timestamp"
+    );
+}


### PR DESCRIPTION
<html><head></head><body><h2>Resolves</h2><p>Closes #754 — [Contract] Add state migration scripts for upgrade-safe schema evolution<br>Closes #745 — [Contract] Add invariant test suite for tipping settlement correctness<br>Closes #737 — [Backend] Enrich OpenAPI docs with request/response examples for critical endpoints</p><hr><h2>What was done</h2><h3>#754 — Contract state migration scripts</h3><p><strong><code inline="">anonymous-tipping</code> contract (<code inline="">contracts/anonymous-tipping/src/lib.rs</code>)</strong></p><ul><li><p>Added <code inline="">SCHEMA_VERSION_INITIAL = 1</code> and <code inline="">SCHEMA_VERSION_CURRENT = 2</code> constants</p></li><li><p>Added <code inline="">DataKey::SchemaVersion</code> and <code inline="">DataKey::GlobalTipCount</code> variants (appended to preserve discriminant order)</p></li><li><p>Added <code inline="">migrate(env, caller)</code> — owner-gated, idempotent v1→v2 migration that initialises <code inline="">GlobalTipCount = 0</code></p></li><li><p>Added <code inline="">schema_version(env)</code> and <code inline="">global_tip_count(env)</code> read helpers</p></li><li><p>Updated <code inline="">send_tip_with_proof</code> to increment <code inline="">GlobalTipCount</code> when the v2 schema is active</p></li></ul><p><strong><code inline="">confession-anchor</code> contract (<code inline="">contracts/confession-anchor/src/lib.rs</code>)</strong></p><ul><li><p>Added <code inline="">ANCHOR_SCHEMA_VERSION_INITIAL = 1</code> and <code inline="">ANCHOR_SCHEMA_VERSION_CURRENT = 2</code> constants</p></li><li><p>Added <code inline="">DataKey::SchemaVersion</code> and <code inline="">DataKey::LastAnchorTimestamp</code> variants</p></li><li><p>Added <code inline="">migrate(env, caller)</code> — owner-gated, idempotent v1→v2 migration that initialises <code inline="">LastAnchorTimestamp = 0</code></p></li><li><p>Added <code inline="">schema_version(env)</code> and <code inline="">last_anchor_timestamp(env)</code> read helpers</p></li><li><p>Updated <code inline="">anchor_confession</code> to update <code inline="">LastAnchorTimestamp</code> when the v2 schema is active</p></li></ul><p><strong>Migration test suites</strong></p><ul><li><p><code inline="">contracts/anonymous-tipping/tests/migration.rs</code> — 15 tests (fixture states A/B/C, idempotency, rollback safety, auth enforcement)</p></li><li><p><code inline="">contracts/confession-anchor/tests/migration.rs</code> — 16 tests (pre-existing anchor preservation, idempotency, pause state, rollback)</p></li><li><p>Both registered as <code inline="">[[test]]</code> targets in their respective <code inline="">Cargo.toml</code> files</p></li></ul><p><strong>Rollback contract documented in tests:</strong> migrations are purely additive (new keys only). Rolling back the WASM to v1 is safe — the old code ignores the new keys.</p><hr><h3>#745 — Invariant test suite for tipping settlement</h3><p><strong><code inline="">contracts/anonymous-tipping/tests/invariants.rs</code></strong> — 23 deterministic tests covering:</p>
# | Invariant
-- | --
I1 | Balance conservation: recipient total == sum of all individual tips
I2 | Nonce monotonicity: each settlement returns prev + 1
I3 | Nonce coherence: latest_settlement_nonce() == total successful settlements
I4 | Balance non-regression: recipient totals never decrease
I5 | Precision: i128 accumulation is exact — no rounding for any amount
I6 | Rate limit bound: per-wallet count never exceeds configured cap
I7 | Pause completeness: all state-changing ops blocked while paused; reads remain
I8 | Invalid amounts (zero/negative) never mutate state
I9 | Overflow safety: TotalOverflow returned before silent i128 corruption
I10 | Recipient isolation: tipping one address never alters another's total
I11 | send_tip and send_tip_with_proof(None) produce identical outcomes
I12 | GlobalTipCount coherence with nonce post-migration

<p>All response schemas include concrete <code inline="">example</code> payloads matching real DTO constraints.</p></body></html>