### PR TITLE
feat(wallet): improve disconnected states for anchor and tip actions

### DIFF
--- a/xconfess-frontend/app/components/confession/AnchorButton.tsx
+++ b/xconfess-frontend/app/components/confession/AnchorButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, type FC } from "react";
-import { Anchor, CheckCircle2, ExternalLink, Loader2 } from "lucide-react";
+import { Anchor, CheckCircle2, ExternalLink, Loader2, AlertCircle, Wallet } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import { Button } from "@/app/components/ui/button";
 import { cn } from "@/app/lib/utils/cn";
@@ -68,7 +68,7 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
       try {
         await connect();
       } catch {
-        setError("Failed to connect wallet");
+        setError("Failed to connect wallet. Please ensure Freighter is unlocked.");
         return;
       }
     }
@@ -155,8 +155,11 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
 
   if (walletCTA.status === "not-installed") {
     return (
-      <div className={cn("text-xs text-zinc-500", className)}>
-        {walletCTA.guidance}
+      <div className={cn("flex flex-col gap-1.5", className)}>
+        <div className="flex items-center gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-1.5">
+          <AlertCircle className="h-3.5 w-3.5 flex-shrink-0 text-yellow-500" />
+          <span className="text-xs text-yellow-400">{walletCTA.guidance}</span>
+        </div>
       </div>
     );
   }
@@ -166,18 +169,22 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
       <Button
         variant="outline"
         size="sm"
-        onClick={handleAnchor}
+        onClick={walletCTA.status === "not-connected" ? handleAnchor : handleAnchor}
         disabled={isAnchoring || walletCTA.disabled}
-        className="h-7 px-2 text-xs"
+        className={cn(
+          "h-7 px-2 text-xs",
+          walletCTA.status === "not-connected" &&
+            "border-blue-500/40 text-blue-400 hover:bg-blue-500/10 hover:text-blue-300",
+        )}
       >
-        {isAnchoring || isLoading ? (
+        {isAnchoring || (isLoading && isConnected) ? (
           <>
             <Loader2 className="mr-1 h-3 w-3 animate-spin" />
             Anchoring...
           </>
         ) : walletCTA.status === "not-connected" ? (
           <>
-            <Anchor className="mr-1 h-3 w-3" />
+            <Wallet className="mr-1 h-3 w-3" />
             Connect Wallet to Anchor
           </>
         ) : (
@@ -187,6 +194,10 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
           </>
         )}
       </Button>
+
+      {walletCTA.status === "not-connected" && walletCTA.guidance && (
+        <p className="text-xs text-zinc-500">{walletCTA.guidance}</p>
+      )}
 
       {error && <div className="text-xs text-red-400">{error}</div>}
 

--- a/xconfess-frontend/app/components/confession/TipButton.tsx
+++ b/xconfess-frontend/app/components/confession/TipButton.tsx
@@ -11,6 +11,8 @@ import { useWallet } from "@/lib/hooks/useWallet";
 import { getWalletCTAState } from "@/lib/hooks/useWalletCTAState";
 import { useActivityStore } from "@/app/lib/store/activity.store";
 import { v4 as uuidv4 } from "uuid";
+import { Wallet, AlertCircle } from "lucide-react";
+import { cn } from "@/app/lib/utils/cn";
 
 const STELLAR_EXPLORER_URL =
   process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet"
@@ -85,7 +87,7 @@ export const TipButton = ({
       try {
         await connect();
       } catch {
-        setError("Connect your wallet");
+        setError("Connect your Freighter wallet to send tips");
         return;
       }
     }
@@ -189,15 +191,26 @@ export const TipButton = ({
       ? `${STELLAR_EXPLORER_URL}/${confirmedTx.hash}`
       : null;
 
+  const needsWallet = !isConnected || walletCTA.status === "not-installed";
+
   return (
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
         disabled={!recipientAddress}
         aria-label="Tip confession"
-        className="flex items-center gap-2 px-4 py-2 rounded-full bg-purple-600 hover:bg-purple-700 disabled:opacity-50 transition-opacity"
+        className={cn(
+          "flex items-center gap-2 px-4 py-2 rounded-full transition-opacity",
+          needsWallet
+            ? "bg-purple-600/40 hover:bg-purple-600/50"
+            : "bg-purple-600 hover:bg-purple-700",
+          "disabled:opacity-50",
+        )}
       >
         <span className="text-lg">💰</span>
+        {needsWallet && (
+          <Wallet className="h-3.5 w-3.5 text-purple-300/70" />
+        )}
         {tipCount > 0 && (
           <span className="text-sm font-medium text-white">{tipCount}</span>
         )}
@@ -206,6 +219,43 @@ export const TipButton = ({
       {isOpen && (
         <div className="absolute right-0 mt-2 w-80 bg-zinc-800 p-4 rounded-xl shadow-xl z-50">
           <h3 className="text-white font-semibold mb-3">Send Tip</h3>
+
+          {/* Wallet not installed warning */}
+          {walletCTA.status === "not-installed" && (
+            <div className="mb-3 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5 text-yellow-500" />
+                <p className="text-xs text-yellow-400">{walletCTA.guidance}</p>
+              </div>
+            </div>
+          )}
+
+          {/* Wallet not connected prompt */}
+          {walletCTA.status === "not-connected" && (
+            <div className="mb-3 p-3 rounded-lg bg-blue-500/10 border border-blue-500/30">
+              <div className="flex items-start gap-2">
+                <Wallet className="h-4 w-4 flex-shrink-0 mt-0.5 text-blue-400" />
+                <div>
+                  <p className="text-xs text-blue-400 font-medium">
+                    Wallet not connected
+                  </p>
+                  <p className="text-xs text-blue-300/70 mt-0.5">
+                    Connect your Freighter wallet to send tips on Stellar.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Wallet not ready warning */}
+          {walletCTA.status === "not-ready" && (
+            <div className="mb-3 p-3 rounded-lg bg-orange-500/10 border border-orange-500/30">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5 text-orange-400" />
+                <p className="text-xs text-orange-400">{walletCTA.guidance}</p>
+              </div>
+            </div>
+          )}
 
           {/* Confirmed state */}
           {confirmedTx && (
@@ -294,22 +344,28 @@ export const TipButton = ({
                 </span>
               </div>
 
-              {walletCTA.status === "not-installed" && (
-                <div className="text-xs text-yellow-400 mt-2">
-                  {walletCTA.guidance}
-                </div>
-              )}
-
               <button
                 onClick={handleTip}
-                disabled={walletCTA.disabled || isSending}
-                className="w-full mt-3 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed py-2.5 rounded-lg text-white font-medium transition-colors flex items-center justify-center gap-2"
+                disabled={
+                  walletCTA.disabled ||
+                  isSending ||
+                  walletCTA.status === "not-installed"
+                }
+                className={cn(
+                  "w-full mt-3 py-2.5 rounded-lg text-white font-medium transition-colors flex items-center justify-center gap-2",
+                  walletCTA.status === "not-connected"
+                    ? "bg-blue-600 hover:bg-blue-500"
+                    : "bg-purple-600 hover:bg-purple-500",
+                  "disabled:opacity-50 disabled:cursor-not-allowed",
+                )}
                 aria-label={
                   isSending
                     ? "Sending tip"
                     : walletCTA.status === "not-connected"
                       ? "Connect Wallet to Tip"
-                      : `Send ${tipAmount} XLM tip`
+                      : walletCTA.status === "not-installed"
+                        ? "Wallet required — install Freighter"
+                        : `Send ${tipAmount} XLM tip`
                 }
               >
                 {isSending ? (
@@ -318,17 +374,14 @@ export const TipButton = ({
                     <span>Sending...</span>
                   </>
                 ) : walletCTA.status === "not-connected" ? (
-                  "Connect Wallet to Tip"
+                  <>
+                    <Wallet className="h-4 w-4" />
+                    Connect Wallet to Tip
+                  </>
                 ) : (
                   `Tip ${tipAmount} XLM`
                 )}
               </button>
-
-              {walletCTA.status === "not-ready" && (
-                <div className="text-xs text-orange-400 mt-2">
-                  {walletCTA.guidance}
-                </div>
-              )}
             </>
           )}
 

--- a/xconfess-frontend/lib/hooks/useWalletCTAState.ts
+++ b/xconfess-frontend/lib/hooks/useWalletCTAState.ts
@@ -30,19 +30,23 @@ export function getWalletCTAState(
     return {
       status: "not-installed",
       disabled: true,
-      guidance: "Install Freighter wallet to continue.",
+      guidance: "Install the Freighter browser extension to connect your Stellar wallet.",
     };
   }
 
   if (!wallet.isConnected) {
-    return { status: "not-connected", disabled: false, guidance: null };
+    return {
+      status: "not-connected",
+      disabled: false,
+      guidance: "Connect your Freighter wallet to perform on-chain actions.",
+    };
   }
 
   if (!wallet.isReady) {
     return {
       status: "not-ready",
       disabled: true,
-      guidance: wallet.readinessError || "Wallet not ready.",
+      guidance: wallet.readinessError || "Your wallet is not ready.",
     };
   }
 


### PR DESCRIPTION
Closes #924

---

﻿## Summary

Makes on-chain actions clearer when the user has not connected a Stellar wallet. Anchor and tip buttons now show distinct visual states with brief explanatory copy, and no on-chain action fires without a wallet.

## Acceptance Criteria

- [x] Anchor and tip buttons show clear disabled or connect-wallet state
- [x] Copy explains the required next step briefly
- [x] No action attempts fire without a wallet
- [x] Mobile layout remains stable (no layout changes, only visual state + text additions)

## Changes

### `AnchorButton` (`app/components/confession/AnchorButton.tsx`)
- **Not connected**: Shows a blue-styled "Connect Wallet to Anchor" button with a `Wallet` icon (was plain outline). Guidance text appears below: "Connect your Freighter wallet to perform on-chain actions."
- **Not installed**: Yellow alert banner with `AlertCircle` icon instead of plain grey text
- **Error state**: Improved error message ("Please ensure Freighter is unlocked")

### `TipButton` (`app/components/confession/TipButton.tsx`)
- **Toggle button**: Reduced opacity + `Wallet` icon when disconnected to visually distinguish from active state
- **Dropdown (not connected)**: Blue info box with "Wallet not connected" header + guidance text
- **Dropdown (not installed)**: Yellow alert box with `AlertCircle` icon + install guidance
- **Dropdown (not ready)**: Orange warning box with readiness error details
- **Connect button**: Blue accent color to distinguish from the "Tip XLM" action button
- **Not installed**: Button is fully disabled (not just action-blocked)

### `useWalletCTAState` (`lib/hooks/useWalletCTAState.ts`)
- Added guidance text for "not-connected" status
- Improved wording for "not-installed" guidance

## Visual State Comparison

| State | Before | After |
|---|---|---|
| Wallet not connected (Anchor) | "Connect Wallet to Anchor" (plain outline btn) | Blue-accented button with Wallet icon + guidance text below |
| Wallet not installed (Anchor) | Small grey text | Yellow alert banner with icon |
| Wallet not connected (Tip) | "Connect Wallet to Tip" (purple btn) | Blue-accented button with wallet icon + info box in dropdown |
| Wallet not installed (Tip) | Yellow text in dropdown | Yellow alert box with icon + send button disabled |

## Test Results

All 9 TipButton tests pass.
