### PR TITLE
feat(dlq): implement notification DLQ cleanup and replay functionalit…

### DIFF
--- a/xconfess-backend/src/audit-log/audit-log.service.spec.ts
+++ b/xconfess-backend/src/audit-log/audit-log.service.spec.ts
@@ -190,6 +190,54 @@ describe('AuditLogService', () => {
     );
   });
 
+  it('records notification DLQ cleanup audit entries with target summaries', async () => {
+    mockRepository.create.mockReturnValue({} as AuditLog);
+    mockRepository.save.mockResolvedValue({} as AuditLog);
+
+    await service.logNotificationDlqCleanup(
+      'admin-9',
+      {
+        cleanupType: 'bulk',
+        queue: 'notifications-dlq',
+        operationId: 'cleanup:admin-9:1',
+        targetJobIds: ['dlq-1', 'dlq-2'],
+        summary: {
+          attempted: 2,
+          removed: 1,
+          failed: 1,
+          noOp: false,
+        },
+        outcomes: [
+          { jobId: 'dlq-1', outcome: 'removed' },
+          { jobId: 'dlq-2', outcome: 'failed', error: 'redis timeout' },
+        ],
+      },
+      { requestId: 'req-clean-1', ipAddress: '10.0.0.7' },
+    );
+
+    expect(mockRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AuditActionType.NOTIFICATION_DLQ_CLEANUP,
+        metadata: expect.objectContaining({
+          entityType: 'notification_dlq',
+          cleanupType: 'bulk',
+          queue: 'notifications-dlq',
+          operationId: 'cleanup:admin-9:1',
+          targetJobIds: ['dlq-1', 'dlq-2'],
+          summary: expect.objectContaining({
+            attempted: 2,
+            removed: 1,
+            failed: 1,
+          }),
+          actorType: 'admin',
+          actorId: 'admin-9',
+        }),
+        requestId: 'req-clean-1',
+        ipAddress: '10.0.0.7',
+      }),
+    );
+  });
+
   it('tags admin moderation actions with admin actor metadata', async () => {
     mockRepository.create.mockReturnValue({} as AuditLog);
     mockRepository.save.mockResolvedValue({} as AuditLog);

--- a/xconfess-backend/src/audit-log/audit-log.service.ts
+++ b/xconfess-backend/src/audit-log/audit-log.service.ts
@@ -345,13 +345,20 @@ export class AuditLogService {
     metadata: {
       replayType: 'single' | 'bulk';
       queue: string;
+      operationId?: string;
       jobId?: string;
+      targetJobIds?: string[];
+      targetJobs?: Array<Record<string, unknown>>;
       filters?: Record<string, any>;
       summary?: {
         attempted: number;
         replayed: number;
         failed: number;
+        deduplicated?: number;
+        removed?: number;
+        noOp?: boolean;
       };
+      outcomes?: Array<Record<string, unknown>>;
       reason?: string | null;
       replayedAt?: string;
     },
@@ -363,6 +370,45 @@ export class AuditLogService {
         entityType: 'notification_dlq',
         ...metadata,
         replayedAt: metadata.replayedAt || new Date().toISOString(),
+      },
+      context: {
+        ...context,
+        userId: adminId,
+        actor: this.createActor('admin', adminId),
+      },
+    });
+  }
+
+  async logNotificationDlqCleanup(
+    adminId: string,
+    metadata: {
+      cleanupType: 'bulk' | 'retention';
+      queue: string;
+      operationId?: string;
+      targetJobIds?: string[];
+      targetJobs?: Array<Record<string, unknown>>;
+      filters?: Record<string, any>;
+      summary?: {
+        attempted: number;
+        removed: number;
+        failed: number;
+        noOp?: boolean;
+      };
+      outcomes?: Array<Record<string, unknown>>;
+      reason?: string | null;
+      cleanedAt?: string;
+      retentionDays?: number;
+      batchSize?: number;
+      dryRun?: boolean;
+    },
+    context?: AuditLogContext,
+  ): Promise<void> {
+    await this.log({
+      actionType: AuditActionType.NOTIFICATION_DLQ_CLEANUP,
+      metadata: {
+        entityType: 'notification_dlq',
+        ...metadata,
+        cleanedAt: metadata.cleanedAt || new Date().toISOString(),
       },
       context: {
         ...context,

--- a/xconfess-backend/src/notifications/dlq-admin.controller.ts
+++ b/xconfess-backend/src/notifications/dlq-admin.controller.ts
@@ -11,11 +11,28 @@ import {
 import { JobManagementService } from './services/job-management.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
+import { AuditLogContext } from '../audit-log/audit-log.service';
 
 @Controller('admin/dlq')
 @UseGuards(JwtAuthGuard, AdminGuard)
 export class DlqAdminController {
   constructor(private readonly jobManagementService: JobManagementService) {}
+
+  private buildAuditContext(req: any): AuditLogContext {
+    const userAgentHeader = req?.headers?.['user-agent'];
+
+    return {
+      requestId:
+        req?.requestId ||
+        req?.id ||
+        (typeof req?.headers?.['x-request-id'] === 'string'
+          ? req.headers['x-request-id']
+          : undefined),
+      ipAddress: req?.ip || req?.socket?.remoteAddress,
+      userAgent:
+        typeof userAgentHeader === 'string' ? userAgentHeader : undefined,
+    };
+  }
 
   @Get()
   async list(
@@ -35,13 +52,22 @@ export class DlqAdminController {
   @Post(':id/retry')
   async retry(@Param('id') id: string, @Req() req: any) {
     const actorId = String(req.user?.id);
-    return this.jobManagementService.replayDlqJob(id, actorId);
+    return this.jobManagementService.replayDlqJob(
+      id,
+      actorId,
+      undefined,
+      this.buildAuditContext(req),
+    );
   }
 
   @Post('replay-bulk')
   async replayBulk(@Req() req: any, @Query() options: any) {
     const actorId = String(req.user?.id);
-    return this.jobManagementService.replayDlqJobsBulk(actorId, options);
+    return this.jobManagementService.replayDlqJobsBulk(
+      actorId,
+      options,
+      this.buildAuditContext(req),
+    );
   }
 
   @Delete(':id')
@@ -51,8 +77,13 @@ export class DlqAdminController {
   }
 
   @Post('cleanup')
-  async cleanup(@Query() options: any) {
-    return this.jobManagementService.cleanupDlq(options);
+  async cleanup(@Req() req: any, @Query() options: any) {
+    const actorId = String(req.user?.id);
+    return this.jobManagementService.cleanupDlq(
+      actorId,
+      options,
+      this.buildAuditContext(req),
+    );
   }
 
   @Get('diagnostics')

--- a/xconfess-backend/src/notifications/processors/notification.processor.ts
+++ b/xconfess-backend/src/notifications/processors/notification.processor.ts
@@ -18,6 +18,9 @@ export interface NotificationJobData {
     failedAt: string;
     attemptsMade: number;
     lastError: string;
+    replayJobId?: string;
+    replayedAt?: string;
+    replayOutcome?: 'replayed' | 'deduplicated';
   };
 }
 

--- a/xconfess-backend/src/notifications/services/job-management.service.spec.ts
+++ b/xconfess-backend/src/notifications/services/job-management.service.spec.ts
@@ -1,0 +1,336 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bullmq';
+import { ConfigService } from '@nestjs/config';
+import { Queue } from 'bullmq';
+import { JobManagementService } from './job-management.service';
+import {
+  NOTIFICATION_DLQ,
+  NOTIFICATION_QUEUE,
+  NotificationJobData,
+} from '../processors/notification.processor';
+import { AuditLogService } from '../../audit-log/audit-log.service';
+import { AppLogger } from '../../logger/logger.service';
+
+type MockJob = {
+  id: string;
+  data: NotificationJobData;
+  timestamp: number;
+  remove: jest.Mock<Promise<void>, []>;
+  updateData: jest.Mock<Promise<void>, [NotificationJobData]>;
+};
+
+describe('JobManagementService', () => {
+  let service: JobManagementService;
+  let mainQueue: jest.Mocked<
+    Pick<Queue<NotificationJobData>, 'add' | 'getJob' | 'getJobCounts'>
+  >;
+  let dlqQueue: jest.Mocked<
+    Pick<Queue<NotificationJobData>, 'getJob' | 'getJobs' | 'getJobCounts'>
+  >;
+  let auditLogService: jest.Mocked<
+    Pick<
+      AuditLogService,
+      'logNotificationDlqReplay' | 'logNotificationDlqCleanup'
+    >
+  >;
+  let appLogger: jest.Mocked<Pick<AppLogger, 'emitEvent' | 'emitWarningEvent'>>;
+
+  const buildJob = (
+    id: string,
+    overrides?: Partial<NotificationJobData>,
+  ): MockJob => ({
+    id,
+    timestamp: Date.now(),
+    remove: jest.fn().mockResolvedValue(undefined),
+    updateData: jest.fn().mockResolvedValue(undefined),
+    data: {
+      userId: `user-${id}`,
+      type: 'message_notification',
+      title: `Job ${id}`,
+      message: `payload-${id}`,
+      metadata: { source: 'spec' },
+      _meta: {
+        originalJobId: `orig-${id}`,
+        failedAt: '2026-04-24T10:00:00.000Z',
+        attemptsMade: 5,
+        lastError: 'SMTP timeout',
+      },
+      ...overrides,
+    },
+  });
+
+  beforeEach(async () => {
+    mainQueue = {
+      add: jest.fn(),
+      getJob: jest.fn(),
+      getJobCounts: jest.fn().mockResolvedValue({ waiting: 0 } as any),
+    };
+    dlqQueue = {
+      getJob: jest.fn(),
+      getJobs: jest.fn(),
+      getJobCounts: jest.fn().mockResolvedValue({
+        failed: 0,
+        completed: 0,
+        waiting: 0,
+        active: 0,
+        delayed: 0,
+      } as any),
+    };
+    auditLogService = {
+      logNotificationDlqReplay: jest.fn().mockResolvedValue(undefined),
+      logNotificationDlqCleanup: jest.fn().mockResolvedValue(undefined),
+    };
+    appLogger = {
+      emitEvent: jest.fn(),
+      emitWarningEvent: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobManagementService,
+        {
+          provide: getQueueToken(NOTIFICATION_QUEUE),
+          useValue: mainQueue,
+        },
+        {
+          provide: getQueueToken(NOTIFICATION_DLQ),
+          useValue: dlqQueue,
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue: unknown) => defaultValue),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: auditLogService,
+        },
+        {
+          provide: AppLogger,
+          useValue: appLogger,
+        },
+      ],
+    }).compile();
+
+    service = module.get(JobManagementService);
+  });
+
+  it('replays bulk DLQ jobs with replay-safe deduplication and audit context', async () => {
+    const replayableJob = buildJob('dlq-1');
+    const duplicateJob = buildJob('dlq-2');
+
+    dlqQueue.getJobs.mockResolvedValue([replayableJob as any, duplicateJob as any]);
+    mainQueue.getJob
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({ id: 'dlq-replay:orig-dlq-2' } as any);
+    mainQueue.add.mockResolvedValue({ id: 'dlq-replay:orig-dlq-1' } as any);
+
+    const result = await service.replayDlqJobsBulk(
+      '42',
+      { ids: 'dlq-1,dlq-2' },
+      {
+        requestId: 'req-dlq-1',
+        ipAddress: '127.0.0.1',
+        userAgent: 'jest',
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: 2,
+      replayed: 1,
+      deduplicated: 1,
+      failed: 0,
+      noOp: false,
+    });
+    expect(mainQueue.add).toHaveBeenCalledWith(
+      'send-notification',
+      expect.objectContaining({
+        userId: 'user-dlq-1',
+        type: 'message_notification',
+      }),
+      {
+        jobId: 'dlq-replay:orig-dlq-1',
+      },
+    );
+    expect(replayableJob.updateData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _meta: expect.objectContaining({
+          replayJobId: 'dlq-replay:orig-dlq-1',
+          replayOutcome: 'replayed',
+          replayedAt: expect.any(String),
+        }),
+      }),
+    );
+    expect(duplicateJob.updateData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _meta: expect.objectContaining({
+          replayJobId: 'dlq-replay:orig-dlq-2',
+          replayOutcome: 'deduplicated',
+          replayedAt: expect.any(String),
+        }),
+      }),
+    );
+    expect(replayableJob.remove).toHaveBeenCalledTimes(1);
+    expect(duplicateJob.remove).toHaveBeenCalledTimes(1);
+    expect(auditLogService.logNotificationDlqReplay).toHaveBeenCalledWith(
+      '42',
+      expect.objectContaining({
+        replayType: 'bulk',
+        targetJobIds: ['dlq-1', 'dlq-2'],
+        summary: expect.objectContaining({
+          attempted: 2,
+          replayed: 1,
+          deduplicated: 1,
+          failed: 0,
+        }),
+        outcomes: expect.arrayContaining([
+          expect.objectContaining({
+            jobId: 'dlq-1',
+            outcome: 'replayed',
+          }),
+          expect.objectContaining({
+            jobId: 'dlq-2',
+            outcome: 'deduplicated',
+          }),
+        ]),
+      }),
+      expect.objectContaining({
+        requestId: 'req-dlq-1',
+        ipAddress: '127.0.0.1',
+        userAgent: 'jest',
+      }),
+    );
+  });
+
+  it('records partial success for cleanup drain operations', async () => {
+    const removableJob = buildJob('dlq-3');
+    const stuckJob = buildJob('dlq-4');
+    stuckJob.remove.mockRejectedValue(new Error('redis timeout'));
+
+    dlqQueue.getJobs.mockResolvedValue([removableJob as any, stuckJob as any]);
+
+    const result = await service.cleanupDlq(
+      '7',
+      { mode: 'drain', ids: 'dlq-3,dlq-4' },
+      { requestId: 'req-cleanup-1' },
+    );
+
+    expect(result).toMatchObject({
+      mode: 'drain',
+      attempted: 2,
+      removed: 1,
+      failed: 1,
+      noOp: false,
+    });
+    expect(auditLogService.logNotificationDlqCleanup).toHaveBeenCalledWith(
+      '7',
+      expect.objectContaining({
+        cleanupType: 'bulk',
+        targetJobIds: ['dlq-3', 'dlq-4'],
+        summary: expect.objectContaining({
+          attempted: 2,
+          removed: 1,
+          failed: 1,
+        }),
+        outcomes: expect.arrayContaining([
+          expect.objectContaining({
+            jobId: 'dlq-3',
+            outcome: 'removed',
+          }),
+          expect.objectContaining({
+            jobId: 'dlq-4',
+            outcome: 'failed',
+            error: 'redis timeout',
+          }),
+        ]),
+      }),
+      expect.objectContaining({
+        requestId: 'req-cleanup-1',
+      }),
+    );
+    expect(appLogger.emitWarningEvent).toHaveBeenCalled();
+  });
+
+  it('treats repeated bulk replay with no matching DLQ jobs as a safe no-op', async () => {
+    dlqQueue.getJobs.mockResolvedValue([]);
+
+    const result = await service.replayDlqJobsBulk(
+      '15',
+      { ids: 'missing-1,missing-2' },
+      { requestId: 'req-dlq-noop' },
+    );
+
+    expect(result).toMatchObject({
+      attempted: 0,
+      replayed: 0,
+      deduplicated: 0,
+      failed: 0,
+      noOp: true,
+      outcomes: [],
+    });
+    expect(mainQueue.add).not.toHaveBeenCalled();
+    expect(auditLogService.logNotificationDlqReplay).toHaveBeenCalledWith(
+      '15',
+      expect.objectContaining({
+        replayType: 'bulk',
+        targetJobIds: [],
+        summary: expect.objectContaining({
+          attempted: 0,
+          noOp: true,
+        }),
+      }),
+      expect.objectContaining({
+        requestId: 'req-dlq-noop',
+      }),
+    );
+  });
+
+  it('treats a previously marked replay as deduplicated even if the main queue job is gone', async () => {
+    const staleReplayedJob = buildJob('dlq-5', {
+      _meta: {
+        originalJobId: 'orig-dlq-5',
+        failedAt: '2026-04-24T10:00:00.000Z',
+        attemptsMade: 5,
+        lastError: 'SMTP timeout',
+        replayJobId: 'dlq-replay:orig-dlq-5',
+        replayedAt: '2026-04-25T11:00:00.000Z',
+        replayOutcome: 'replayed',
+      },
+    });
+
+    dlqQueue.getJobs.mockResolvedValue([staleReplayedJob as any]);
+
+    const result = await service.replayDlqJobsBulk(
+      '18',
+      { ids: 'dlq-5' },
+      { requestId: 'req-dlq-stale' },
+    );
+
+    expect(result).toMatchObject({
+      attempted: 1,
+      replayed: 0,
+      deduplicated: 1,
+      failed: 0,
+      noOp: false,
+    });
+    expect(mainQueue.getJob).not.toHaveBeenCalled();
+    expect(mainQueue.add).not.toHaveBeenCalled();
+    expect(staleReplayedJob.remove).toHaveBeenCalledTimes(1);
+    expect(auditLogService.logNotificationDlqReplay).toHaveBeenCalledWith(
+      '18',
+      expect.objectContaining({
+        outcomes: expect.arrayContaining([
+          expect.objectContaining({
+            jobId: 'dlq-5',
+            outcome: 'deduplicated',
+            existingJobId: 'dlq-replay:orig-dlq-5',
+          }),
+        ]),
+      }),
+      expect.objectContaining({
+        requestId: 'req-dlq-stale',
+      }),
+    );
+  });
+});

--- a/xconfess-backend/src/notifications/services/job-management.service.ts
+++ b/xconfess-backend/src/notifications/services/job-management.service.ts
@@ -1,25 +1,48 @@
-import { Injectable, Logger, Inject, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue, Job } from 'bullmq';
 import { ConfigService } from '@nestjs/config';
 import { AppLogger } from '../../logger/logger.service';
-import { AuditLogService } from '../../audit-log/audit-log.service';
-import { AuditActionType } from '../../audit-log/audit-log.entity';
+import {
+  AuditLogContext,
+  AuditLogService,
+} from '../../audit-log/audit-log.service';
 import {
   NOTIFICATION_QUEUE,
   NOTIFICATION_DLQ,
   NotificationJobData,
 } from '../processors/notification.processor';
+import { getDlqRetentionConfig } from '../../config/dlq-retention.config';
 
 export interface DlqJobFilter {
   failedAfter?: string;
   failedBefore?: string;
   search?: string;
+  jobIds?: string[];
+}
+
+interface DlqReplayOutcome {
+  jobId: string;
+  originalJobId: string | null;
+  replayJobId: string;
+  outcome: 'replayed' | 'deduplicated' | 'failed';
+  newJobId?: string;
+  existingJobId?: string;
+  error?: string;
+}
+
+interface DlqCleanupOutcome {
+  jobId: string;
+  originalJobId: string | null;
+  outcome: 'removed' | 'failed';
+  error?: string;
 }
 
 @Injectable()
 export class JobManagementService {
-  private readonly logger = new Logger(JobManagementService.name);
+  private readonly dlqStates: Array<
+    'failed' | 'completed' | 'waiting' | 'active' | 'delayed'
+  > = ['failed', 'completed', 'waiting', 'active', 'delayed'];
 
   constructor(
     @InjectQueue(NOTIFICATION_QUEUE)
@@ -35,12 +58,7 @@ export class JobManagementService {
     const start = (page - 1) * limit;
     const end = start + limit - 1;
 
-    const jobs = await this.dlq.getJobs(
-      ['failed', 'completed', 'waiting', 'active', 'delayed'],
-      start,
-      end,
-      true,
-    );
+    const jobs = await this.dlq.getJobs(this.dlqStates, start, end, true);
 
     const totalObj = await this.dlq.getJobCounts();
     const totalCount =
@@ -53,29 +71,7 @@ export class JobManagementService {
     // Apply filtering if provided (Bull's getJobs doesn't filter by payload/reason out of the box easily)
     let filteredJobs = jobs;
     if (filter) {
-      filteredJobs = jobs.filter((job) => {
-        const failedAt = job.data._meta?.failedAt
-          ? new Date(job.data._meta.failedAt)
-          : null;
-        if (
-          filter.failedAfter &&
-          failedAt &&
-          failedAt < new Date(filter.failedAfter)
-        )
-          return false;
-        if (
-          filter.failedBefore &&
-          failedAt &&
-          failedAt > new Date(filter.failedBefore)
-        )
-          return false;
-        if (filter.search) {
-          const search = filter.search.toLowerCase();
-          const content = JSON.stringify(job.data).toLowerCase();
-          if (!content.includes(search)) return false;
-        }
-        return true;
-      });
+      filteredJobs = jobs.filter((job) => this.matchesDlqFilter(job, filter));
     }
 
     return {
@@ -95,61 +91,137 @@ export class JobManagementService {
     };
   }
 
-  async replayDlqJob(jobId: string, actorId: string, reason?: string) {
+  async replayDlqJob(
+    jobId: string,
+    actorId: string,
+    reason?: string,
+    context?: AuditLogContext,
+  ) {
     const job = await this.dlq.getJob(jobId);
     if (!job) throw new NotFoundException(`DLQ job ${jobId} not found`);
 
-    const { _meta, ...payload } = job.data;
-    const newJob = await this.mainQueue.add('send-notification', payload);
-    await job.remove();
+    const operationId = this.buildOperationId('single-replay', actorId);
+    const outcome = await this.replayJobSafely(job);
+    const summary = this.buildReplaySummary([outcome]);
 
     await this.auditLogService.logNotificationDlqReplay(actorId, {
       replayType: 'single',
       queue: NOTIFICATION_QUEUE,
+      operationId,
       jobId: String(job.id),
+      targetJobIds: [String(job.id)],
+      targetJobs: [this.toAuditTarget(job)],
+      outcomes: [outcome],
+      summary,
       reason: reason || null,
       replayedAt: new Date().toISOString(),
-    });
+    }, context);
 
-    return { id: job.id, newJobId: newJob.id };
+    this.emitReplayObservability(operationId, actorId, summary, context);
+
+    return {
+      id: job.id,
+      outcome: outcome.outcome,
+      replayJobId: outcome.replayJobId,
+      newJobId: outcome.newJobId ?? outcome.existingJobId ?? null,
+    };
   }
 
-  async replayDlqJobsBulk(actorId: string, options: any) {
-    const jobs = await this.dlq.getJobs([
-      'failed',
-      'completed',
-      'waiting',
-      'active',
-      'delayed',
-    ]);
-    const attempted = jobs.length;
-    // Simplified bulk replay for space
-    let count = 0;
+  async replayDlqJobsBulk(
+    actorId: string,
+    options: any,
+    context?: AuditLogContext,
+  ) {
+    const filter = this.normalizeDlqFilter(options);
+    const jobs = await this.getFilteredDlqJobs(filter);
+    const operationId = this.buildOperationId('bulk-replay', actorId);
+    const outcomes: DlqReplayOutcome[] = [];
+
     for (const job of jobs) {
-      const { _meta, ...payload } = job.data;
-      await this.mainQueue.add('send-notification', payload);
-      await job.remove();
-      count++;
+      outcomes.push(await this.replayJobSafely(job));
     }
+
+    const summary = this.buildReplaySummary(outcomes);
 
     await this.auditLogService.logNotificationDlqReplay(actorId, {
       replayType: 'bulk',
       queue: NOTIFICATION_QUEUE,
-      summary: {
-        attempted,
-        replayed: count,
-        failed: Math.max(0, attempted - count),
-      },
+      operationId,
+      filters: filter,
+      targetJobIds: jobs.map((job) => String(job.id)),
+      targetJobs: jobs.map((job) => this.toAuditTarget(job)),
+      outcomes,
+      summary,
       replayedAt: new Date().toISOString(),
-    });
+    }, context);
 
-    return { count };
+    this.emitReplayObservability(operationId, actorId, summary, context);
+
+    return {
+      operationId,
+      ...summary,
+      outcomes,
+    };
   }
 
-  async cleanupDlq(options: any) {
-    // Ported logic from old NotificationQueue
-    await this.dlq.clean(1000 * 60 * 60 * 24 * 7, 1000, 'failed'); // 7 days, max 1000
-    return { cleaned: true };
+  async cleanupDlq(
+    actorId: string,
+    options: any,
+    context?: AuditLogContext,
+  ) {
+    const retentionConfig = getDlqRetentionConfig(this.configService);
+    const filter = this.normalizeDlqFilter(options);
+    const requestedMode =
+      typeof options?.mode === 'string' ? options.mode.toLowerCase() : null;
+    const hasExplicitTargeting =
+      Boolean(filter.search) ||
+      Boolean(filter.failedAfter) ||
+      Boolean(filter.failedBefore) ||
+      Boolean(filter.jobIds?.length);
+    const useRetentionMode =
+      requestedMode === 'retention' ||
+      (requestedMode !== 'drain' && !hasExplicitTargeting);
+    const operationId = this.buildOperationId(
+      useRetentionMode ? 'retention-cleanup' : 'bulk-cleanup',
+      actorId,
+    );
+
+    const result = useRetentionMode
+      ? await this.runRetentionCleanup(options, retentionConfig)
+      : await this.runBulkCleanup(filter);
+
+    await this.auditLogService.logNotificationDlqCleanup(
+      actorId,
+      {
+        cleanupType: useRetentionMode ? 'retention' : 'bulk',
+        queue: NOTIFICATION_DLQ,
+        operationId,
+        filters: result.filters,
+        targetJobIds: result.targetJobIds,
+        targetJobs: result.targetJobs,
+        outcomes: result.outcomes,
+        summary: result.summary,
+        retentionDays: result.retentionDays,
+        batchSize: result.batchSize,
+        dryRun: result.dryRun,
+      },
+      context,
+    );
+
+    this.emitCleanupObservability(
+      operationId,
+      actorId,
+      result.summary,
+      context,
+      useRetentionMode,
+    );
+
+    return {
+      operationId,
+      mode: useRetentionMode ? 'retention' : 'drain',
+      ...result.summary,
+      outcomes: result.outcomes,
+    };
   }
 
   async getDiagnostics() {
@@ -162,5 +234,429 @@ export class JobManagementService {
       main: mainCounts,
       dlq: dlqCounts,
     };
+  }
+
+  private normalizeDlqFilter(options?: any): DlqJobFilter {
+    return {
+      failedAfter:
+        typeof options?.failedAfter === 'string' ? options.failedAfter : undefined,
+      failedBefore:
+        typeof options?.failedBefore === 'string'
+          ? options.failedBefore
+          : undefined,
+      search: typeof options?.search === 'string' ? options.search : undefined,
+      jobIds: this.parseListOption(options?.jobIds ?? options?.ids),
+    };
+  }
+
+  private parseListOption(value: unknown): string[] | undefined {
+    if (Array.isArray(value)) {
+      const parsed = value
+        .flatMap((entry) =>
+          typeof entry === 'string' ? entry.split(',') : String(entry),
+        )
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      return parsed.length > 0 ? parsed : undefined;
+    }
+
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    const parsed = value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    return parsed.length > 0 ? parsed : undefined;
+  }
+
+  private matchesDlqFilter(
+    job: Job<NotificationJobData>,
+    filter: DlqJobFilter,
+  ): boolean {
+    if (filter.jobIds?.length && !filter.jobIds.includes(String(job.id))) {
+      return false;
+    }
+
+    const failedAt = job.data._meta?.failedAt
+      ? new Date(job.data._meta.failedAt)
+      : null;
+    if (filter.failedAfter && failedAt && failedAt < new Date(filter.failedAfter)) {
+      return false;
+    }
+    if (
+      filter.failedBefore &&
+      failedAt &&
+      failedAt > new Date(filter.failedBefore)
+    ) {
+      return false;
+    }
+
+    if (filter.search) {
+      const search = filter.search.toLowerCase();
+      const content = JSON.stringify(job.data).toLowerCase();
+      if (!content.includes(search)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private async getFilteredDlqJobs(filter?: DlqJobFilter) {
+    const jobs = await this.dlq.getJobs(this.dlqStates);
+    return filter ? jobs.filter((job) => this.matchesDlqFilter(job, filter)) : jobs;
+  }
+
+  private buildOperationId(action: string, actorId: string): string {
+    return `${action}:${actorId}:${Date.now()}`;
+  }
+
+  private getOriginalJobId(job: Job<NotificationJobData>): string | null {
+    return job.data._meta?.originalJobId || null;
+  }
+
+  private buildReplayJobId(job: Job<NotificationJobData>): string {
+    return `dlq-replay:${this.getOriginalJobId(job) || String(job.id)}`;
+  }
+
+  private toAuditTarget(job: Job<NotificationJobData>) {
+    return {
+      jobId: String(job.id),
+      originalJobId: this.getOriginalJobId(job),
+      type: job.data.type,
+      userId: job.data.userId,
+      failedAt: job.data._meta?.failedAt || null,
+      lastError: job.data._meta?.lastError || null,
+    };
+  }
+
+  private buildReplaySummary(outcomes: DlqReplayOutcome[]) {
+    const replayed = outcomes.filter((item) => item.outcome === 'replayed').length;
+    const deduplicated = outcomes.filter(
+      (item) => item.outcome === 'deduplicated',
+    ).length;
+    const failed = outcomes.filter((item) => item.outcome === 'failed').length;
+
+    return {
+      attempted: outcomes.length,
+      replayed,
+      deduplicated,
+      failed,
+      noOp: outcomes.length === 0,
+    };
+  }
+
+  private buildCleanupSummary(outcomes: DlqCleanupOutcome[]) {
+    const removed = outcomes.filter((item) => item.outcome === 'removed').length;
+    const failed = outcomes.filter((item) => item.outcome === 'failed').length;
+
+    return {
+      attempted: outcomes.length,
+      removed,
+      failed,
+      noOp: outcomes.length === 0,
+    };
+  }
+
+  private async replayJobSafely(
+    job: Job<NotificationJobData>,
+  ): Promise<DlqReplayOutcome> {
+    const jobId = String(job.id);
+    const originalJobId = this.getOriginalJobId(job);
+    const replayJobId = this.buildReplayJobId(job);
+    const recordedReplayJobId = job.data._meta?.replayJobId;
+
+    if (recordedReplayJobId) {
+      try {
+        await job.remove();
+      } catch (error: unknown) {
+        return {
+          jobId,
+          originalJobId,
+          replayJobId: recordedReplayJobId,
+          outcome: 'failed',
+          existingJobId: recordedReplayJobId,
+          error:
+            error instanceof Error
+              ? error.message
+              : 'failed to remove already replayed DLQ job',
+        };
+      }
+
+      return {
+        jobId,
+        originalJobId,
+        replayJobId: recordedReplayJobId,
+        outcome: 'deduplicated',
+        existingJobId: recordedReplayJobId,
+      };
+    }
+
+    const existingJob = await this.mainQueue.getJob(replayJobId);
+
+    if (existingJob) {
+      await this.markJobAsReplayed(job, replayJobId, 'deduplicated');
+      try {
+        await job.remove();
+      } catch (error: unknown) {
+        return {
+          jobId,
+          originalJobId,
+          replayJobId,
+          outcome: 'failed',
+          existingJobId: String(existingJob.id),
+          error:
+            error instanceof Error ? error.message : 'failed to remove stale DLQ job',
+        };
+      }
+
+      return {
+        jobId,
+        originalJobId,
+        replayJobId,
+        outcome: 'deduplicated',
+        existingJobId: String(existingJob.id),
+      };
+    }
+
+    const { _meta, ...payload } = job.data;
+
+    try {
+      const newJob = await this.mainQueue.add('send-notification', payload, {
+        jobId: replayJobId,
+      });
+      await this.markJobAsReplayed(job, replayJobId, 'replayed');
+      try {
+        await job.remove();
+      } catch (error: unknown) {
+        return {
+          jobId,
+          originalJobId,
+          replayJobId,
+          outcome: 'failed',
+          newJobId: String(newJob.id),
+          error:
+            error instanceof Error
+              ? error.message
+              : 'replayed but failed to remove stale DLQ job',
+        };
+      }
+
+      return {
+        jobId,
+        originalJobId,
+        replayJobId,
+        outcome: 'replayed',
+        newJobId: String(newJob.id),
+      };
+    } catch (error: unknown) {
+      return {
+        jobId,
+        originalJobId,
+        replayJobId,
+        outcome: 'failed',
+        error: error instanceof Error ? error.message : 'replay failed',
+      };
+    }
+  }
+
+  private async markJobAsReplayed(
+    job: Job<NotificationJobData>,
+    replayJobId: string,
+    replayOutcome: 'replayed' | 'deduplicated',
+  ) {
+    if (typeof job.updateData !== 'function') {
+      return;
+    }
+
+    await job.updateData({
+      ...job.data,
+      _meta: {
+        ...job.data._meta,
+        replayJobId,
+        replayOutcome,
+        replayedAt: new Date().toISOString(),
+      },
+    });
+  }
+
+  private async runBulkCleanup(filter: DlqJobFilter) {
+    const jobs = await this.getFilteredDlqJobs(filter);
+    const outcomes: DlqCleanupOutcome[] = [];
+
+    for (const job of jobs) {
+      try {
+        await job.remove();
+        outcomes.push({
+          jobId: String(job.id),
+          originalJobId: this.getOriginalJobId(job),
+          outcome: 'removed',
+        });
+      } catch (error: unknown) {
+        outcomes.push({
+          jobId: String(job.id),
+          originalJobId: this.getOriginalJobId(job),
+          outcome: 'failed',
+          error: error instanceof Error ? error.message : 'cleanup failed',
+        });
+      }
+    }
+
+    return {
+      filters: filter,
+      targetJobIds: jobs.map((job) => String(job.id)),
+      targetJobs: jobs.map((job) => this.toAuditTarget(job)),
+      outcomes,
+      summary: this.buildCleanupSummary(outcomes),
+      retentionDays: undefined,
+      batchSize: undefined,
+      dryRun: undefined,
+    };
+  }
+
+  private async runRetentionCleanup(
+    options: any,
+    defaults: ReturnType<typeof getDlqRetentionConfig>,
+  ) {
+    const retentionDays =
+      Number.parseInt(String(options?.retentionDays ?? defaults.retentionDays), 10) ||
+      defaults.retentionDays;
+    const batchSize =
+      Number.parseInt(
+        String(options?.batchSize ?? defaults.cleanupBatchSize),
+        10,
+      ) || defaults.cleanupBatchSize;
+    const dryRun =
+      typeof options?.dryRun === 'string'
+        ? options.dryRun === 'true'
+        : Boolean(options?.dryRun ?? defaults.dryRun);
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+    const jobs = (await this.getFilteredDlqJobs()).filter((job) => {
+      const failedAt = job.data._meta?.failedAt;
+      return Boolean(failedAt) && new Date(failedAt) <= cutoff;
+    });
+    const selectedJobs = jobs.slice(0, batchSize);
+    const outcomes: DlqCleanupOutcome[] = [];
+
+    if (!dryRun) {
+      for (const job of selectedJobs) {
+        try {
+          await job.remove();
+          outcomes.push({
+            jobId: String(job.id),
+            originalJobId: this.getOriginalJobId(job),
+            outcome: 'removed',
+          });
+        } catch (error: unknown) {
+          outcomes.push({
+            jobId: String(job.id),
+            originalJobId: this.getOriginalJobId(job),
+            outcome: 'failed',
+            error: error instanceof Error ? error.message : 'cleanup failed',
+          });
+        }
+      }
+    }
+
+    return {
+      filters: {
+        failedBefore: cutoff.toISOString(),
+      },
+      targetJobIds: selectedJobs.map((job) => String(job.id)),
+      targetJobs: selectedJobs.map((job) => this.toAuditTarget(job)),
+      outcomes,
+      summary: dryRun
+        ? {
+            attempted: selectedJobs.length,
+            removed: 0,
+            failed: 0,
+            noOp: selectedJobs.length === 0,
+          }
+        : this.buildCleanupSummary(outcomes),
+      retentionDays,
+      batchSize,
+      dryRun,
+    };
+  }
+
+  private emitReplayObservability(
+    operationId: string,
+    actorId: string,
+    summary: {
+      attempted: number;
+      replayed: number;
+      deduplicated: number;
+      failed: number;
+      noOp: boolean;
+    },
+    context?: AuditLogContext,
+  ) {
+    this.appLogger.emitEvent(
+      'info',
+      'notification.dlq.bulk_replay',
+      {
+        operationId,
+        actorId,
+        ...summary,
+      },
+      'NotificationDLQ',
+      context?.requestId,
+    );
+
+    if (summary.failed > 0) {
+      this.appLogger.emitWarningEvent(
+        'notification.dlq.bulk_replay_partial_failure',
+        {
+          operationId,
+          actorId,
+          ...summary,
+        },
+        'NotificationDLQ',
+        context?.requestId,
+      );
+    }
+  }
+
+  private emitCleanupObservability(
+    operationId: string,
+    actorId: string,
+    summary: {
+      attempted: number;
+      removed: number;
+      failed: number;
+      noOp: boolean;
+    },
+    context: AuditLogContext | undefined,
+    retentionMode: boolean,
+  ) {
+    this.appLogger.emitEvent(
+      'info',
+      retentionMode
+        ? 'notification.dlq.retention_cleanup'
+        : 'notification.dlq.bulk_cleanup',
+      {
+        operationId,
+        actorId,
+        ...summary,
+      },
+      'NotificationDLQ',
+      context?.requestId,
+    );
+
+    if (summary.failed > 0) {
+      this.appLogger.emitWarningEvent(
+        'notification.dlq.bulk_cleanup_partial_failure',
+        {
+          operationId,
+          actorId,
+          ...summary,
+        },
+        'NotificationDLQ',
+        context?.requestId,
+      );
+    }
   }
 }


### PR DESCRIPTION
Summary
Hardened admin DLQ bulk replay and cleanup so repeated operator actions are safe, observable, and reconstructable from audit data.

What Changed
Added replay-safe semantics for notification DLQ bulk replay by using stable replay job IDs.
Prevented ambiguous repeat behavior by treating already-replayed stale DLQ entries as deduplicated outcomes.
Recorded replay markers on DLQ jobs before removal so retries remain safe even if cleanup/remove fails mid-operation.
Expanded DLQ audit logging to capture:
actor context
request metadata
operation ID
target job set
filters
per-job outcomes
replay / cleanup summaries
Updated admin DLQ controller paths to pass requestId, ipAddress, and userAgent into audit logging.
Added focused specs for replay dedupe, stale replay markers, partial cleanup failure, no-op replay, and cleanup audit logging.
Why
Bulk DLQ actions can fan out retried work. Repeating the same admin action should not create ambiguous queue state or weak audit evidence. This change makes repeated replay/cleanup attempts deterministic and reviewable.

Behavior Notes
Re-running a bulk replay after jobs were already replayed is now safe.
If a replay succeeded previously but the stale DLQ job was not removed, a later replay treats it as deduplicated instead of replaying again.
Bulk cleanup/drain now returns explicit per-job outcomes and logs partial success/failure clearly.
Empty repeated operations are logged as no-ops rather than silently succeeding.
Tests
Added/updated coverage for:

authenticated replay-safe bulk replay
partial success cleanup/drain
no-op repeat replay
stale replay marker deduplication
notification DLQ cleanup audit metadata
Verification
I prepared the code and tests, but I could not run Jest in the current environment because node / npm were not available on PATH here. Recommended local verification:

npm test -- --runTestsByPath src/notifications/services/job-management.service.spec.ts src/audit-log/audit-log.service.spec.ts
npm test -- notifications

closes #790 