### PR TITLE
feat(health): clarify queue health when background jobs are disabled

### DIFF
--- a/xconfess-backend/.env.example
+++ b/xconfess-backend/.env.example
@@ -5,6 +5,11 @@ PORT=5000
 FRONTEND_URL=http://localhost:3000
 BACKEND_URL=http://localhost:5000
 
+# Background jobs — set to "true" to enable BullMQ workers (notifications, exports, drafts).
+# When disabled, queue health checks report mode=disabled instead of unhealthy.
+# Production: "true".  Local dev: "false" if Redis/workers aren't needed.
+ENABLE_BACKGROUND_JOBS=false
+
 # Database
 DB_HOST=localhost
 DB_PORT=55432

--- a/xconfess-backend/.env.sample
+++ b/xconfess-backend/.env.sample
@@ -5,6 +5,11 @@ PORT=5000
 FRONTEND_URL=http://localhost:3000
 BACKEND_URL=http://localhost:5000
 
+# Background jobs — set to "true" to enable BullMQ workers (notifications, exports, drafts).
+# When disabled, queue health checks report mode=disabled instead of unhealthy.
+# Production: "true".  Local dev: "false" if Redis/workers aren't needed.
+ENABLE_BACKGROUND_JOBS=false
+
 # Database
 DB_HOST=localhost
 DB_PORT=55432

--- a/xconfess-backend/src/health/HEALTH_CHECK_DOCUMENTATION.md
+++ b/xconfess-backend/src/health/HEALTH_CHECK_DOCUMENTATION.md
@@ -74,12 +74,12 @@ HTTP/1.1 200 OK
 
 Runs four health indicators in sequence via NestJS Terminus:
 
-1. **`database`** — TypeORM `pingCheck` against Postgres
-2. **`redis`** — custom `RedisHealthIndicator.isHealthy()`
-3. **`queues`** — custom `QueueHealthIndicator.isHealthy()` (BullMQ workers)
-4. **`schema`** — custom `SchemaReadinessHealthIndicator.isHealthy()` — validates the `anonymous_confessions` table has all required columns and indexes via `MigrationVerificationService.checkConfessionSchema()`
+ 1. **`database`** — TypeORM `pingCheck` against Postgres
+ 2. **`redis`** — custom `RedisHealthIndicator.isHealthy()`
+ 3. **`queues`** — custom `QueueHealthIndicator.isHealthy()` (BullMQ workers). Returns `mode: 'disabled'` when `ENABLE_BACKGROUND_JOBS !== 'true'` — see Queue health troubleshooting below.
+ 4. **`schema`** — custom `SchemaReadinessHealthIndicator.isHealthy()` — validates the `anonymous_confessions` table has all required columns and indexes via `MigrationVerificationService.checkConfessionSchema()`
 
-All four must pass for the endpoint to return `200 OK`. A single failure causes the whole probe to return `503 Service Unavailable` with per-check detail in the body.
+ All four must pass for the endpoint to return `200 OK` (the queues check "passes" either by having healthy workers or by being explicitly disabled). A single non-disabled failure causes the whole probe to return `503 Service Unavailable` with per-check detail in the body.
 
 **Response — all healthy**
 
@@ -282,6 +282,67 @@ redis-cli ping
 | Stalled jobs blocking the queue | Inspect via Bull Board or drain manually |
 
 > **Note:** The key in the response body is `queues` (plural), matching the `key` argument passed in the controller. Use this when grepping logs or writing alerting rules.
+
+---
+
+### Queue health — disabled mode (local development)
+
+When `ENABLE_BACKGROUND_JOBS` is **not** set to the exact string `"true"`, the queue health indicator returns a `disabled` mode instead of checking individual queues. This prevents the readiness probe from failing in environments where BullMQ workers are intentionally absent (e.g. local development without Redis, or CI pipelines that only need the HTTP layer).
+
+**Response — disabled (intentional, `"false"`)**
+
+```json
+"queues": {
+  "status": "up",
+  "mode": "disabled",
+  "reason": "ENABLE_BACKGROUND_JOBS is set to \"false\" (background jobs intentionally disabled)",
+  "severity": "info"
+}
+```
+
+**Response — disabled (not configured)**
+
+```json
+"queues": {
+  "status": "up",
+  "mode": "disabled",
+  "reason": "ENABLE_BACKGROUND_JOBS is not set (defaults to disabled)",
+  "severity": "info"
+}
+```
+
+**Response — disabled (misconfigured)**
+
+```json
+"queues": {
+  "status": "up",
+  "mode": "disabled",
+  "reason": "ENABLE_BACKGROUND_JOBS is set to \"yes\" (expected \"true\" to enable)",
+  "severity": "info"
+}
+```
+
+**How to interpret the reason field**
+
+| `ENABLE_BACKGROUND_JOBS` value | Reason message includes | Meaning |
+|---|---|---|
+| `"false"` | `"intentionally disabled"` | Dev/CI — expected and fine |
+| `undefined` / not set | `"not set (defaults to disabled)"` | Might be accidental in production |
+| `"true"` | *(no disabled mode — queues are checked)* | Production — workers expected |
+| Any other value | `expected "true" to enable` | Likely a typo — fix to `"true"` |
+
+> **Important for production:** Always set `ENABLE_BACKGROUND_JOBS=true` in production environments. Omitting this variable (or setting it to anything other than `"true"`) causes the readiness probe to skip queue checks entirely — the probe will pass even if all workers are down.
+
+**Local vs production expectations**
+
+| Environment | `ENABLE_BACKGROUND_JOBS` | Queue health behavior |
+|---|---|---|
+| **Production** | `"true"` | Checks all 4 queues; fails probe if any worker-required queue has 0 workers |
+| **Staging** | `"true"` | Same as production — verifies workers are healthy before deployment |
+| **Local dev** | `"false"` (or unset) | Skips queue checks; readiness probe passes without Redis/BullMQ |
+| **CI pipeline** | `"false"` (or unset) | Avoids false failures when Redis is unavailable in CI |
+
+**Startup guard:** When `ENABLE_BACKGROUND_JOBS` is `"true"` but `REDIS_HOST` or `REDIS_PORT` is missing, the application **refuses to start** with a clear error message. This prevents a misconfigured production deployment from silently losing background job functionality.
 
 ---
 

--- a/xconfess-backend/src/health/queue.health.spec.ts
+++ b/xconfess-backend/src/health/queue.health.spec.ts
@@ -29,7 +29,7 @@ type MockQueue = ReturnType<typeof makeMockQueue>;
 
 function buildModule(
   queueOverrides: Partial<Record<QueueName, MockQueue>>,
-  jobsEnabled = true,
+  backgroundJobsValue?: string,
 ) {
   const queues = Object.fromEntries(
     QUEUE_NAMES.map((name) => [name, queueOverrides[name] ?? makeMockQueue()]),
@@ -43,9 +43,7 @@ function buildModule(
         useValue: {
           get: jest.fn((key: string) =>
             key === 'ENABLE_BACKGROUND_JOBS'
-              ? jobsEnabled
-                ? 'true'
-                : 'false'
+              ? backgroundJobsValue
               : undefined,
           ),
         },
@@ -62,22 +60,77 @@ describe('QueueHealthIndicator', () => {
   let indicator: QueueHealthIndicator;
 
   describe('when background jobs are disabled', () => {
-    beforeEach(async () => {
-      const module: TestingModule = await buildModule({}, false);
-      indicator = module.get(QueueHealthIndicator);
+    describe('with ENABLE_BACKGROUND_JOBS set to "false"', () => {
+      beforeEach(async () => {
+        const module: TestingModule = await buildModule({}, 'false');
+        indicator = module.get(QueueHealthIndicator);
+      });
+
+      it('returns up with mode=disabled and intentional disable reason', async () => {
+        const result = await indicator.isHealthy('queues');
+        expect(result.queues.status).toBe('up');
+        expect(result.queues).toMatchObject({
+          mode: 'disabled',
+          severity: 'info',
+        });
+        expect(result.queues.reason).toContain('"false"');
+        expect(result.queues.reason).toContain('intentionally disabled');
+      });
     });
 
-    it('returns up with mode=disabled and skips queue checks', async () => {
+    describe('with ENABLE_BACKGROUND_JOBS not set (undefined)', () => {
+      beforeEach(async () => {
+        const module: TestingModule = await buildModule({}, undefined);
+        indicator = module.get(QueueHealthIndicator);
+      });
+
+      it('returns up with mode=disabled and unset reason', async () => {
+        const result = await indicator.isHealthy('queues');
+        expect(result.queues.status).toBe('up');
+        expect(result.queues).toMatchObject({
+          mode: 'disabled',
+          severity: 'info',
+        });
+        expect(result.queues.reason).toContain('not set');
+        expect(result.queues.reason).toContain('defaults to disabled');
+      });
+    });
+
+    describe('with ENABLE_BACKGROUND_JOBS set to unexpected value', () => {
+      beforeEach(async () => {
+        const module: TestingModule = await buildModule({}, 'yes');
+        indicator = module.get(QueueHealthIndicator);
+      });
+
+      it('returns up with mode=disabled and misconfiguration reason', async () => {
+        const result = await indicator.isHealthy('queues');
+        expect(result.queues.status).toBe('up');
+        expect(result.queues).toMatchObject({
+          mode: 'disabled',
+          severity: 'info',
+        });
+        expect(result.queues.reason).toContain('"yes"');
+        expect(result.queues.reason).toContain('expected "true"');
+      });
+    });
+
+    it('skips queue checks entirely when disabled', async () => {
+      const module: TestingModule = await buildModule({}, 'false');
+      indicator = module.get(QueueHealthIndicator);
+
       const result = await indicator.isHealthy('queues');
-      expect(result.queues.status).toBe('up');
-      expect(result.queues).toMatchObject({ mode: 'disabled' });
+      // Per-queue details must not be present when disabled
+      expect(result.queues['notifications']).toBeUndefined();
+      expect(result.queues['notifications-dlq']).toBeUndefined();
+      expect(result.queues['export-queue']).toBeUndefined();
+      expect(result.queues['confession-draft-publisher']).toBeUndefined();
     });
   });
 
   describe('when background jobs are enabled', () => {
     describe('and all queues have workers', () => {
       beforeEach(async () => {
-        const module: TestingModule = await buildModule({});
+        const module: TestingModule = await buildModule({}, 'true');
         indicator = module.get(QueueHealthIndicator);
       });
 
@@ -89,13 +142,23 @@ describe('QueueHealthIndicator', () => {
           workers: 1,
         });
       });
+
+      it('does not include disabled mode fields when enabled', async () => {
+        const result = await indicator.isHealthy('queues');
+        expect(result.queues.mode).toBeUndefined();
+        expect(result.queues.reason).toBeUndefined();
+        expect(result.queues.severity).toBeUndefined();
+      });
     });
 
     describe('and a worker-required queue has no workers', () => {
       beforeEach(async () => {
-        const module: TestingModule = await buildModule({
-          notifications: makeMockQueue(0),
-        });
+        const module: TestingModule = await buildModule(
+          {
+            notifications: makeMockQueue(0),
+          },
+          'true',
+        );
         indicator = module.get(QueueHealthIndicator);
       });
 
@@ -125,9 +188,12 @@ describe('QueueHealthIndicator', () => {
 
     describe('and the DLQ has no workers', () => {
       beforeEach(async () => {
-        const module: TestingModule = await buildModule({
-          'notifications-dlq': makeMockQueue(0),
-        });
+        const module: TestingModule = await buildModule(
+          {
+            'notifications-dlq': makeMockQueue(0),
+          },
+          'true',
+        );
         indicator = module.get(QueueHealthIndicator);
       });
 
@@ -149,9 +215,12 @@ describe('QueueHealthIndicator', () => {
             .mockRejectedValue(new Error('ECONNREFUSED')),
           getJobCounts: jest.fn().mockResolvedValue({}),
         };
-        const module: TestingModule = await buildModule({
-          'export-queue': broken,
-        });
+        const module: TestingModule = await buildModule(
+          {
+            'export-queue': broken,
+          },
+          'true',
+        );
         indicator = module.get(QueueHealthIndicator);
       });
 
@@ -170,9 +239,12 @@ describe('QueueHealthIndicator', () => {
           failed: 1,
           delayed: 0,
         });
-        const module: TestingModule = await buildModule({
-          notifications: queueWithJobs,
-        });
+        const module: TestingModule = await buildModule(
+          {
+            notifications: queueWithJobs,
+          },
+          'true',
+        );
         indicator = module.get(QueueHealthIndicator);
       });
 

--- a/xconfess-backend/src/health/queue.health.ts
+++ b/xconfess-backend/src/health/queue.health.ts
@@ -15,6 +15,29 @@ interface QueueDetail {
   error?: string;
 }
 
+/**
+ * Resolves a human-readable reason for why background jobs are disabled
+ * based on the raw config value of ENABLE_BACKGROUND_JOBS.
+ *
+ * Distinguishes three cases so operators can tell at a glance whether the
+ * disabled state is intentional or a misconfiguration:
+ *
+ * - `"false"` → intentionally disabled (e.g. local development)
+ * - `undefined` → not set at all (defaults to disabled)
+ * - any other value → misconfiguration (expected `"true"`)
+ */
+function resolveDisabledReason(rawValue: unknown): string {
+  if (rawValue === 'false') {
+    return 'ENABLE_BACKGROUND_JOBS is set to "false" (background jobs intentionally disabled)';
+  }
+
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return 'ENABLE_BACKGROUND_JOBS is not set (defaults to disabled)';
+  }
+
+  return `ENABLE_BACKGROUND_JOBS is set to "${String(rawValue)}" (expected "true" to enable)`;
+}
+
 @Injectable()
 export class QueueHealthIndicator extends HealthIndicator {
   private readonly logger = new Logger(QueueHealthIndicator.name);
@@ -31,13 +54,16 @@ export class QueueHealthIndicator extends HealthIndicator {
   }
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
-    const jobsEnabled =
-      this.configService.get<string>('ENABLE_BACKGROUND_JOBS') === 'true';
+    const rawConfig = this.configService.get<string | undefined>(
+      'ENABLE_BACKGROUND_JOBS',
+    );
+    const jobsEnabled = rawConfig === 'true';
 
     if (!jobsEnabled) {
       return this.getStatus(key, true, {
         mode: 'disabled',
-        reason: 'ENABLE_BACKGROUND_JOBS is not set',
+        reason: resolveDisabledReason(rawConfig),
+        severity: 'info',
       });
     }
 
@@ -51,7 +77,6 @@ export class QueueHealthIndicator extends HealthIndicator {
         queue: this.notifications,
         requiresWorkers: true,
       },
-      // DLQ is a retention queue — no processor is expected to run against it
       {
         name: 'notifications-dlq',
         queue: this.dlq,


### PR DESCRIPTION
Closes #920

---

﻿## Summary

Makes queue health behavior explicit when `ENABLE_BACKGROUND_JOBS` is not `"true"`, distinguishing disabled jobs from unhealthy queues. This prevents confusion in local development and CI environments where BullMQ workers are intentionally absent.

## Acceptance Criteria

- [x] Health output distinguishes disabled jobs from unhealthy queues
- [x] Docs explain local versus production expectations
- [x] Existing QueueHealthIndicator tests are updated or extended

## Changes

- `src/health/queue.health.ts` — `resolveDisabledReason()` with three-case logic; reads raw config value; adds `severity: "info"` field
- `src/health/queue.health.spec.ts` — 4 new test blocks for `"false"`, `undefined`, unexpected value, and contract
- `src/health/HEALTH_CHECK_DOCUMENTATION.md` — New disabled mode section with response examples, reason table, environment matrix
- `.env.sample`, `.env.example` — Added `ENABLE_BACKGROUND_JOBS=false` with docs

## Disabled mode reason resolution

| Config value | Health response reason |
|---|---|
| `"false"` | intentionally disabled |
| `undefined` | not set (defaults to disabled) |
| other value | expected `"true"` to enable |

## Test Results

All 21 health tests pass (4 suites, 21/21 green).
