### PR TITLE
[Wave 5] Improve boot warnings, network banner, messages page, and audit log filters

### DIFF
--- a/xconfess-backend/src/database/migration-verification.service.ts
+++ b/xconfess-backend/src/database/migration-verification.service.ts
@@ -22,6 +22,28 @@ export interface SchemaReadinessResult {
   queryError?: string;
 }
 
+function getMigrationHint(column: string): string {
+  switch (column) {
+    case 'search_vector':
+      return 'Run: npm run migration:run -- xconfess-backend (add FTS migration)';
+    case 'view_count':
+      return 'Run: npm run migration:run -- xconfess-backend (add view_count column)';
+    default:
+      return '';
+  }
+}
+
+function getIndexHint(index: string): string {
+  switch (index) {
+    case 'idx_confession_search_vector':
+      return 'Run: CREATE INDEX concurrently idx_confession_search_vector ON anonymous_confessions USING GIN(search_vector);';
+    case 'idx_confession_created_at':
+      return 'Run: CREATE INDEX concurrently idx_confession_created_at ON anonymous_confessions(created_at DESC);';
+    default:
+      return '';
+  }
+}
+
 @Injectable()
 export class MigrationVerificationService implements OnModuleInit {
   private readonly logger = new Logger(MigrationVerificationService.name);
@@ -93,8 +115,17 @@ export class MigrationVerificationService implements OnModuleInit {
       return;
     }
     if (!result.ok) {
+      const hints: string[] = [];
+      for (const col of result.missingColumns) {
+        const hint = getMigrationHint(col);
+        if (hint) hints.push(`${col}: ${hint}`);
+      }
+      for (const idx of result.missingIndexes) {
+        const hint = getIndexHint(idx);
+        if (hint) hints.push(`${idx}: ${hint}`);
+      }
       this.logger.warn(
-        `schema_readiness_degraded missingColumns=[${result.missingColumns.join(', ')}] missingIndexes=[${result.missingIndexes.join(', ')}]`,
+        `schema_readiness_degraded missingColumns=[${result.missingColumns.join(', ')}] missingIndexes=[${result.missingIndexes.join(', ')}] — ${hints.join('; ')}`,
       );
       return;
     }

--- a/xconfess-backend/src/email/email.service.ts
+++ b/xconfess-backend/src/email/email.service.ts
@@ -330,10 +330,18 @@ export class EmailService implements OnModuleInit {
       this.templateSloConfig = mailConfig.slo;
     }
 
+    const isDev =
+      !process.env.NODE_ENV ||
+      ['development', 'dev', 'local'].includes(process.env.NODE_ENV);
+
     if (!mailConfig?.primary?.host) {
-      this.logger.warn(
-        'No primary mail config found — using Ethereal test account.',
-      );
+      const msg =
+        'No primary mail config found — using Ethereal test account.';
+      if (isDev) {
+        this.logger.log(msg);
+      } else {
+        this.logger.warn(msg);
+      }
       this.initEtherealFallback();
       return;
     }
@@ -344,9 +352,13 @@ export class EmailService implements OnModuleInit {
       this.fallback = this.buildTransporter(mailConfig.fallback, 'fallback');
       this.logger.log('Fallback email provider configured.');
     } else {
-      this.logger.warn(
-        'No fallback email provider configured. Circuit breaker will have no fallback.',
-      );
+      const msg =
+        'No fallback email provider configured. Circuit breaker will have no fallback.';
+      if (isDev) {
+        this.logger.log(msg);
+      } else {
+        this.logger.warn(msg);
+      }
     }
   }
 

--- a/xconfess-backend/src/email/mail-config-validator.ts
+++ b/xconfess-backend/src/email/mail-config-validator.ts
@@ -24,6 +24,10 @@ export class MailConfigValidator implements OnModuleInit {
       warnings: [],
     };
 
+    const isDev =
+      !process.env.NODE_ENV ||
+      ['development', 'dev', 'local'].includes(process.env.NODE_ENV);
+
     const host = this.configService.get<string>('mail.primary.host');
     const port = this.configService.get<string>('mail.primary.port');
     const user = this.configService.get<string>('mail.primary.auth.user');
@@ -83,9 +87,14 @@ export class MailConfigValidator implements OnModuleInit {
     if (result.valid) {
       this.logger.log('Mail configuration validated successfully');
     } else {
-      this.logger.error(
-        `Mail configuration has errors: ${result.errors.join(', ')}`,
-      );
+      const msg = `Mail configuration has errors: ${result.errors.join(', ')}`;
+      if (isDev) {
+        this.logger.warn(
+          `${msg} — Email features will be disabled, but the app can continue in local development. Set MAIL_HOST, MAIL_USER, MAIL_PASSWORD, etc. in .env to enable email.`,
+        );
+      } else {
+        this.logger.error(msg);
+      }
     }
 
     if (result.warnings.length > 0) {

--- a/xconfess-frontend/app/(dashboard)/messages/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/messages/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { AuthGuard } from '@/app/components/AuthGuard';
 import apiClient from '@/app/lib/api/client';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Send, User as UserIcon, MessageSquare, WifiOff, RefreshCw } from 'lucide-react';
+import { Send, User as UserIcon, MessageSquare, WifiOff, RefreshCw, Inbox, AlertCircle } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { useGlobalToast } from '@/app/components/common/Toast';
 
@@ -46,6 +46,108 @@ interface Message {
   repliedAt: string | null;
 }
 
+function MobileThreadList({
+  threads,
+  selectedThread,
+  isLoading,
+  error,
+  onSelect,
+  onRetry,
+  onBack,
+}: {
+  threads: Thread[];
+  selectedThread: Thread | null;
+  isLoading: boolean;
+  error: string | null;
+  onSelect: (t: Thread) => void;
+  onRetry: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="h-full flex flex-col bg-white dark:bg-gray-950">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-800 flex items-center gap-2">
+        {selectedThread && (
+          <Button variant="ghost" size="sm" onClick={onBack} className="mr-1">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
+          </Button>
+        )}
+        <h1 className="text-lg font-bold flex items-center gap-2">
+          <MessageSquare className="w-5 h-5" />
+          Messages
+        </h1>
+      </div>
+      {!selectedThread && (
+        <ScrollArea className="flex-1">
+          {error ? (
+            <div className="p-8 flex flex-col items-center justify-center text-center space-y-4">
+              <div className="bg-amber-50 dark:bg-amber-900/20 p-4 rounded-full">
+                <WifiOff className="w-8 h-8 text-amber-500" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Backend Unreachable</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 max-w-[200px]">{error}</p>
+              </div>
+              <Button size="sm" variant="secondary" onClick={onRetry} className="mt-2 gap-2">
+                <RefreshCw className="w-3 h-3" />
+                Retry Fetch
+              </Button>
+            </div>
+          ) : isLoading ? (
+            <div className="p-4 space-y-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex gap-3">
+                  <Skeleton className="h-12 w-12 rounded-full" />
+                  <div className="space-y-2 flex-1">
+                    <Skeleton className="h-4 w-1/2" />
+                    <Skeleton className="h-3 w-full" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : threads.length === 0 ? (
+            <div className="p-8 flex flex-col items-center justify-center text-center min-h-[300px]">
+              <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded-full mb-4">
+                <Inbox className="w-10 h-10 text-gray-400" />
+              </div>
+              <p className="text-base font-medium text-gray-900 dark:text-gray-100 mb-1">No messages yet</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xs">
+                When someone replies to your confession or you send a message, conversations will appear here.
+              </p>
+            </div>
+          ) : (
+            <div className="divide-y divide-gray-100 dark:divide-gray-800">
+              {threads.map((thread) => (
+                <button
+                  key={`${thread.confessionId}-${thread.senderId}`}
+                  onClick={() => onSelect(thread)}
+                  className={`w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors flex flex-col gap-1 ${
+                    selectedThread?.confessionId === thread.confessionId && selectedThread?.senderId === thread.senderId ? 'bg-purple-50 dark:bg-purple-900/20' : ''
+                  }`}
+                >
+                  <div className="flex justify-between items-start">
+                    <span className="text-xs font-semibold text-purple-600 dark:text-purple-400 uppercase tracking-wider">
+                      {thread.isAuthor ? 'Your Confession' : 'Sent Message'}
+                    </span>
+                    <span className="text-[10px] text-gray-400">
+                      {formatDistanceToNow(new Date(thread.lastMessageAt), { addSuffix: true })}
+                    </span>
+                  </div>
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100 line-clamp-1">
+                    {thread.confessionMessage}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-1">
+                    {thread.lastMessage}
+                  </p>
+                </button>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+      )}
+    </div>
+  );
+}
+
 export default function MessagesPage() {
   const [threads, setThreads] = useState<Thread[]>([]);
   const [selectedThread, setSelectedThread] = useState<Thread | null>(null);
@@ -56,7 +158,10 @@ export default function MessagesPage() {
   const [isSending, setIsSending] = useState(false);
   const [threadsError, setThreadsError] = useState<string | null>(null);
   const [messagesError, setMessagesError] = useState<string | null>(null);
+  const [showMobileList, setShowMobileList] = useState(true);
   const toast = useGlobalToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const fetchThreads = useCallback(async () => {
     try {
@@ -103,175 +208,118 @@ export default function MessagesPage() {
   useEffect(() => {
     if (selectedThread) {
       fetchMessages(selectedThread.confessionId, selectedThread.senderId);
+      setShowMobileList(false);
     }
   }, [selectedThread, fetchMessages]);
 
   const handleSendMessage = async () => {
     if (!selectedThread || !newMessage.trim()) return;
 
+    const text = newMessage;
     try {
       setIsSending(true);
       if (selectedThread.isAuthor) {
-        // Author replies to the last unreplied message in this thread
         const unrepliedMessage = [...messages].reverse().find(m => !m.hasReply);
         if (unrepliedMessage) {
           await apiClient.post('/messages/reply', {
             message_id: unrepliedMessage.id,
-            reply: newMessage.trim(),
+            reply: text.trim(),
           });
         } else {
           toast.warning("Please wait for the sender to message you again.");
           return;
         }
       } else {
-        // Sender sends a new message to the confession
         await apiClient.post('/messages', {
           confession_id: selectedThread.confessionId,
-          content: newMessage.trim(),
+          content: text.trim(),
         });
       }
-      
+
       setNewMessage('');
       fetchMessages(selectedThread.confessionId, selectedThread.senderId);
     } catch (error) {
       console.error('Failed to send message:', error);
-      toast.error('Unable to send message right now.');
+      toast.error('Failed to send. Your message has been saved — try again.');
     } finally {
       setIsSending(false);
     }
   };
 
+  const handleSelectThread = (thread: Thread) => {
+    setSelectedThread(thread);
+    setMessagesError(null);
+  };
+
+  const handleBackToList = () => {
+    setSelectedThread(null);
+    setShowMobileList(true);
+    setMessagesError(null);
+  };
+
   return (
     <AuthGuard>
+      {/* Mobile: toggle between list and detail */}
       <div className="flex h-[calc(100vh-4rem)] bg-gray-50 dark:bg-gray-900 overflow-hidden">
-        {/* Thread List Sidebar */}
-        <div className="w-1/3 border-r border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 flex flex-col">
-          <div className="p-4 border-b border-gray-200 dark:border-gray-800">
-            <h1 className="text-xl font-bold flex items-center gap-2">
-              <MessageSquare className="w-5 h-5" />
-              Messages
-            </h1>
-          </div>
-          <ScrollArea className="flex-1">
-            {threadsError ? (
-              <div className="p-8 flex flex-col items-center justify-center text-center space-y-4">
-                <div className="bg-amber-50 dark:bg-amber-900/20 p-4 rounded-full">
-                  <WifiOff className="w-8 h-8 text-amber-500" />
-                </div>
-                <div className="space-y-1">
-                  <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Backend Unreachable</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 max-w-[200px]">
-                    Messages will appear once the backend is reachable
-                  </p>
-                </div>
-                <Button 
-                  size="sm" 
-                  variant="secondary" 
-                  onClick={() => fetchThreads()} 
-                  className="mt-2 gap-2"
-                >
-                  <RefreshCw className="w-3 h-3" />
-                  Retry Fetch
+        <div className="md:hidden w-full">
+          {showMobileList || !selectedThread ? (
+            <MobileThreadList
+              threads={threads}
+              selectedThread={selectedThread}
+              isLoading={isLoadingThreads}
+              error={threadsError}
+              onSelect={handleSelectThread}
+              onRetry={fetchThreads}
+              onBack={handleBackToList}
+            />
+          ) : (
+            <div className="h-full flex flex-col">
+              <div className="p-3 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 flex items-center gap-2">
+                <Button variant="ghost" size="sm" onClick={handleBackToList}>
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
                 </Button>
-              </div>
-            ) : isLoadingThreads ? (
-              <div className="p-4 space-y-4">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="flex gap-3">
-                    <Skeleton className="h-12 w-12 rounded-full" />
-                    <div className="space-y-2 flex-1">
-                      <Skeleton className="h-4 w-1/2" />
-                      <Skeleton className="h-3 w-full" />
-                    </div>
+                <div className="flex items-center gap-2 min-w-0">
+                  <div className="bg-purple-100 dark:bg-purple-900/40 p-1.5 rounded-full text-purple-600 flex-shrink-0">
+                    <UserIcon className="w-4 h-4" />
                   </div>
-                ))}
-              </div>
-            ) : threads.length === 0 ? (
-              <div className="p-8 text-center text-gray-500">
-                <p>No messages yet.</p>
-              </div>
-            ) : (
-              <div className="divide-y divide-gray-100 dark:divide-gray-800">
-                {threads.map((thread) => (
-                  <button
-                    key={`${thread.confessionId}-${thread.senderId}`}
-                    onClick={() => setSelectedThread(thread)}
-                    className={`w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors flex flex-col gap-1 ${
-                      selectedThread?.confessionId === thread.confessionId && selectedThread?.senderId === thread.senderId ? 'bg-purple-50 dark:bg-purple-900/20' : ''
-                    }`}
-                  >
-                    <div className="flex justify-between items-start">
-                      <span className="text-xs font-semibold text-purple-600 dark:text-purple-400 uppercase tracking-wider">
-                        {thread.isAuthor ? 'Your Confession' : 'Sent Message'}
-                      </span>
-                      <span className="text-[10px] text-gray-400">
-                        {formatDistanceToNow(new Date(thread.lastMessageAt), { addSuffix: true })}
-                      </span>
-                    </div>
-                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100 line-clamp-1">
-                      {thread.confessionMessage}
-                    </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-1">
-                      {thread.lastMessage}
-                    </p>
-                  </button>
-                ))}
-              </div>
-            )}
-          </ScrollArea>
-        </div>
-
-        {/* Message View Panel */}
-        <div className="flex-1 flex flex-col">
-          {selectedThread ? (
-            <>
-              <div className="p-4 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950">
-                <div className="flex items-center gap-3">
-                  <div className="bg-purple-100 dark:bg-purple-900/40 p-2 rounded-full text-purple-600">
-                    <UserIcon className="w-5 h-5" />
-                  </div>
-                  <div>
-                    <h2 className="text-sm font-bold text-gray-900 dark:text-gray-100 line-clamp-1">
-                      {selectedThread.confessionMessage}
-                    </h2>
-                    <Badge variant="outline" className="text-[10px] py-0 h-4">
-                      {selectedThread.isAuthor ? 'AUTHOR VIEW' : 'SENDER VIEW'}
-                    </Badge>
+                  <div className="min-w-0">
+                    <p className="text-sm font-bold text-gray-900 dark:text-gray-100 truncate">{selectedThread.confessionMessage}</p>
+                    <Badge variant="outline" className="text-[9px] py-0 h-3.5">{selectedThread.isAuthor ? 'AUTHOR' : 'SENDER'}</Badge>
                   </div>
                 </div>
               </div>
-
-              <ScrollArea className="flex-1 p-4 bg-gray-50 dark:bg-gray-900">
+              <ScrollArea className="flex-1 p-3 bg-gray-50 dark:bg-gray-900">
                 {isLoadingMessages ? (
-                  <div className="space-y-4">
-                    <Skeleton className="h-10 w-2/3" />
-                    <Skeleton className="h-10 w-1/2 ml-auto" />
-                    <Skeleton className="h-10 w-3/4" />
+                  <div className="space-y-3">
+                    <Skeleton className="h-8 w-2/3 rounded-lg" />
+                    <Skeleton className="h-8 w-1/2 ml-auto rounded-lg" />
+                    <Skeleton className="h-8 w-3/4 rounded-lg" />
                   </div>
                 ) : messagesError ? (
-                  <div className="p-8 flex flex-col items-center justify-center text-center space-y-4 h-full">
-                    <WifiOff className="w-8 h-8 text-amber-500" />
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      Unable to load messages. The backend might be offline.
-                    </p>
-                    <Button 
-                      size="sm" 
-                      variant="outline" 
-                      onClick={() => selectedThread && fetchMessages(selectedThread.confessionId, selectedThread.senderId)}
-                      className="gap-2"
-                    >
+                  <div className="p-6 flex flex-col items-center justify-center text-center space-y-3 h-full">
+                    <AlertCircle className="w-8 h-8 text-amber-500" />
+                    <p className="text-sm text-gray-500 dark:text-gray-400">{messagesError}</p>
+                    <Button size="sm" variant="outline" onClick={() => selectedThread && fetchMessages(selectedThread.confessionId, selectedThread.senderId)} className="gap-2">
                       <RefreshCw className="w-3 h-3" />
                       Try Again
                     </Button>
                   </div>
+                ) : messages.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center text-center py-16">
+                    <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-full mb-3">
+                      <MessageSquare className="w-6 h-6 text-gray-400" />
+                    </div>
+                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">No messages yet</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 max-w-[200px]">Start the conversation by sending a message below.</p>
+                  </div>
                 ) : (
-                  <div className="space-y-6 pb-4">
+                  <div className="space-y-4 pb-4">
                     {messages.map((msg) => (
-                      <div key={msg.id} className="space-y-2">
+                      <div key={msg.id} className="space-y-1.5">
                         <div className={`flex ${selectedThread.isAuthor ? 'justify-start' : 'justify-end'}`}>
-                          <Card className={`max-w-[80%] p-3 ${
-                            selectedThread.isAuthor 
-                              ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700' 
+                          <Card className={`max-w-[85%] p-2.5 ${
+                            selectedThread.isAuthor
+                              ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700'
                               : 'bg-purple-600 text-white border-none'
                           }`}>
                             <p className="text-sm">{msg.content}</p>
@@ -280,19 +328,16 @@ export default function MessagesPage() {
                                 {formatDistanceToNow(new Date(msg.createdAt), { addSuffix: true })}
                               </p>
                               {!selectedThread.isAuthor && msg.hasReply && (
-                                <Badge variant="secondary" className="bg-purple-500/50 text-[8px] py-0 h-3 text-white border-none">
-                                  Replied
-                                </Badge>
+                                <Badge variant="secondary" className="bg-purple-500/50 text-[8px] py-0 h-3 text-white border-none">Replied</Badge>
                               )}
                             </div>
                           </Card>
                         </div>
-                        
                         {msg.hasReply && (
                           <div className={`flex ${selectedThread.isAuthor ? 'justify-end' : 'justify-start'}`}>
-                            <Card className={`max-w-[80%] p-3 ${
-                              selectedThread.isAuthor 
-                                ? 'bg-purple-600 text-white border-none' 
+                            <Card className={`max-w-[85%] p-2.5 ${
+                              selectedThread.isAuthor
+                                ? 'bg-purple-600 text-white border-none'
                                 : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700'
                             }`}>
                               <p className="text-sm">{msg.replyContent}</p>
@@ -304,47 +349,219 @@ export default function MessagesPage() {
                         )}
                       </div>
                     ))}
-                    {messages.length === 0 && (
-                      <div className="text-center py-12 text-gray-400">
-                        No messages in this thread yet.
-                      </div>
-                    )}
+                    <div ref={messagesEndRef} />
                   </div>
                 )}
               </ScrollArea>
-
-              <div className="p-4 bg-white dark:bg-gray-950 border-t border-gray-200 dark:border-gray-800">
+              <div className="p-3 bg-white dark:bg-gray-950 border-t border-gray-200 dark:border-gray-800">
                 <div className="flex gap-2">
                   <Input
+                    ref={inputRef}
                     placeholder={selectedThread.isAuthor ? "Type a reply..." : "Send another message..."}
                     value={newMessage}
                     onChange={(e) => setNewMessage(e.target.value)}
                     onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()}
                     disabled={isSending}
-                    className="flex-1"
+                    className="flex-1 text-sm"
                   />
-                  <Button onClick={handleSendMessage} disabled={isSending || !newMessage.trim()}>
+                  <Button onClick={handleSendMessage} disabled={isSending || !newMessage.trim()} size="sm">
                     <Send className="w-4 h-4" />
                   </Button>
                 </div>
                 {selectedThread.isAuthor && messages.every(m => m.hasReply) && (
-                  <p className="text-[10px] text-gray-400 mt-2 text-center">
-                    You have replied to all messages. Wait for the sender to message you again.
-                  </p>
+                  <p className="text-[10px] text-gray-400 mt-2 text-center">You have replied to all messages. Wait for the sender to message you again.</p>
                 )}
               </div>
-            </>
-          ) : (
-            <div className="flex-1 flex flex-col items-center justify-center text-gray-400 p-8">
-              <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-full mb-4">
-                <MessageSquare className="w-12 h-12" />
-              </div>
-              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">Select a conversation</h3>
-              <p className="text-sm max-w-xs text-center">
-                Choose a message thread from the list to view the conversation.
-              </p>
             </div>
           )}
+        </div>
+
+        {/* Desktop: split view */}
+        <div className="hidden md:flex w-full">
+          <div className="w-1/3 border-r border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 flex flex-col">
+            <div className="p-4 border-b border-gray-200 dark:border-gray-800">
+              <h1 className="text-xl font-bold flex items-center gap-2">
+                <MessageSquare className="w-5 h-5" />
+                Messages
+              </h1>
+            </div>
+            <ScrollArea className="flex-1">
+              {threadsError ? (
+                <div className="p-8 flex flex-col items-center justify-center text-center space-y-4">
+                  <div className="bg-amber-50 dark:bg-amber-900/20 p-4 rounded-full">
+                    <WifiOff className="w-8 h-8 text-amber-500" />
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Backend Unreachable</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 max-w-[200px]">{threadsError}</p>
+                  </div>
+                  <Button size="sm" variant="secondary" onClick={fetchThreads} className="mt-2 gap-2">
+                    <RefreshCw className="w-3 h-3" />
+                    Retry Fetch
+                  </Button>
+                </div>
+              ) : isLoadingThreads ? (
+                <div className="p-4 space-y-4">
+                  {[1, 2, 3].map((i) => (
+                    <div key={i} className="flex gap-3">
+                      <Skeleton className="h-12 w-12 rounded-full" />
+                      <div className="space-y-2 flex-1">
+                        <Skeleton className="h-4 w-1/2" />
+                        <Skeleton className="h-3 w-full" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : threads.length === 0 ? (
+                <div className="p-8 flex flex-col items-center justify-center text-center">
+                  <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded-full mb-4">
+                    <Inbox className="w-10 h-10 text-gray-400" />
+                  </div>
+                  <p className="text-base font-medium text-gray-900 dark:text-gray-100 mb-1">No messages yet</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 max-w-[220px]">
+                    When someone replies to your confession or you send a message, conversations will appear here.
+                  </p>
+                </div>
+              ) : (
+                <div className="divide-y divide-gray-100 dark:divide-gray-800">
+                  {threads.map((thread) => (
+                    <button
+                      key={`${thread.confessionId}-${thread.senderId}`}
+                      onClick={() => handleSelectThread(thread)}
+                      className={`w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors flex flex-col gap-1 ${
+                        selectedThread?.confessionId === thread.confessionId && selectedThread?.senderId === thread.senderId ? 'bg-purple-50 dark:bg-purple-900/20' : ''
+                      }`}
+                    >
+                      <div className="flex justify-between items-start">
+                        <span className="text-xs font-semibold text-purple-600 dark:text-purple-400 uppercase tracking-wider">
+                          {thread.isAuthor ? 'Your Confession' : 'Sent Message'}
+                        </span>
+                        <span className="text-[10px] text-gray-400">
+                          {formatDistanceToNow(new Date(thread.lastMessageAt), { addSuffix: true })}
+                        </span>
+                      </div>
+                      <p className="text-sm font-medium text-gray-900 dark:text-gray-100 line-clamp-1">{thread.confessionMessage}</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-1">{thread.lastMessage}</p>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </ScrollArea>
+          </div>
+
+          <div className="flex-1 flex flex-col">
+            {selectedThread ? (
+              <>
+                <div className="p-4 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950">
+                  <div className="flex items-center gap-3">
+                    <div className="bg-purple-100 dark:bg-purple-900/40 p-2 rounded-full text-purple-600">
+                      <UserIcon className="w-5 h-5" />
+                    </div>
+                    <div>
+                      <h2 className="text-sm font-bold text-gray-900 dark:text-gray-100 line-clamp-1">{selectedThread.confessionMessage}</h2>
+                      <Badge variant="outline" className="text-[10px] py-0 h-4">{selectedThread.isAuthor ? 'AUTHOR VIEW' : 'SENDER VIEW'}</Badge>
+                    </div>
+                  </div>
+                </div>
+
+                <ScrollArea className="flex-1 p-4 bg-gray-50 dark:bg-gray-900">
+                  {isLoadingMessages ? (
+                    <div className="space-y-4">
+                      <Skeleton className="h-10 w-2/3 rounded-lg" />
+                      <Skeleton className="h-10 w-1/2 ml-auto rounded-lg" />
+                      <Skeleton className="h-10 w-3/4 rounded-lg" />
+                    </div>
+                  ) : messagesError ? (
+                    <div className="p-8 flex flex-col items-center justify-center text-center space-y-4 h-full">
+                      <AlertCircle className="w-8 h-8 text-amber-500" />
+                      <p className="text-sm text-gray-500 dark:text-gray-400">{messagesError}</p>
+                      <Button size="sm" variant="outline" onClick={() => selectedThread && fetchMessages(selectedThread.confessionId, selectedThread.senderId)} className="gap-2">
+                        <RefreshCw className="w-3 h-3" />
+                        Try Again
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="space-y-6 pb-4">
+                      {messages.map((msg) => (
+                        <div key={msg.id} className="space-y-2">
+                          <div className={`flex ${selectedThread.isAuthor ? 'justify-start' : 'justify-end'}`}>
+                            <Card className={`max-w-[80%] p-3 ${
+                              selectedThread.isAuthor
+                                ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700'
+                                : 'bg-purple-600 text-white border-none'
+                            }`}>
+                              <p className="text-sm">{msg.content}</p>
+                              <div className="flex items-center gap-1 mt-1">
+                                <p className={`text-[10px] ${selectedThread.isAuthor ? 'text-gray-400' : 'text-purple-200'}`}>
+                                  {formatDistanceToNow(new Date(msg.createdAt), { addSuffix: true })}
+                                </p>
+                                {!selectedThread.isAuthor && msg.hasReply && (
+                                  <Badge variant="secondary" className="bg-purple-500/50 text-[8px] py-0 h-3 text-white border-none">Replied</Badge>
+                                )}
+                              </div>
+                            </Card>
+                          </div>
+                          {msg.hasReply && (
+                            <div className={`flex ${selectedThread.isAuthor ? 'justify-end' : 'justify-start'}`}>
+                              <Card className={`max-w-[80%] p-3 ${
+                                selectedThread.isAuthor
+                                  ? 'bg-purple-600 text-white border-none'
+                                  : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700'
+                              }`}>
+                                <p className="text-sm">{msg.replyContent}</p>
+                                <p className={`text-[10px] mt-1 ${selectedThread.isAuthor ? 'text-purple-200' : 'text-gray-400'}`}>
+                                  {msg.repliedAt && formatDistanceToNow(new Date(msg.repliedAt), { addSuffix: true })}
+                                </p>
+                              </Card>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                      {messages.length === 0 && (
+                        <div className="flex flex-col items-center justify-center text-center py-16">
+                          <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded-full mb-3">
+                            <MessageSquare className="w-8 h-8 text-gray-400" />
+                          </div>
+                          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">No messages in this thread yet</p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400 max-w-[220px]">Send a message to start the conversation.</p>
+                        </div>
+                      )}
+                      <div ref={messagesEndRef} />
+                    </div>
+                  )}
+                </ScrollArea>
+
+                <div className="p-4 bg-white dark:bg-gray-950 border-t border-gray-200 dark:border-gray-800">
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder={selectedThread.isAuthor ? "Type a reply..." : "Send another message..."}
+                      value={newMessage}
+                      onChange={(e) => setNewMessage(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()}
+                      disabled={isSending}
+                      className="flex-1"
+                    />
+                    <Button onClick={handleSendMessage} disabled={isSending || !newMessage.trim()}>
+                      <Send className="w-4 h-4" />
+                    </Button>
+                  </div>
+                  {selectedThread.isAuthor && messages.every(m => m.hasReply) && (
+                    <p className="text-[10px] text-gray-400 mt-2 text-center">You have replied to all messages. Wait for the sender to message you again.</p>
+                  )}
+                </div>
+              </>
+            ) : (
+              <div className="flex-1 flex flex-col items-center justify-center text-gray-400 p-8">
+                <div className="bg-gray-100 dark:bg-gray-800 p-6 rounded-full mb-4">
+                  <MessageSquare className="w-12 h-12" />
+                </div>
+                <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">Select a conversation</h3>
+                <p className="text-sm max-w-xs text-center">
+                  Choose a message thread from the list to view the conversation.
+                </p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </AuthGuard>

--- a/xconfess-frontend/app/components/admin/AuditLogList.tsx
+++ b/xconfess-frontend/app/components/admin/AuditLogList.tsx
@@ -10,19 +10,33 @@ export default function AuditLogList() {
   const { triggerExport } = useExportCSV({ label: 'audit logs' });
   const [actionFilter, setActionFilter] = useState<string>("all");
   const [entityTypeFilter, setEntityTypeFilter] = useState<string>("all");
+  const [entityIdFilter, setEntityIdFilter] = useState("");
+  const [requestIdFilter, setRequestIdFilter] = useState("");
+  const [startDateFilter, setStartDateFilter] = useState("");
+  const [endDateFilter, setEndDateFilter] = useState("");
   const [page, setPage] = useState(1);
   const limit = 50;
 
+  const filters = {
+    actionFilter,
+    entityTypeFilter,
+    entityIdFilter: entityIdFilter.trim() || undefined,
+    requestIdFilter: requestIdFilter.trim() || undefined,
+    startDateFilter: startDateFilter || undefined,
+    endDateFilter: endDateFilter || undefined,
+    page,
+  };
+
   const { data, isLoading } = useQuery({
-    queryKey: queryKeys.admin.auditLogs.list({
-      actionFilter,
-      entityTypeFilter,
-      page,
-    }),
+    queryKey: queryKeys.admin.auditLogs.list(filters),
     queryFn: () =>
       adminApi.getAuditLogs({
         action: actionFilter !== "all" ? actionFilter : undefined,
         entityType: entityTypeFilter !== "all" ? entityTypeFilter : undefined,
+        entityId: entityIdFilter.trim() || undefined,
+        requestId: requestIdFilter.trim() || undefined,
+        startDate: startDateFilter || undefined,
+        endDate: endDateFilter || undefined,
         limit,
         offset: (page - 1) * limit,
       }),
@@ -31,6 +45,23 @@ export default function AuditLogList() {
   const logs = data?.logs || [];
   const total = data?.total || 0;
   const totalPages = Math.ceil(total / limit);
+  const hasActiveFilters =
+    actionFilter !== "all" ||
+    entityTypeFilter !== "all" ||
+    entityIdFilter.trim() ||
+    requestIdFilter.trim() ||
+    startDateFilter ||
+    endDateFilter;
+
+  const clearFilters = () => {
+    setActionFilter("all");
+    setEntityTypeFilter("all");
+    setEntityIdFilter("");
+    setRequestIdFilter("");
+    setStartDateFilter("");
+    setEndDateFilter("");
+    setPage(1);
+  };
 
   if (isLoading) {
     return (
@@ -44,18 +75,15 @@ export default function AuditLogList() {
     <div className="space-y-4">
       {/* Filters */}
       <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 mb-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Action
             </label>
             <select
               value={actionFilter}
-              onChange={(e) => {
-                setActionFilter(e.target.value);
-                setPage(1);
-              }}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
+              onChange={(e) => { setActionFilter(e.target.value); setPage(1); }}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
             >
               <option value="all">All</option>
               <option value="report_resolved">Report Resolved</option>
@@ -65,6 +93,9 @@ export default function AuditLogList() {
               <option value="user_banned">User Banned</option>
               <option value="user_unbanned">User Unbanned</option>
               <option value="bulk_action">Bulk Action</option>
+              <option value="report_created">Report Created</option>
+              <option value="failed_login">Failed Login</option>
+              <option value="moderation_escalation">Moderation Escalation</option>
             </select>
           </div>
           <div>
@@ -73,38 +104,95 @@ export default function AuditLogList() {
             </label>
             <select
               value={entityTypeFilter}
-              onChange={(e) => {
-                setEntityTypeFilter(e.target.value);
-                setPage(1);
-              }}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
+              onChange={(e) => { setEntityTypeFilter(e.target.value); setPage(1); }}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm"
             >
               <option value="all">All</option>
               <option value="report">Report</option>
               <option value="confession">Confession</option>
               <option value="user">User</option>
+              <option value="comment">Comment</option>
+              <option value="notification_dlq">Notification DLQ</option>
+              <option value="data_export">Data Export</option>
+              <option value="template_version">Template</option>
             </select>
           </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Entity ID
+            </label>
+            <input
+              type="text"
+              value={entityIdFilter}
+              onChange={(e) => { setEntityIdFilter(e.target.value); setPage(1); }}
+              placeholder="UUID of the target entity"
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm px-3 py-2 border"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Request ID
+            </label>
+            <input
+              type="text"
+              value={requestIdFilter}
+              onChange={(e) => { setRequestIdFilter(e.target.value); setPage(1); }}
+              placeholder="Correlation request ID"
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm px-3 py-2 border"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Start Date
+            </label>
+            <input
+              type="date"
+              value={startDateFilter}
+              onChange={(e) => { setStartDateFilter(e.target.value); setPage(1); }}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm px-3 py-2 border"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              End Date
+            </label>
+            <input
+              type="date"
+              value={endDateFilter}
+              onChange={(e) => { setEndDateFilter(e.target.value); setPage(1); }}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white text-sm px-3 py-2 border"
+            />
+          </div>
         </div>
-        <button
-          onClick={() => {
-            const exportData = logs.map((log: AuditLog) => ({
-              admin: log.admin?.username || `User ${log.adminId}`,
-              action: log.action,
-              entityType: log.entityType || "",
-              entityId: log.entityId || "",
-              notes: log.notes || "",
-              createdAt: new Date(log.createdAt).toLocaleString(),
-            }));
-            triggerExport(
-              exportData,
-              `audit-logs-${new Date().toISOString().split("T")[0]}.csv`,
-            );
-          }}
-          className="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 text-sm"
-        >
-          Export CSV
-        </button>
+        <div className="flex items-center gap-3 flex-wrap">
+          <button
+            onClick={() => {
+              const exportData = logs.map((log: AuditLog) => ({
+                admin: log.admin?.username || `User ${log.adminId}`,
+                action: log.action,
+                entityType: log.entityType || "",
+                entityId: log.entityId || "",
+                notes: log.notes || "",
+                createdAt: new Date(log.createdAt).toLocaleString(),
+              }));
+              triggerExport(
+                exportData,
+                `audit-logs-${new Date().toISOString().split("T")[0]}.csv`,
+              );
+            }}
+            className="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 text-sm"
+          >
+            Export CSV
+          </button>
+          {hasActiveFilters && (
+            <button
+              onClick={clearFilters}
+              className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
+            >
+              Clear all filters
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Audit Logs Table */}
@@ -113,29 +201,17 @@ export default function AuditLogList() {
           <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                  Admin
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                  Action
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                  Entity
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                  Notes
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                  Date
-                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Admin</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Action</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Entity</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Notes</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Request ID</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Date</th>
               </tr>
             </thead>
             <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
               {logs.map((log: AuditLog) => (
-                <tr
-                  key={log.id}
-                  className="hover:bg-gray-50 dark:hover:bg-gray-700"
-                >
+                <tr key={log.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                     {log.admin?.username || `User ${log.adminId}`}
                   </td>
@@ -150,6 +226,11 @@ export default function AuditLogList() {
                   <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate">
                     {log.notes || "-"}
                   </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 font-mono">
+                    {log.requestId
+                      ? log.requestId.substring(0, 8) + "..."
+                      : "-"}
+                  </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                     {new Date(log.createdAt).toLocaleString()}
                   </td>
@@ -158,27 +239,33 @@ export default function AuditLogList() {
             </tbody>
           </table>
         </div>
+        {logs.length === 0 && (
+          <div className="text-center py-12 text-gray-400 text-sm">
+            {hasActiveFilters
+              ? "No audit logs match your filters. Try adjusting the criteria."
+              : "No audit logs recorded yet."}
+          </div>
+        )}
       </div>
 
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between">
           <div className="text-sm text-gray-700 dark:text-gray-300">
-            Showing {(page - 1) * limit + 1} to {Math.min(page * limit, total)}{" "}
-            of {total} results
+            Showing {(page - 1) * limit + 1} to {Math.min(page * limit, total)} of {total} results
           </div>
           <div className="flex gap-2">
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="px-4 py-2 border rounded-md disabled:opacity-50"
+              className="px-4 py-2 border rounded-md disabled:opacity-50 text-sm"
             >
               Previous
             </button>
             <button
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={page === totalPages}
-              className="px-4 py-2 border rounded-md disabled:opacity-50"
+              className="px-4 py-2 border rounded-md disabled:opacity-50 text-sm"
             >
               Next
             </button>

--- a/xconfess-frontend/app/components/common/NetworkBanner.tsx
+++ b/xconfess-frontend/app/components/common/NetworkBanner.tsx
@@ -1,104 +1,117 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useNetwork } from "@/app/lib/providers/NetworkStatusProvider";
-import { WifiOff, AlertTriangle, RefreshCcw, X } from "lucide-react";
+import { WifiOff, AlertTriangle, ServerOff, RefreshCcw, X } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 
 export const NetworkBanner = () => {
-  const { isOnline, isDegraded } = useNetwork();
+  const { isOnline, isDegraded, isApiOnline, checkApiStatus } = useNetwork();
+  const queryClient = useQueryClient();
   const [isVisible, setIsVisible] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
-  const [lastStatus, setLastStatus] = useState({ isOnline, isDegraded });
+  const [offlineReason, setOfflineReason] = useState<"browser" | "api" | "degraded" | null>(null);
 
   useEffect(() => {
-    // Show banner if offline or degraded
-    if (!isOnline || isDegraded) {
+    if (!isOnline) {
+      setOfflineReason("browser");
       setIsVisible(true);
-      setLastStatus({ isOnline, isDegraded });
+    } else if (!isApiOnline) {
+      setOfflineReason("api");
+      setIsVisible(true);
+    } else if (isDegraded) {
+      setOfflineReason("degraded");
+      setIsVisible(true);
     } else {
-      // Small delay before hiding to avoid flickering on quick reconnections
-      const timer = setTimeout(() => setIsVisible(false), 3000);
+      const timer = setTimeout(() => {
+        setIsVisible(false);
+        setOfflineReason(null);
+      }, 3000);
       return () => clearTimeout(timer);
     }
-  }, [isOnline, isDegraded]);
+  }, [isOnline, isDegraded, isApiOnline]);
 
-  const handleRetry = () => {
+  const handleRetry = useCallback(async () => {
     setIsRetrying(true);
-    // Trigger a window refresh or a re-fetch of critical data
-    // For now, we simulate a retry by checking navigation status
-    setTimeout(() => {
-      setIsRetrying(false);
-      if (typeof window !== "undefined") {
-        window.location.reload();
+    if (offlineReason === "api" || offlineReason === "degraded") {
+      const ok = await checkApiStatus();
+      if (ok) {
+        queryClient.invalidateQueries();
       }
-    }, 1500);
-  };
+    } else if (typeof window !== "undefined" && "navigator" in window) {
+      if (navigator.onLine) {
+        const ok = await checkApiStatus();
+        if (ok) {
+          queryClient.invalidateQueries();
+        }
+      }
+    }
+    setIsRetrying(false);
+  }, [offlineReason, checkApiStatus, queryClient]);
 
   if (!isVisible) return null;
 
+  const icon = offlineReason === "browser" ? WifiOff : offlineReason === "api" ? ServerOff : AlertTriangle;
+  const Icon = icon;
+
+  const bannerTitle = {
+    browser: "You're offline",
+    api: "Backend unreachable",
+    degraded: "Unstable connection",
+  }[offlineReason!];
+
+  const bannerText = {
+    browser: "Check your internet connection.",
+    api: "The backend server is not responding. Retry when back online.",
+    degraded: "Some features may be limited.",
+  }[offlineReason!];
+
   return (
-    <div 
-      className={`fixed top-4 left-1/2 -translate-x-1/2 z-[100] w-[calc(100%-2rem)] max-w-md transition-all duration-500 ease-out transform ${
-        isVisible ? "translate-y-0 opacity-100" : "-translate-y-10 opacity-0"
-      }`}
-    >
-      <div className={`relative overflow-hidden rounded-2xl border p-4 shadow-2xl backdrop-blur-md ${
-        !lastStatus.isOnline 
-          ? "bg-red-500/10 border-red-500/20 text-red-200" 
-          : "bg-amber-500/10 border-amber-500/20 text-amber-200"
+    <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[100] w-[calc(100%-2rem)] max-w-sm transition-all duration-500 ease-out">
+      <div className={`relative overflow-hidden rounded-xl border p-3 shadow-2xl backdrop-blur-md ${
+        offlineReason === "browser"
+          ? "bg-red-500/10 border-red-500/20 text-red-200"
+          : offlineReason === "api"
+            ? "bg-orange-500/10 border-orange-500/20 text-orange-200"
+            : "bg-amber-500/10 border-amber-500/20 text-amber-200"
       }`}>
-        {/* Animated background gradient */}
-        <div className={`absolute inset-0 opacity-20 bg-gradient-to-r from-transparent via-white/10 to-transparent animate-shimmer`} />
-        
-        <div className="flex items-start gap-4 relative z-10">
-          <div className={`flex-shrink-0 rounded-xl p-2 ${
-            !lastStatus.isOnline ? "bg-red-500/20" : "bg-amber-500/20"
+        <div className="flex items-start gap-3">
+          <div className={`flex-shrink-0 rounded-lg p-1.5 ${
+            offlineReason === "browser" ? "bg-red-500/20" : offlineReason === "api" ? "bg-orange-500/20" : "bg-amber-500/20"
           }`}>
-            {!lastStatus.isOnline ? (
-              <WifiOff className="w-5 h-5 text-red-400" />
-            ) : (
-              <AlertTriangle className="w-5 h-5 text-amber-400" />
-            )}
+            <Icon className="w-4 h-4" />
           </div>
-          
-          <div className="flex-grow pt-0.5">
-            <h3 className="font-semibold text-sm">
-              {!lastStatus.isOnline ? "You're offline" : "Poor network connection"}
-            </h3>
-            <p className="text-xs opacity-70 mt-0.5 leading-relaxed">
-              {!lastStatus.isOnline 
-                ? "Check your internet connection and try again." 
-                : "Your connection is unstable. Some features may be limited."}
-            </p>
-            
-            <div className="mt-3 flex items-center gap-3">
+          <div className="flex-grow min-w-0">
+            <p className="font-semibold text-sm leading-tight">{bannerTitle}</p>
+            <p className="text-[11px] opacity-70 mt-0.5 leading-tight">{bannerText}</p>
+            <div className="mt-2 flex items-center gap-2">
               <button
                 onClick={handleRetry}
                 disabled={isRetrying}
-                className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
-                  !lastStatus.isOnline
+                className={`flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all ${
+                  offlineReason === "browser"
                     ? "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
-                    : "bg-amber-500 hover:bg-amber-600 text-white shadow-lg shadow-amber-500/20"
+                    : offlineReason === "api"
+                      ? "bg-orange-500 hover:bg-orange-600 text-white shadow-lg shadow-orange-500/20"
+                      : "bg-amber-500 hover:bg-amber-600 text-white shadow-lg shadow-amber-500/20"
                 } disabled:opacity-50`}
               >
-                <RefreshCcw className={`w-3.5 h-3.5 ${isRetrying ? "animate-spin" : ""}`} />
-                {isRetrying ? "Retrying..." : "Retry Connection"}
+                <RefreshCcw className={`w-3 h-3 ${isRetrying ? "animate-spin" : ""}`} />
+                {isRetrying ? "Checking..." : "Retry"}
               </button>
-              
               <button
                 onClick={() => setIsVisible(false)}
-                className="text-xs font-medium opacity-60 hover:opacity-100 transition-opacity"
+                className="text-[11px] font-medium opacity-60 hover:opacity-100 transition-opacity"
               >
                 Dismiss
               </button>
             </div>
           </div>
-
-          <button 
+          <button
             onClick={() => setIsVisible(false)}
-            className="flex-shrink-0 opacity-40 hover:opacity-100 transition-opacity p-1"
+            className="flex-shrink-0 opacity-40 hover:opacity-100 transition-opacity p-0.5"
           >
-            <X className="w-4 h-4" />
+            <X className="w-3.5 h-3.5" />
           </button>
         </div>
       </div>

--- a/xconfess-frontend/app/components/providers/QueryProvider.tsx
+++ b/xconfess-frontend/app/components/providers/QueryProvider.tsx
@@ -6,7 +6,7 @@ import { useNetwork } from '@/app/lib/providers/NetworkStatusProvider';
 import { isNetworkError } from '@/app/lib/utils/errorHandler';
 
 export default function QueryProvider({ children }: { children: React.ReactNode }) {
-  const { setDegraded } = useNetwork();
+  const { setDegraded, setApiOnline, checkApiStatus } = useNetwork();
   const [client] = useState(
     () =>
       new QueryClient({
@@ -17,10 +17,10 @@ export default function QueryProvider({ children }: { children: React.ReactNode 
             retry: 1,
             refetchOnReconnect: true,
             retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 30000),
-            // Global error handler for degradation detection
             throwOnError: (error) => {
               if (isNetworkError(error)) {
                 setDegraded(true);
+                setApiOnline(false);
               }
               return false;
             },
@@ -29,14 +29,11 @@ export default function QueryProvider({ children }: { children: React.ReactNode 
       }),
   );
 
-  // Handle page visibility changes for background tab recovery
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (!document.hidden) {
-        // Page became visible, invalidate potentially stale queries
         client.invalidateQueries({
           predicate: (query) => {
-            // Only refetch queries that are older than 30 seconds
             const age = Date.now() - (query.state.dataUpdatedAt || 0);
             return age > 30000;
           },
@@ -45,7 +42,7 @@ export default function QueryProvider({ children }: { children: React.ReactNode 
     };
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    
+
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };

--- a/xconfess-frontend/app/lib/api/admin.ts
+++ b/xconfess-frontend/app/lib/api/admin.ts
@@ -181,10 +181,19 @@ export const adminApi = {
     action?: string;
     entityType?: string;
     entityId?: string;
+    requestId?: string;
+    startDate?: string;
+    endDate?: string;
     limit?: number;
     offset?: number;
   }) => {
-    const response = await apiClient.get('/api/admin/audit-logs', { params });
+    const response = await apiClient.get('/api/admin/audit-logs', {
+      params: {
+        ...params,
+        startDate: params?.startDate || undefined,
+        endDate: params?.endDate || undefined,
+      },
+    });
     return response.data;
   },
 

--- a/xconfess-frontend/app/lib/providers/NetworkStatusProvider.tsx
+++ b/xconfess-frontend/app/lib/providers/NetworkStatusProvider.tsx
@@ -1,39 +1,77 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from "react";
 
 interface NetworkStatusContextType {
   isOnline: boolean;
   isDegraded: boolean;
+  isApiOnline: boolean;
   setDegraded: (degraded: boolean) => void;
+  setApiOnline: (online: boolean) => void;
+  checkApiStatus: () => Promise<boolean>;
 }
 
 const NetworkStatusContext = createContext<NetworkStatusContextType | undefined>(undefined);
 
+function getApiBaseUrl(): string {
+  if (typeof window === "undefined") return "http://localhost:3000";
+  return process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api";
+}
+
 export const NetworkStatusProvider = ({ children }: { children: React.ReactNode }) => {
   const [isOnline, setIsOnline] = useState(typeof navigator !== "undefined" ? navigator.onLine : true);
   const [isDegraded, setIsDegraded] = useState(false);
+  const [isApiOnline, setIsApiOnline] = useState(true);
+  const checkInFlight = useRef(false);
 
   const setDegradedValue = useCallback((degraded: boolean) => {
     setIsDegraded(degraded);
   }, []);
 
+  const setApiOnlineValue = useCallback((online: boolean) => {
+    setIsApiOnline(online);
+  }, []);
+
+  const checkApiStatus = useCallback(async (): Promise<boolean> => {
+    if (checkInFlight.current) return isApiOnline;
+    checkInFlight.current = true;
+    try {
+      const base = getApiBaseUrl().replace(/\/api\/?$/, "");
+      const controller = new AbortController();
+      const id = setTimeout(() => controller.abort(), 5000);
+      const res = await fetch(`${base}/api/health`, {
+        method: "GET",
+        signal: controller.signal,
+      });
+      clearTimeout(id);
+      const online = res.ok;
+      setIsApiOnline(online);
+      return online;
+    } catch {
+      setIsApiOnline(false);
+      return false;
+    } finally {
+      checkInFlight.current = false;
+    }
+  }, [isApiOnline]);
+
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const handleOnline = () => setIsOnline(true);
+    const handleOnline = () => {
+      setIsOnline(true);
+      checkApiStatus();
+    };
     const handleOffline = () => setIsOnline(false);
 
     window.addEventListener("online", handleOnline);
     window.addEventListener("offline", handleOffline);
 
-    // Network Information API for degradation detection
     const nav = navigator as any;
     const connection = nav.connection || nav.mozConnection || nav.webkitConnection;
 
     const updateConnectionStatus = () => {
       if (connection) {
-        // Degraded if effectiveType is 2g or slow-2g, or if rtt is high
         const degraded = 
           connection.effectiveType === "2g" || 
           connection.effectiveType === "slow-2g" ||
@@ -55,10 +93,10 @@ export const NetworkStatusProvider = ({ children }: { children: React.ReactNode 
         connection.removeEventListener("change", updateConnectionStatus);
       }
     };
-  }, []);
+  }, [checkApiStatus]);
 
   return (
-    <NetworkStatusContext.Provider value={{ isOnline, isDegraded, setDegraded: setDegradedValue }}>
+    <NetworkStatusContext.Provider value={{ isOnline, isDegraded, isApiOnline, setDegraded: setDegradedValue, setApiOnline: setApiOnlineValue, checkApiStatus }}>
       {children}
     </NetworkStatusContext.Provider>
   );


### PR DESCRIPTION
## Summary

This PR resolves four issues assigned for Wave 5:

### #903 — Reduce local backend boot warning noise
- **MailConfigValidator**: In local dev, downgrades mail config errors to actionable warnings (app continues without email)
- **EmailService**: No-primary-mail and no-fallback warnings become info-level logs in dev
- **MigrationVerificationService**: Schema readiness warnings now include the exact migration or index SQL command needed to fix them

### #911 — Improve NetworkBanner retry and API status behavior
- Added `isApiOnline` state to NetworkStatusProvider, distinct from browser `isOnline`
- Banner now shows three distinct states: browser offline, backend unreachable, degraded connection
- Retry calls `/api/health` and invalidates React Query caches instead of a full page reload
- Compact mobile-friendly banner with smaller padding and font sizes

### #912 — Polish messages page loading, empty, and error states
- Empty states (no threads, no messages) now include descriptive guidance text and icons
- Loading skeletons match actual content dimensions to preserve layout
- Reply failures preserve typed text in the input field (not cleared on error)
- Full responsive mobile layout with list/detail toggle via `MobileThreadList` component

### #914 — Improve admin audit log filters
- Added filter inputs for entity ID, request ID, start date, and end date
- Expanded action and entity type dropdowns to match backend enum values
- Table now includes a Request ID column for better incident review context
- Clear all filters button and empty-state guidance when no results match

Closes #903, Closes #911, Closes #912, Closes #914