### PR TITLE
#1131: Register backend comment module

### DIFF
--- a/xconfess-backend/src/app.module.spec.ts
+++ b/xconfess-backend/src/app.module.spec.ts
@@ -1,0 +1,10 @@
+import { AppModule } from './app.module';
+import { CommentModule } from './comment/comment.module';
+
+describe('AppModule', () => {
+  it('registers the comment module so comment API routes are mounted', () => {
+    const imports = Reflect.getMetadata('imports', AppModule) ?? [];
+
+    expect(imports).toContain(CommentModule);
+  });
+});

--- a/xconfess-backend/src/app.module.ts
+++ b/xconfess-backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { AuthModule } from './auth/auth.module';
 import { ConfessionModule } from './confession/confession.module';
 import { SearchDiscoveryModule } from './search-discovery/search-discovery.module';
 import { ReactionModule } from './reaction/reaction.module';
+import { CommentModule } from './comment/comment.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 import throttleConfig from './config/throttle.config';
@@ -111,6 +112,7 @@ import { BullModule } from '@nestjs/bullmq';
     ConfessionModule,
     SearchDiscoveryModule,
     ReactionModule,
+    CommentModule,
     MessagesModule,
     AdminModule,
     ReportModule,

--- a/xconfess-backend/src/comment/comment.module.spec.ts
+++ b/xconfess-backend/src/comment/comment.module.spec.ts
@@ -1,0 +1,24 @@
+import { AnonymousContextMiddleware } from '../middleware/anonymous-context.middleware';
+import { CommentAdminController } from './comment-admin.controller';
+import { CommentController } from './comment.controller';
+import { CommentModule } from './comment.module';
+
+describe('CommentModule', () => {
+  it('exposes comment API controllers', () => {
+    const controllers = Reflect.getMetadata('controllers', CommentModule) ?? [];
+
+    expect(controllers).toEqual(
+      expect.arrayContaining([CommentController, CommentAdminController]),
+    );
+  });
+
+  it('applies anonymous context middleware to comment routes', () => {
+    const forRoutes = jest.fn();
+    const apply = jest.fn().mockReturnValue({ forRoutes });
+
+    new CommentModule().configure({ apply } as any);
+
+    expect(apply).toHaveBeenCalledWith(AnonymousContextMiddleware);
+    expect(forRoutes).toHaveBeenCalledWith('comments');
+  });
+});


### PR DESCRIPTION
## Closes

Closes #1131

---

## What changed

Registers `CommentModule` in `AppModule` so the existing comment and admin comment controllers are mounted by the backend application. Adds module-level regression coverage for the AppModule import and the CommentModule controller/middleware wiring.

## Why

Without `CommentModule` in the root module imports, the existing comment API controllers are never registered at runtime.

## How to test

1. From a fresh checkout, install dependencies for the backend workspace.
2. Run the focused backend regression tests for the module wiring.
3. Optionally start the backend and confirm the existing comment routes are registered under the global `/api` prefix.

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines <= 400 and files touched <= 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

N/A

---

## Evidence

### Tests

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable - manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output:

```bash
$ npx --yes jest@30.0.5 --config jest.config.js app.module.spec.ts comment.module.spec.ts --runInBand
PASS src/comment/comment.module.spec.ts
PASS src/app.module.spec.ts

Test Suites: 2 passed, 2 total
Tests:       3 passed, 3 total
```

Additional checks:

```bash
$ pnpm exec eslint src/app.module.ts src/app.module.spec.ts src/comment/comment.module.spec.ts --max-warnings=0
# passed

$ git diff --check
# passed
```

Full backend suite note:

```text
npx --yes jest@30.0.5 --config jest.config.js --runInBand
Result: 94 passed, 11 failed, 105 total suites. The failures are in existing Stellar, health, notification gateway, and env validation specs, not in the AppModule/CommentModule regression tests added here.
```

Build note:

```text
pnpm build currently fails on existing unrelated TypeScript errors in admin, health, and tipping files before this PR's changed files are implicated.
```

### Screenshots (UI changes only)

N/A

---

## Checklist

- [x] Branch is up to date with `main`
- [ ] All CI checks pass
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)
