### PR TITLE
Wave5 docs 1031 1034 1050 1051

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ docker compose -f compose.yaml ps
 
 ### 3. Configure environment files
 
+> **Security reminder:** Never commit `.env` or `.env.local` files. Always commit only the `.env.example` template files (which contain no real secrets). Do not paste real secret values into issues, PR descriptions, or comments.
+
 **Backend** — copy the sample and fill in the values marked `change-me`:
 
 ```bash
@@ -99,6 +101,7 @@ This starts the backend and frontend concurrently. Once both are ready:
 |---------|-----|
 | Frontend | http://localhost:3000 |
 | Backend API | http://localhost:5000 |
+| Backend health | http://localhost:5000/health |
 | Postgres | localhost:55432 |
 | Redis | localhost:6379 |
 

--- a/WAVE_5_ROADMAP.md
+++ b/WAVE_5_ROADMAP.md
@@ -65,12 +65,13 @@ Wave 5 should move XConfess from a completed Wave 1-4 implementation into a stro
 
 ### 6. Wave 5 Reporting Package
 
-- Prepare a short Wave 5 progress summary.
+- Prepare a short Wave 5 progress summary using `maintainer/WAVE_5_PROGRESS_TEMPLATE.md`.
 - Capture screenshots or a demo script for the main flows — see `docs/DEMO_SCRIPT.md`.
 - List completed Wave 5 work, remaining risks, and next milestones.
 - Link key verification commands and results.
 - Keep the external contributor issue queue aligned with `maintainer/WAVE_TRIAGE.md`.
 - Use `maintainer/WAVE_5_CONTRIBUTOR_ASSIGNMENT.md` for contributor assignment process.
+- Use `maintainer/DASHBOARD_SYNC_CHECKLIST.md` to keep GitHub issue status aligned with the Drips Wave dashboard.
 
 ## Immediate Next Actions
 

--- a/maintainer/DASHBOARD_SYNC_CHECKLIST.md
+++ b/maintainer/DASHBOARD_SYNC_CHECKLIST.md
@@ -1,0 +1,65 @@
+# Maintainer Dashboard Sync Checklist
+
+Use this checklist to keep GitHub issue status aligned with the Drips Wave dashboard. Run it at least once per week during Wave 5, and again before the Wave 5 deadline.
+
+To find all open Stellar Wave issues, filter by the `Stellar Wave` label:
+`is:issue is:open label:"Stellar Wave"`
+
+---
+
+## Issue state transitions
+
+Work through the open issue list and apply the correct state for each.
+
+### Assigned
+
+- [ ] The issue has an assignee set in GitHub.
+- [ ] The assignee has acknowledged the issue (commented or opened a draft PR).
+- [ ] If no acknowledgment within 4 hours of assignment, ping the contributor per the process in `WAVE_5_CONTRIBUTOR_ASSIGNMENT.md`.
+
+### In progress
+
+- [ ] A draft PR or branch exists with at least one meaningful commit.
+- [ ] The issue has a status comment from the assignee or maintainer showing recent activity.
+- [ ] If no visible progress after 5 days, ask for a status update in the issue thread.
+
+### Blocked
+
+- [ ] A `blocked` label is applied to the issue.
+- [ ] A comment explains what the issue is waiting on and who owns the unblock.
+- [ ] The issue is removed from the active Wave queue until the blocker resolves.
+- [ ] Check back within 48 hours to see if the blocker has cleared.
+
+### Merged
+
+- [ ] The PR that closes the issue has been merged.
+- [ ] The issue is closed (GitHub closes it automatically if the PR uses `Closes #NNN`; verify).
+- [ ] The issue no longer appears in the open `Stellar Wave` query above.
+- [ ] Add the issue and PR to the Wave 5 progress report using `WAVE_5_PROGRESS_TEMPLATE.md`.
+
+### Closed (without merge)
+
+- [ ] A comment explains why the issue was closed without a merged PR.
+- [ ] The `Stellar Wave` label is removed if the issue will not be re-opened in this wave.
+- [ ] If the work is partially complete and salvageable, open a follow-up issue and link it.
+
+---
+
+## Pre-deadline sweep
+
+Run this additional sweep before the Wave 5 deadline.
+
+- [ ] Every open `Stellar Wave` issue has either an open PR or a clear owner comment.
+- [ ] Issues with no activity for > 7 days have been pinged or closed.
+- [ ] Issues that cannot close before the deadline are labeled and noted for rollover.
+- [ ] All merged PRs are reflected as closed issues — no merged-but-open stragglers.
+- [ ] The Wave 5 progress report (`WAVE_5_PROGRESS_TEMPLATE.md`) is up to date.
+- [ ] `maintainer/BACKLOG_INDEX.md` reflects any new issues added during Wave 5.
+
+---
+
+## Notes
+
+- Always leave a comment when changing issue state so the contributor and other maintainers have a clear audit trail.
+- Do not close an issue as completed unless the corresponding PR has been reviewed and merged.
+- If an issue was assigned but the contributor is unresponsive for > 7 days after pings, close per the process in `WAVE_5_CONTRIBUTOR_ASSIGNMENT.md`.

--- a/maintainer/WAVE_5_PROGRESS_TEMPLATE.md
+++ b/maintainer/WAVE_5_PROGRESS_TEMPLATE.md
@@ -1,0 +1,71 @@
+# Wave 5 Progress Report
+
+> **Usage:** Copy this template for weekly check-ins or the Wave 5 closeout summary. Fill in each section, remove placeholder text, and delete any rows or fields that do not apply. Do not include contributor names, email addresses, GitHub handles, wallet addresses, or any other private contributor data.
+
+---
+
+## Report period
+
+- **From:** <!-- YYYY-MM-DD -->
+- **To:** <!-- YYYY-MM-DD -->
+- **Report type:** <!-- Weekly check-in | Closeout summary -->
+
+---
+
+## Completed issues
+
+List issues closed during this period. Omit issues that are still open.
+
+| Issue # | Title | Subsystem |
+|---------|-------|-----------|
+| <!-- #NNN --> | <!-- short title --> | <!-- backend / frontend / contracts / docs / ops --> |
+
+---
+
+## Merged PRs
+
+List PRs merged during this period.
+
+| PR # | Title | Related issue(s) |
+|------|-------|-----------------|
+| <!-- #NNN --> | <!-- short title --> | <!-- #NNN or — --> |
+
+---
+
+## Test status
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Backend unit tests (`npm run backend:test`) | <!-- pass / fail / skipped --> | |
+| Frontend build (`npm run frontend:build`) | <!-- pass / fail / skipped --> | |
+| Contract checks (`cargo test --workspace`) | <!-- pass / fail / skipped --> | |
+| Full CI (`npm run ci`) | <!-- pass / fail / skipped --> | |
+
+---
+
+## Demo notes
+
+Brief notes on what can be demonstrated at this point in Wave 5. Focus on user-visible flows, not implementation details.
+
+- <!-- e.g. "Confession feed loads and displays reactions end-to-end on local stack." -->
+- <!-- e.g. "Tipping flow reaches the Soroban testnet contract." -->
+
+---
+
+## Risks and blockers
+
+List anything that could delay Wave 5 delivery. If there are none, write "None."
+
+| Risk or blocker | Severity | Mitigation or owner |
+|----------------|----------|---------------------|
+| <!-- description --> | <!-- High / Medium / Low --> | <!-- action or — --> |
+
+---
+
+## Next steps
+
+Ordered list of the highest-priority remaining tasks before Wave 5 closeout.
+
+1. <!-- task -->
+2. <!-- task -->
+3. <!-- task -->


### PR DESCRIPTION
# [Wave 5] Add maintainer docs: progress template, dashboard checklist, local URL reference, and env safety reminder

## Summary

This PR addresses four trivial Wave 5 documentation tasks in a single focused change:

- **#1031** – Adds `maintainer/WAVE_5_PROGRESS_TEMPLATE.md`, a structured template maintainers can fill in for weekly check-ins or the Wave 5 closeout report. Covers completed issues, merged PRs, test status, demo notes, risks, and next steps. Does not include private contributor data. Linked from `WAVE_5_ROADMAP.md`.
- **#1034** – Adds `maintainer/DASHBOARD_SYNC_CHECKLIST.md`, a checklist for keeping GitHub issue status in sync with the Drips Wave dashboard. Covers the full issue lifecycle (assigned → in progress → blocked → merged → closed), a pre-deadline sweep, references the `Stellar Wave` label query, and cross-links `WAVE_5_CONTRIBUTOR_ASSIGNMENT.md`.
- **#1050** – Adds the backend health URL (`http://localhost:5000/health`) to the local services table in `README.md`, keeping the quick reference complete for contributors doing local dev.
- **#1051** – Adds a concise env file safety reminder to `README.md` near the "Configure environment files" section, reminding contributors not to commit `.env`/`.env.local` files, to use `.env.example` templates instead, and not to paste secrets into issues or PRs.

## Files changed

- `maintainer/WAVE_5_PROGRESS_TEMPLATE.md` — new file (issue #1031)
- `maintainer/DASHBOARD_SYNC_CHECKLIST.md` — new file (issue #1034)
- `WAVE_5_ROADMAP.md` — links to progress template and dashboard checklist (issue #1031 validation)
- `README.md` — health URL in services table + env safety reminder (issues #1050 and #1051)

## Closes

Closes #1031 
Closes #1034 
Closes #1050 
Closes #1051 

## Test plan

- [ ] Open `maintainer/WAVE_5_PROGRESS_TEMPLATE.md` and verify all required sections are present (completed issues, merged PRs, test status, demo notes, risks, next steps).
- [ ] Confirm the template contains no private contributor data (names, handles, emails, wallet addresses).
- [ ] Open `WAVE_5_ROADMAP.md` and confirm the template is linked under the Wave 5 Reporting Package section.
- [ ] Open `maintainer/DASHBOARD_SYNC_CHECKLIST.md` and verify it covers assigned, in progress, blocked, merged, and closed states, references the `Stellar Wave` label, mentions the Wave deadline, and cross-links `WAVE_5_CONTRIBUTOR_ASSIGNMENT.md`.
- [ ] Open `README.md` and confirm `http://localhost:5000/health` appears in the local services table.
- [ ] Open `README.md` and confirm the env file safety reminder appears near the "Configure environment files" section and mentions `.env.example` and no secrets in issues/PRs.
- [ ] Confirm no real secret values were added anywhere in this PR.
