### PR TITLE
test(websocket): add CORS and origin regression tests

### DIFF
--- a/xconfess-backend/src/websocket/websocket.adapter.spec.ts
+++ b/xconfess-backend/src/websocket/websocket.adapter.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression tests for WebSocket CORS and Origin behavior.
+ * Issue #1010: Protect CORS assumptions and origin behavior.
+ */
+import { buildWebSocketServerOptions } from './websocket.adapter';
+
+describe('WebSocket Adapter - CORS Regression Tests (#1010)', () => {
+  it('should use FRONTEND_URL as the allowed CORS origin', () => {
+    const frontendUrl = 'https://app.xconfess.com';
+    const options = buildWebSocketServerOptions(frontendUrl);
+    
+    expect(options.cors).toBeDefined();
+    expect(options.cors.origin).toBe(frontendUrl);
+    expect(options.cors.credentials).toBe(true);
+  });
+
+  it('should default to localhost:3000 if no origin is provided (fallback check)', () => {
+    // This replicates the logic in createIOServer fallback
+    const defaultOrigin = 'http://localhost:3000';
+    const options = buildWebSocketServerOptions(defaultOrigin);
+    
+    expect(options.cors.origin).toBe('http://localhost:3000');
+  });
+
+  it('should enforce strictly defined methods', () => {
+    const options = buildWebSocketServerOptions('http://localhost:3000');
+    expect(options.cors.methods).toEqual(['GET', 'POST']);
+  });
+
+  it('should have standard transport settings for stability', () => {
+    const options = buildWebSocketServerOptions('http://localhost:3000');
+    expect(options.transports).toEqual(['websocket', 'polling']);
+    expect(options.allowUpgrades).toBe(true);
+  });
+});


### PR DESCRIPTION
## Wave 5 pull request

Closes #<!-- issue number -->

### Summary

<!-- One or two sentences: what changed and why -->

### Scope

- [ ] This PR addresses **only** the linked issue (no drive-by refactors or unrelated fixes)

### Validation

Check everything that applies to your change:

- [ ] `npm ci` (from repo root)
- [ ] `npm run backend:test` and/or `npm run backend:build` (backend changes)
- [ ] `npm run frontend:test` and/or `npm run frontend:build` (frontend changes)
- [ ] `npm run contract:test` and/or `cargo fmt --check` / `cargo clippy` under `xconfess-contracts/` (contracts changes)
- [ ] `npm run test:smoke --workspace=xconfess-frontend` (Playwright public-pages smoke, if touched)
- [ ] Screenshots or short screen recording attached (UI-visible changes)

### Notes for reviewers

<!-- Optional: env vars, follow-ups, known limitations -->
Closes #1010