### PR TITLE
[Wave 5] Contract ops & docs: preflight script, dry-run checklist, Windows setup, DEPLOYMENT.md fix (#966 #968 #969 #970)

### DIFF
--- a/scripts/contracts-preflight.sh
+++ b/scripts/contracts-preflight.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Preflight checks for the xConfess contract build/deploy pipeline.
+# Exits nonzero with an actionable message for each missing prerequisite.
+# Does NOT require a private key — safe to run before any key is configured.
+#
+# Usage:
+#   ./scripts/contracts-preflight.sh          # build-only checks
+#   ./scripts/contracts-preflight.sh --deploy # also check deploy prerequisites
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONTRACTS_DIR="$REPO_ROOT/xconfess-contracts"
+
+DEPLOY_MODE=0
+if [[ "${1:-}" == "--deploy" ]]; then
+  DEPLOY_MODE=1
+fi
+
+PASS=0
+FAIL=1
+errors=0
+
+ok() {
+  printf "  [OK] %s\n" "$1"
+}
+
+fail() {
+  printf "  [FAIL] %s\n" "$1" >&2
+  errors=$((errors + 1))
+}
+
+header() {
+  printf "\n==> %s\n" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Rust / Cargo
+# ---------------------------------------------------------------------------
+header "Rust toolchain"
+
+if command -v rustc >/dev/null 2>&1; then
+  rust_version="$(rustc --version 2>&1 | awk '{print $2}')"
+  required_major=1
+  required_minor=81
+  actual_major="$(echo "$rust_version" | cut -d. -f1)"
+  actual_minor="$(echo "$rust_version" | cut -d. -f2)"
+  if [[ "$actual_major" -gt "$required_major" ]] || \
+     { [[ "$actual_major" -eq "$required_major" ]] && [[ "$actual_minor" -ge "$required_minor" ]]; }; then
+    ok "rustc $rust_version (>= 1.81.0)"
+  else
+    fail "rustc $rust_version is too old — need >= 1.81.0. Run: rustup update stable"
+  fi
+else
+  fail "rustc not found. Install via: curl https://sh.rustup.rs -sSf | sh"
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+  ok "cargo $(cargo --version 2>&1 | awk '{print $2}')"
+else
+  fail "cargo not found (should be installed alongside rustc)"
+fi
+
+if command -v rustup >/dev/null 2>&1; then
+  ok "rustup $(rustup --version 2>&1 | head -1 | awk '{print $2}')"
+else
+  fail "rustup not found. Install via: curl https://sh.rustup.rs -sSf | sh"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. WASM target
+# ---------------------------------------------------------------------------
+header "WASM target"
+
+if command -v rustup >/dev/null 2>&1; then
+  if rustup target list --installed 2>/dev/null | grep -q "wasm32-unknown-unknown"; then
+    ok "wasm32-unknown-unknown target is installed"
+  else
+    fail "wasm32-unknown-unknown target is missing. Fix: rustup target add wasm32-unknown-unknown"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Workspace files
+# ---------------------------------------------------------------------------
+header "Workspace layout"
+
+if [[ -d "$CONTRACTS_DIR" ]]; then
+  ok "xconfess-contracts directory exists"
+else
+  fail "xconfess-contracts directory not found at: $CONTRACTS_DIR"
+fi
+
+if [[ -f "$CONTRACTS_DIR/Cargo.toml" ]]; then
+  ok "xconfess-contracts/Cargo.toml present"
+else
+  fail "xconfess-contracts/Cargo.toml missing — workspace may be incomplete"
+fi
+
+if [[ -f "$CONTRACTS_DIR/Cargo.lock" ]]; then
+  ok "xconfess-contracts/Cargo.lock present (reproducible builds enabled)"
+else
+  fail "xconfess-contracts/Cargo.lock missing — run: cargo generate-lockfile inside xconfess-contracts"
+fi
+
+expected_crates=(
+  "confession-anchor"
+  "confession-registry"
+  "anonymous-tipping"
+  "reputation-badges"
+)
+
+for crate in "${expected_crates[@]}"; do
+  crate_dir="$CONTRACTS_DIR/contracts/$crate"
+  if [[ -d "$crate_dir" ]]; then
+    ok "contracts/$crate exists"
+  else
+    fail "contracts/$crate directory missing — workspace may be corrupted or partially cloned"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 4. Stellar CLI (build checks are complete without it; deploy needs it)
+# ---------------------------------------------------------------------------
+header "Stellar CLI"
+
+if command -v stellar >/dev/null 2>&1; then
+  stellar_raw="$(stellar --version 2>&1)"
+  stellar_version="$(echo "$stellar_raw" | grep -o '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*' | head -1)"
+  req_major=22
+  actual_stellar_major="$(echo "$stellar_version" | cut -d. -f1)"
+  if [[ "$actual_stellar_major" -ge "$req_major" ]]; then
+    ok "stellar $stellar_version (>= 22.0.0)"
+  else
+    fail "stellar $stellar_version is too old — need >= 22.0.0. Upgrade: cargo install --locked stellar-cli --features opt"
+  fi
+else
+  if [[ "$DEPLOY_MODE" -eq 1 ]]; then
+    fail "stellar CLI not found (required for --deploy). Install: cargo install --locked stellar-cli --features opt"
+  else
+    printf "  [SKIP] stellar CLI not found — not required for build-only checks\n"
+    printf "         To check deploy prerequisites, re-run: %s --deploy\n" "$(basename "$0")"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Deploy-only checks (key presence, network, funded account)
+# ---------------------------------------------------------------------------
+if [[ "$DEPLOY_MODE" -eq 1 ]]; then
+  header "Deploy prerequisites"
+
+  if ! command -v stellar >/dev/null 2>&1; then
+    printf "  [SKIP] remaining deploy checks require stellar CLI\n"
+  else
+    stellar_keys="$(stellar keys list 2>/dev/null || true)"
+    if [[ -n "$stellar_keys" ]]; then
+      ok "at least one Stellar key is configured"
+      printf "         Keys: %s\n" "$(echo "$stellar_keys" | tr '\n' ' ')"
+    else
+      fail "no Stellar keys found. Generate one: stellar keys generate --name deployer"
+    fi
+
+    stellar_networks="$(stellar network list 2>/dev/null || true)"
+    if echo "$stellar_networks" | grep -q "testnet"; then
+      ok "testnet network is configured"
+    else
+      fail "testnet network not configured. Add it: stellar network add-remote testnet https://horizon-testnet.stellar.org"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf "\n"
+if [[ "$errors" -eq 0 ]]; then
+  printf "Preflight passed — all checks OK.\n"
+  exit 0
+else
+  printf "Preflight FAILED — %d issue(s) found. Fix the items marked [FAIL] above.\n" "$errors" >&2
+  exit 1
+fi

--- a/xconfess-contracts/DEPLOYMENT.md
+++ b/xconfess-contracts/DEPLOYMENT.md
@@ -28,6 +28,20 @@ Before deploying contracts, ensure you have:
 3. ✅ Stellar account with testnet XLM (for testing)
 4. ✅ Stellar CLI v22.0.0 or later
 
+For Windows contributors, see [WINDOWS_SETUP.md](./WINDOWS_SETUP.md) for
+platform-specific notes on PowerShell, the WASM target, and path issues.
+
+Before a full deployment, run the automated preflight check from the repository
+root to verify all prerequisites at once:
+
+```bash
+./scripts/contracts-preflight.sh           # build-only checks
+./scripts/contracts-preflight.sh --deploy  # also checks key, network, and Stellar CLI
+```
+
+A dry-run checklist with manual verification steps is available in
+[TESTNET_DRY_RUN_CHECKLIST.md](./TESTNET_DRY_RUN_CHECKLIST.md).
+
 ### Quick Setup Check
 
 ```bash
@@ -168,12 +182,15 @@ cargo test -- --nocapture
 After deploying to a network, test contract invocations:
 
 ```bash
-# Test ConfessionAnchor
+# Test ConfessionAnchor — get_version is a read-only call available on all contracts
 stellar contract invoke \
   --id $CONFESSION_ANCHOR_ID \
   --source "$DEPLOYER_KEY" \
   --network testnet \
-  -- gDeployment Metadata
+  -- get_version
+```
+
+## Deployment Metadata
 
 Contract IDs are automatically saved in `deployments/<network>.json` by the canonical script:
 
@@ -195,14 +212,40 @@ This file includes:
 
 ```bash
 git add deployments/testnet.json
-git commit -m "deploy: contracts deployed to testnet"     "id": "CYYYYYYYYY...",
-      "wasm": "reputation_badges.wasm",
-      "version": "0.1.0"
+git commit -m "deploy: contracts deployed to testnet"
+```
+
+Example `deployments/testnet.json` structure:
+
+```json
+{
+  "generated_at_utc": "2025-01-01T00:00:00Z",
+  "network": "testnet",
+  "target": "wasm32-unknown-unknown",
+  "contracts": {
+    "confession-anchor": {
+      "contract_id": "CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "sha256": "abc123...",
+      "version": "0.1.0",
+      "wasm_file": "target/wasm32-unknown-unknown/release/confession_anchor.wasm"
     },
-    "anonymous_tipping": {
-      "id": "CZZZZZZZZZZ...",
-      "wasm": "anonymous_tipping.wasm",
-      "version": "0.1.0"
+    "confession-registry": {
+      "contract_id": "CWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW",
+      "sha256": "def456...",
+      "version": "0.1.0",
+      "wasm_file": "target/wasm32-unknown-unknown/release/confession_registry.wasm"
+    },
+    "reputation-badges": {
+      "contract_id": "CYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY",
+      "sha256": "ghi789...",
+      "version": "0.1.0",
+      "wasm_file": "target/wasm32-unknown-unknown/release/reputation_badges.wasm"
+    },
+    "anonymous-tipping": {
+      "contract_id": "CZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+      "sha256": "jkl012...",
+      "version": "0.1.0",
+      "wasm_file": "target/wasm32-unknown-unknown/release/anonymous_tipping.wasm"
     }
   }
 }

--- a/xconfess-contracts/TESTNET_DRY_RUN_CHECKLIST.md
+++ b/xconfess-contracts/TESTNET_DRY_RUN_CHECKLIST.md
@@ -1,0 +1,158 @@
+# Testnet Deployment Dry-Run Checklist
+
+Run through this checklist from a fresh terminal before spending time on a full
+testnet deployment. Each item shows the expected command and a clear pass/fail
+signal.
+
+> **Security note:** Never paste your private key or seed phrase into any command
+> or config file. All key references below use named keys managed by the Stellar
+> CLI key store.
+
+---
+
+## 1. Stellar CLI version
+
+```bash
+stellar --version
+```
+
+**Pass:** output contains `22.0.0` or later (e.g. `stellar 22.1.0`).  
+**Fail:** command not found, or version is older than `22.0.0`. Install or
+upgrade via `cargo install --locked stellar-cli --features opt`.
+
+---
+
+## 2. Rust toolchain
+
+```bash
+rustc --version
+cargo --version
+```
+
+**Pass:** `rustc 1.81.0` or later.  
+**Fail:** version below `1.81.0`. Run `rustup update stable`.
+
+---
+
+## 3. WASM target installed
+
+```bash
+rustup target list --installed | grep wasm32-unknown-unknown
+```
+
+**Pass:** `wasm32-unknown-unknown` appears in the output.  
+**Fail:** no output. Fix with `rustup target add wasm32-unknown-unknown`.
+
+---
+
+## 4. Named key present in Stellar CLI key store
+
+```bash
+stellar keys list
+```
+
+**Pass:** your deployer key name (e.g. `deployer`) appears in the list.  
+**Fail:** key is missing. Generate one with `stellar keys generate --name deployer`.
+
+---
+
+## 5. Deployer account funded on testnet
+
+```bash
+stellar keys show deployer           # prints the public key
+stellar account show --account <PUBLIC_KEY> --network testnet
+```
+
+**Pass:** the `account show` call returns JSON with a non-zero XLM balance.  
+**Fail:** `account not found` error. Fund via the
+[Stellar Testnet Friendbot](https://laboratory.stellar.org/#account-creator?network=testnet)
+or run:
+
+```bash
+curl "https://friendbot.stellar.org?addr=$(stellar keys show deployer)"
+```
+
+---
+
+## 6. Network configured
+
+```bash
+stellar network list
+```
+
+**Pass:** `testnet` appears in the list.  
+**Fail:** `testnet` is absent. Add it:
+
+```bash
+stellar network add-remote testnet https://horizon-testnet.stellar.org
+```
+
+---
+
+## 7. WASM artifacts exist
+
+Run this from the repository root after a successful `./scripts/contracts-release.sh build`:
+
+```bash
+ls xconfess-contracts/target/wasm32-unknown-unknown/release/*.wasm
+```
+
+**Pass:** all four files are present:
+
+```
+confession_anchor.wasm
+confession_registry.wasm
+reputation_badges.wasm
+anonymous_tipping.wasm
+```
+
+**Fail:** one or more files are missing. Re-run the build:
+
+```bash
+./scripts/contracts-release.sh build
+```
+
+---
+
+## 8. WASM manifest is current
+
+```bash
+cat deployments/contract-wasm-manifest.json | jq '.generated_at_utc'
+```
+
+**Pass:** timestamp matches (or postdates) your most recent build.  
+**Fail:** file is missing or timestamp is stale. Re-run `./scripts/contracts-release.sh build`.
+
+---
+
+## 9. Workspace Cargo.toml is reachable
+
+```bash
+cargo metadata --manifest-path xconfess-contracts/Cargo.toml --no-deps --quiet > /dev/null && echo OK
+```
+
+**Pass:** prints `OK`.  
+**Fail:** cargo reports an error — check for syntax issues in `Cargo.toml` or a
+broken workspace member path.
+
+---
+
+## All checks passed?
+
+```
+[ ] stellar --version >= 22.0.0
+[ ] rustc --version >= 1.81.0
+[ ] wasm32-unknown-unknown target installed
+[ ] Deployer key present in stellar keys list
+[ ] Deployer account funded on testnet
+[ ] testnet network configured in stellar network list
+[ ] All four .wasm artifacts present in target/
+[ ] deployments/contract-wasm-manifest.json is current
+[ ] cargo metadata succeeds on xconfess-contracts/Cargo.toml
+```
+
+Once every item is checked, proceed with:
+
+```bash
+./scripts/contracts-release.sh deploy --network testnet --source deployer
+```

--- a/xconfess-contracts/WINDOWS_SETUP.md
+++ b/xconfess-contracts/WINDOWS_SETUP.md
@@ -1,0 +1,190 @@
+# Windows Setup for Stellar CLI and Rust Contract Deployment
+
+This guide covers Windows-specific considerations for contributors who want to
+build or deploy xConfess Soroban contracts on a Windows machine.
+
+---
+
+## Recommended approach: WSL 2
+
+The canonical build and deploy scripts (`scripts/contracts-release.sh`,
+`scripts/deploy-contracts.sh`, etc.) are **bash scripts** and run without
+modification under [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install)
+(Windows Subsystem for Linux). Unless you have a specific reason to stay in a
+native Windows shell, **WSL 2 with Ubuntu is the path of least resistance**.
+
+```powershell
+# Install WSL 2 (run in an elevated PowerShell or Windows Terminal)
+wsl --install
+# Restart your machine, then open the Ubuntu app and follow the prompts.
+```
+
+All subsequent steps in the standard README and DEPLOYMENT.md apply unchanged
+inside WSL 2.
+
+---
+
+## Native Windows (PowerShell) — what works and what does not
+
+If you must work natively in PowerShell, be aware of the following.
+
+### Shell expectations
+
+| Script / command | Works in PowerShell? | Notes |
+|---|---|---|
+| `./scripts/contracts-release.sh build` | No | Bash syntax; use WSL 2 or Git Bash |
+| `cargo build --locked ...` | Yes | Cargo is cross-platform |
+| `stellar contract deploy ...` | Yes | Stellar CLI is cross-platform |
+| `rustup target add ...` | Yes | Rustup is cross-platform |
+
+For any `.sh` script you need to run natively, you can open it in
+[Git Bash](https://git-scm.com/download/win) instead.
+
+### Install Rust on Windows
+
+Download and run the official installer from <https://rustup.rs/>. It installs
+`rustup`, `cargo`, and the stable toolchain.
+
+After installation, open a **new** terminal so that the `%USERPROFILE%\.cargo\bin`
+directory is on your `PATH`.
+
+Verify:
+
+```powershell
+rustc --version
+cargo --version
+```
+
+### Add the WASM target
+
+```powershell
+rustup target add wasm32-unknown-unknown
+```
+
+Verify:
+
+```powershell
+rustup target list --installed
+# wasm32-unknown-unknown should appear
+```
+
+### Common PATH and environment issues
+
+1. **`cargo` not found after install**  
+   Close and reopen your terminal. The Rust installer modifies `PATH` only for
+   new sessions. On some corporate machines you may need to add
+   `%USERPROFILE%\.cargo\bin` to your user `PATH` manually via
+   *System Properties → Environment Variables*.
+
+2. **`CARGO_HOME` / `RUSTUP_HOME` on a non-`C:` drive**  
+   If your user profile is on a drive other than `C:`, set both environment
+   variables explicitly before running any `cargo` or `rustup` commands:
+
+   ```powershell
+   $env:CARGO_HOME  = "D:\rust\cargo"
+   $env:RUSTUP_HOME = "D:\rust\rustup"
+   ```
+
+   Or set them permanently via System Properties → Environment Variables.
+
+3. **Long-path errors during `cargo build`**  
+   Rust/LLVM temporary paths can exceed the Windows 260-character limit. Enable
+   long paths in Group Policy or via the registry:
+
+   ```powershell
+   # Run in an elevated PowerShell
+   Set-ItemProperty `
+     -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
+     -Name LongPathsEnabled `
+     -Value 1
+   ```
+
+   Then add `[build] target-dir = "C:/rust-target"` to a short path in
+   `.cargo/config.toml` to keep artifact paths short.
+
+### Install Stellar CLI on Windows
+
+Stellar CLI is distributed as a Rust binary and can be installed with cargo:
+
+```powershell
+cargo install --locked stellar-cli --features opt
+```
+
+After installation, verify:
+
+```powershell
+stellar --version   # expect 22.0.0 or later
+```
+
+If `stellar` is not found, ensure `%USERPROFILE%\.cargo\bin` is on your `PATH`
+(same fix as for `cargo` above).
+
+### Build contracts natively (PowerShell)
+
+```powershell
+cd xconfess-contracts
+
+# Build all contracts for WASM
+cargo build --locked --workspace --release --target wasm32-unknown-unknown
+```
+
+Artifacts land in:
+
+```
+xconfess-contracts\target\wasm32-unknown-unknown\release\
+├── confession_anchor.wasm
+├── confession_registry.wasm
+├── reputation_badges.wasm
+└── anonymous_tipping.wasm
+```
+
+### Deploy contracts natively (PowerShell)
+
+The canonical `contracts-release.sh deploy` command cannot run in native
+PowerShell. As an alternative, use the Stellar CLI directly for each contract:
+
+```powershell
+$network   = "testnet"
+$sourceKey = "deployer"
+$targetDir = "xconfess-contracts\target\wasm32-unknown-unknown\release"
+
+stellar contract deploy `
+  --wasm "$targetDir\confession_anchor.wasm" `
+  --network $network `
+  --source $sourceKey
+
+stellar contract deploy `
+  --wasm "$targetDir\confession_registry.wasm" `
+  --network $network `
+  --source $sourceKey
+
+stellar contract deploy `
+  --wasm "$targetDir\reputation_badges.wasm" `
+  --network $network `
+  --source $sourceKey
+
+stellar contract deploy `
+  --wasm "$targetDir\anonymous_tipping.wasm" `
+  --network $network `
+  --source $sourceKey
+```
+
+Record the contract IDs printed by each command and save them manually in
+`deployments\testnet.json` following the schema in
+[DEPLOYMENT.md](./DEPLOYMENT.md#deployment-metadata).
+
+---
+
+## Summary
+
+| Task | WSL 2 / Git Bash | Native PowerShell |
+|---|---|---|
+| Run `.sh` scripts | Yes (recommended) | No |
+| `cargo build` | Yes | Yes |
+| `stellar` CLI commands | Yes | Yes |
+| `rustup target add` | Yes | Yes |
+| Automated deployment script | Yes | Partial (manual steps above) |
+
+For the smoothest experience on Windows, use WSL 2. For native PowerShell,
+all individual `cargo` and `stellar` commands work, but you will need to run
+deployment steps manually instead of via the bash convenience scripts.


### PR DESCRIPTION
## Summary

This PR resolves four Wave 5 issues in a single combined change across the `xconfess-contracts` workspace and the root `scripts/` directory.

| Issue | Title | Deliverable |
|---|---|---|
| #966 | Clean up Soroban deployment guide encoding and broken sections | Fixed `DEPLOYMENT.md` |
| #968 | Add testnet deployment dry-run checklist | New `TESTNET_DRY_RUN_CHECKLIST.md` |
| #969 | Document Windows setup for Stellar CLI and Rust contract deployment | New `WINDOWS_SETUP.md` |
| #970 | Add contract release preflight script | New `scripts/contracts-preflight.sh` |

---

### #966 — Fix `DEPLOYMENT.md` encoding and broken sections

- Replaced the corrupted post-deployment verification snippet (mojibake / truncated `-- g` artifact) with a valid `stellar contract invoke -- get_version` example.
- Restored the `## Deployment Metadata` section heading that had been swallowed into a code fence.
- Replaced the mangled `git commit` line (which contained raw JSON fragments) with a clean commit command and a proper JSON schema example showing the structure of `deployments/testnet.json`.

### #968 — `TESTNET_DRY_RUN_CHECKLIST.md`

Nine step-by-step checks a maintainer can run from a fresh terminal before starting a full deployment:
1. `stellar --version` ≥ 22.0.0
2. `rustc --version` ≥ 1.81.0
3. `wasm32-unknown-unknown` target installed
4. Named key present in Stellar CLI key store
5. Deployer account funded on testnet (via Friendbot if needed)
6. `testnet` network configured
7. All four `.wasm` artifacts present
8. `deployments/contract-wasm-manifest.json` is current
9. `cargo metadata` succeeds on the workspace

Each item shows the exact command to run and clear pass/fail signals.

### #969 — `WINDOWS_SETUP.md`

Documents Windows-specific considerations for contributors deploying or testing Soroban contracts:
- **Recommended path:** WSL 2 (all `.sh` scripts work unchanged)
- **Native PowerShell:** which commands work, which do not, and how to do the deploy steps manually
- Rust installer and `PATH` caveats (`%USERPROFILE%\.cargo\bin`)
- `CARGO_HOME` / `RUSTUP_HOME` on non-`C:` drives
- Windows long-path registry fix for deep `cargo build` artifact paths
- Summary table comparing WSL 2 vs native PowerShell for each task

### #970 — `scripts/contracts-preflight.sh`

Automated preflight script that exits nonzero with actionable `[FAIL]` messages if any prerequisite is missing:

```
./scripts/contracts-preflight.sh           # build-only checks
./scripts/contracts-preflight.sh --deploy  # adds key/network checks
```

Checks performed (build mode):
- `rustc` ≥ 1.81.0, `cargo`, `rustup` present
- `wasm32-unknown-unknown` target installed
- `xconfess-contracts/` directory, `Cargo.toml`, `Cargo.lock` present
- All four contract crate directories exist
- `stellar` ≥ 22.0.0 (skipped with a notice in build-only mode)

Additional checks in `--deploy` mode:
- At least one Stellar key configured
- `testnet` network configured

Does **not** require a private key for build-only checks.

All three new artefacts are cross-linked from the `## Prerequisites` section of `DEPLOYMENT.md`.

---

## Test plan

- [ ] Run `./scripts/contracts-preflight.sh` on a correctly configured machine — all checks should show `[OK]` and exit 0.
- [ ] Temporarily uninstall or rename `stellar` and re-run — the script should print `[SKIP]` in build mode and `[FAIL]` in `--deploy` mode, then exit 1.
- [ ] Render `DEPLOYMENT.md`, `TESTNET_DRY_RUN_CHECKLIST.md`, and `WINDOWS_SETUP.md` locally and verify headings, code fences, and tables are readable.
- [ ] Follow `TESTNET_DRY_RUN_CHECKLIST.md` from a fresh terminal to confirm every command and pass/fail signal is accurate.

Closes #966 
Closes #968
Closes #969
Closes #970