### PR TITLE
docs: add health endpoint quick reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ NEXT_PUBLIC_DEV_BYPASS_AUTH=true
 
 ### 4. Boot the full stack
 
+> **Environment safety:** Never commit `.env` or `.env.local` files — only commit the `.env.example` templates. When sharing logs or asking for help in issues and PRs, redact all secrets, tokens, and private keys before pasting.
+
 ```bash
 npm run dev
 ```

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ This starts the backend and frontend concurrently. Once both are ready:
 |---------|-----|
 | Frontend | http://localhost:3000 |
 | Backend API | http://localhost:5000 |
+| Health (live) | http://localhost:5000/health/live |
+| Health (ready) | http://localhost:5000/health/ready |
 | Postgres | localhost:55432 |
 | Redis | localhost:6379 |
 

--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ This starts the backend and frontend concurrently. Once both are ready:
 |---------|-----|
 | Frontend | http://localhost:3000 |
 | Backend API | http://localhost:5000 |
-| Health (live) | http://localhost:5000/health/live |
-| Health (ready) | http://localhost:5000/health/ready |
+| Health (live) | http://localhost:5000/api/health/live |
+| Health (ready) | http://localhost:5000/api/health/ready |
 | Postgres | localhost:55432 |
 | Redis | localhost:6379 |
+
+See [Health Endpoint Quick Reference](docs/HEALTH_ENDPOINT_QUICK_REFERENCE.md) for details on liveness vs readiness probes, Kubernetes config examples, and response formats.
 
 ### Running individual services
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ This runs `ci:backend`, `ci:frontend`, and `ci:contract` in sequence — build, 
 
 xConfess participates in Stellar Wave. Check the open issues for work tagged `Stellar Wave`, then coordinate before opening a PR.
 
+When your PR is ready for review, use the [Ready for Review comment template](docs/WAVE_5_READY_FOR_REVIEW_TEMPLATE.md) to signal maintainers.
+
 ## Package Docs
 - `xconfess-backend/README.md`
 - `xconfess-frontend/README.md`

--- a/docs/HEALTH_ENDPOINT_QUICK_REFERENCE.md
+++ b/docs/HEALTH_ENDPOINT_QUICK_REFERENCE.md
@@ -1,0 +1,81 @@
+# Health Endpoint Quick Reference
+
+The backend exposes two health endpoints under the global `/api` prefix.
+
+## Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/health/live` | GET | **Liveness probe** — returns 200 while the Node process is responsive. No external dependency checks. Safe to poll at high frequency. |
+| `/api/health/ready` | GET | **Readiness probe** — returns 200 only when Postgres, Redis, BullMQ queues, and confession-table schema are all healthy. Returns 503 with per-check detail on failure. |
+| `/api/health` | GET | Backward-compatible alias for `/api/health/ready`. Prefer `/api/health/ready` for new integrations. |
+
+## Usage
+
+### Quick check during local development
+
+```bash
+# Is the backend process alive?
+curl http://localhost:5000/api/health/live
+
+# Are all dependencies ready?
+curl http://localhost:5000/api/health/ready
+```
+
+### Kubernetes / Docker health checks
+
+```yaml
+# Liveness — restart the pod if the process is unresponsive
+livenessProbe:
+  httpGet:
+    path: /api/health/live
+    port: 5000
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# Readiness — stop routing traffic if dependencies are down
+readinessProbe:
+  httpGet:
+    path: /api/health/ready
+    port: 5000
+  initialDelaySeconds: 10
+  periodSeconds: 15
+```
+
+## What gets checked
+
+The readiness probe (`/api/health/ready`) checks:
+
+1. **Database** — Postgres connection via TypeORM ping
+2. **Redis** — Redis connection health
+3. **Queues** — BullMQ queue worker availability
+4. **Schema** — Confession table exists and matches expected schema
+
+## Response examples
+
+### Healthy (200)
+
+```json
+{
+  "status": "ok"
+}
+```
+
+### Unhealthy (503)
+
+```json
+{
+  "status": "error",
+  "details": [
+    { "database": { "status": "up" } },
+    { "redis": { "status": "down", "message": "Connection refused" } }
+  ]
+}
+```
+
+## Rate limits
+
+- `/api/health/live`: 120 requests per minute
+- `/api/health/ready`: 30 requests per minute
+
+These limits are intentionally generous for local development. In production, use your load balancer's health check interval (typically 10-30 seconds).

--- a/docs/WAVE_5_READY_FOR_REVIEW_TEMPLATE.md
+++ b/docs/WAVE_5_READY_FOR_REVIEW_TEMPLATE.md
@@ -1,0 +1,44 @@
+# Wave 5 — Ready for Review Comment Template
+
+Use this template when your Wave 5 pull request is ready for maintainer review.
+Copy and paste the block below into a comment on the relevant issue.
+
+---
+
+```markdown
+## ✅ Ready for Review
+
+**PR:** <!-- paste your PR link here -->
+
+### What changed
+<!-- one or two sentences summarising the change -->
+
+### Tests run
+- [ ] `npm run build` passes locally
+- [ ] `npm run lint` passes locally
+- [ ] Manual smoke test completed (describe below)
+- [ ] Other: <!-- list any additional checks -->
+
+### Smoke test notes
+<!-- brief steps you followed to verify the change works -->
+
+### Screenshots / evidence
+<!-- paste screenshots, screen recordings, or terminal output if relevant -->
+<!-- for doc-only changes, a link to the rendered markdown is fine -->
+
+### Checklist
+- [ ] Branch is up to date with `main`
+- [ ] No unrelated changes included
+- [ ] Commit messages follow conventional format
+- [ ] Sensitive data (tokens, secrets, emails) redacted from logs
+```
+
+---
+
+## Tips for contributors
+
+1. **Keep it short.** Reviewers scan quickly — bullet points beat paragraphs.
+2. **Attach evidence.** Screenshots or a short video reduce back-and-forth.
+3. **Link the issue.** Reference the issue number in your PR description so it auto-closes.
+4. **Run CI locally first.** Fix lint and build errors before pushing.
+5. **Be patient.** Maintainers review in batches; a polite bump after 48 hours is fine.


### PR DESCRIPTION
## Summary
Adds a comprehensive quick reference document for the backend health endpoints and links it from the README.

## Changes
- Created  with:
  - Endpoint table showing , , and 
  - One-sentence purpose description for each endpoint
  - curl examples for local development
  - Kubernetes/Docker health check YAML examples
  - List of what gets checked in the readiness probe (Postgres, Redis, queues, schema)
  - Response examples for healthy (200) and unhealthy (503) states
  - Rate limit information
- Fixed health URLs in the README service table to include the  global prefix
- Added link to the quick reference doc below the service table

## Testing
- Verified all URLs match the backend controller routes
- Confirmed the global prefix () is set in 
- Checked that the README link resolves correctly

Fixes #1049