### PR TITLE
feat: enhance empty and error states in ConfessionFeed component

### DIFF
--- a/xconfess-frontend/app/components/confession/ConfessionFeed.tsx
+++ b/xconfess-frontend/app/components/confession/ConfessionFeed.tsx
@@ -36,6 +36,13 @@ export const ConfessionFeed = () => {
     void refetch();
   };
 
+  const scrollToComposer = () => {
+    document.getElementById("composer")?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  };
+
   // Render pagination items
   const renderPaginationItems = () => {
     const items = [];
@@ -87,47 +94,61 @@ export const ConfessionFeed = () => {
 
   return (
     <div className="mx-auto w-full max-w-3xl py-2">
-      {/* Empty State */}
-      {isEmpty && (
-        <div className="luxury-panel rounded-[30px] p-10 text-center">
-          <p className="mb-3 font-editorial text-4xl text-[var(--foreground)]">
-            No confessions yet.
-          </p>
-          <p className="mb-5 text-sm leading-7 text-[var(--secondary)]">
-            Be the first to set the tone for the community.
-          </p>
-          <button
-            onClick={handleRetry}
-            className="rounded-full bg-[linear-gradient(135deg,var(--primary),var(--primary-deep))] px-5 py-2.5 text-sm font-medium text-white shadow-[0_18px_40px_-22px_rgba(143,109,60,0.85)] transition-colors hover:brightness-105"
+      {/* Reserve vertical space to avoid layout shifts between states */}
+      <div className="min-h-[320px] sm:min-h-[420px] md:min-h-[520px]">
+        {/* Empty State */}
+        {isEmpty && (
+          <div className="luxury-panel rounded-[30px] p-8 text-center">
+            <p className="mb-3 font-editorial text-3xl sm:text-4xl text-[var(--foreground)]">
+              No confessions yet.
+            </p>
+            <p className="mb-4 max-w-xl mx-auto text-sm leading-7 text-[var(--secondary)]">
+              Be the first to set the tone for the community — share something
+              thoughtful, kind, and true. Your first post helps others
+              understand what belongs here.
+            </p>
+            <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+              <button
+                onClick={() => scrollToComposer()}
+                className="rounded-full bg-[linear-gradient(135deg,var(--primary),var(--primary-deep))] px-5 py-2.5 text-sm font-medium text-white shadow-[0_18px_40px_-22px_rgba(143,109,60,0.85)] transition-colors hover:brightness-105"
+              >
+                Begin writing
+              </button>
+              <button
+                onClick={handleRetry}
+                className="rounded-full border border-[var(--border)] bg-[var(--surface-muted)] px-5 py-2.5 text-sm font-medium text-[var(--secondary)] transition-colors hover:bg-[var(--surface-strong)] hover:text-[var(--foreground)]"
+              >
+                Refresh
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Error State (do not expose raw technical errors) */}
+        {error && (
+          <ErrorState
+            error={undefined}
+            title="Unable to load feed"
+            description="We couldn't load recent confessions. Please try again or check your connection."
+            showRetry
+            onRetry={handleRetry}
+          />
+        )}
+
+        {/* Loading state (skeleton kept inside the reserved space to avoid jumps) */}
+        {isLoading && <ConfessionFeedSkeleton />}
+
+        {/* Confessions Grid */}
+        {!isEmpty && confessions.length > 0 && (
+          <div
+            className={`space-y-5 transition-opacity duration-200 ${isFetching && !isLoading ? "opacity-50" : "opacity-100"}`}
           >
-            Refresh
-          </button>
-        </div>
-      )}
-
-      {/* Error State */}
-      {error && (
-        <ErrorState
-          error={error.message ?? "Failed to load confessions"}
-          title="Failed to load confessions"
-          description="Something went wrong while fetching confessions."
-          showRetry
-          onRetry={handleRetry}
-        />
-      )}
-
-      {isLoading && <ConfessionFeedSkeleton />}
-
-      {/* Confessions Grid */}
-      {!isEmpty && confessions.length > 0 && (
-        <div
-          className={`space-y-5 transition-opacity duration-200 ${isFetching && !isLoading ? "opacity-50" : "opacity-100"}`}
-        >
-          {confessions.map((confession) => (
-            <ConfessionCard key={confession.id} confession={confession} />
-          ))}
-        </div>
-      )}
+            {confessions.map((confession) => (
+              <ConfessionCard key={confession.id} confession={confession} />
+            ))}
+          </div>
+        )}
+      </div>
 
       {/* Pagination Controls */}
       {!isEmpty && totalPages > 1 && (


### PR DESCRIPTION
#closes #905 

Summary
- This PR improves the confession feed UX when the feed is empty, while loading, and on API errors. It prevents layout shifts during loading, provides actionable guidance in the empty state, and replaces raw technical error output with a friendly retryable error panel.

Files changed
- [xconfess-frontend/app/components/confession/ConfessionFeed.tsx](xconfess-frontend/app/components/confession/ConfessionFeed.tsx)

Acceptance criteria mapping
- Empty state tells the user what they can do next: Added clear copy and two CTA buttons: "Begin writing" (scrolls to composer) and "Refresh".
- Loading state does not shift layout awkwardly: Reserved minimum vertical space for the feed so skeleton loading doesn't jump content.
- Error state offers retry and does not expose raw technical errors: ErrorState invoked with a user-friendly message and retry handler; raw error text is not displayed.
- States work on mobile and desktop widths: Responsive classes applied to empty and skeleton panels.

How to test (step-by-step)

1. Install dependencies

```bash
npm install
```

2. Start local infra (Postgres + Redis)

```bash
docker compose -f compose.yaml up -d
```

3. Ensure env files are present
- Configure `xconfess-backend/.env` and `xconfess-frontend/.env.local` per project README.

4. Start dev server

```bash
npm run dev
```

5. Verify loading state (no layout shift)
- In Chrome DevTools set Network throttling to "Slow 3G", then reload http://localhost:3000.
- Expectation: skeleton appears in the feed and reserved vertical space prevents content jumping when the feed finishes loading.

6. Verify empty state (helpful next actions)
- Visit `http://localhost:3000/?page=9999` (or otherwise force an empty response).
- Expectation: friendly panel with copy, "Begin writing" (scrolls to composer), and "Refresh".
- Click "Begin writing" -> page should smoothly scroll to the composer area (id `composer`).
- Click "Refresh" -> feed should retry fetching.

7. Verify error state (no raw error text)
- Temporarily stop or block the backend (or block requests to the backend in DevTools).
- Reload http://localhost:3000.
- Expectation: friendly error panel with retry button and no raw technical error details.
- Re-enable the backend and click Retry -> feed should reload.

8. Responsive checks
- In DevTools, test mobile viewport widths and repeat steps 5–7 to confirm UI remains usable.

9. Build check

```bash
npm run frontend:build
```

- Expectation: frontend build completes without errors.

Screenshots (attach to PR)
- Loading state (network throttled) — attach `loading.png`.
- Empty state (page forced to empty) — attach `empty.png`.
- Error state (backend blocked) — attach `error.png`.

Notes for reviewers
- The change is intentionally scoped to the feed component to keep the PR focused (per contributor notes).
- Empty state uses DOM id `composer` to scroll the user to the composer; no API or backend changes required.
- The ErrorState component was reused without modifying its signature — we pass a sanitized message so internal error stacks are not exposed.

#closes 