### PR TITLE
#1114: Register confession draft module

### DIFF
--- a/xconfess-backend/src/app.module.ts
+++ b/xconfess-backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { AuthModule } from './auth/auth.module';
 import { ConfessionModule } from './confession/confession.module';
 import { SearchDiscoveryModule } from './search-discovery/search-discovery.module';
 import { ReactionModule } from './reaction/reaction.module';
+import { ConfessionDraftModule } from './confession-draft/confession-draft.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 import throttleConfig from './config/throttle.config';
@@ -111,6 +112,7 @@ import { BullModule } from '@nestjs/bullmq';
     ConfessionModule,
     SearchDiscoveryModule,
     ReactionModule,
+    ConfessionDraftModule,
     MessagesModule,
     AdminModule,
     ReportModule,

--- a/xconfess-backend/src/confession-draft/confession-draft.app-module.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.app-module.spec.ts
@@ -1,0 +1,10 @@
+import { AppModule } from '../app.module';
+import { ConfessionDraftModule } from './confession-draft.module';
+
+describe('AppModule confession draft wiring', () => {
+  it('registers the confession draft module so draft API routes are mounted', () => {
+    const imports = Reflect.getMetadata('imports', AppModule) ?? [];
+
+    expect(imports).toContain(ConfessionDraftModule);
+  });
+});

--- a/xconfess-backend/src/confession-draft/confession-draft.module.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.module.spec.ts
@@ -1,0 +1,18 @@
+import { ConfessionDraftController } from './confession-draft.controller';
+import { ConfessionDraftModule } from './confession-draft.module';
+import { ConfessionDraftQueue } from './confession-draft.queue';
+import { ConfessionDraftService } from './confession-draft.service';
+
+describe('ConfessionDraftModule', () => {
+  it('exposes draft API controller and queue-backed providers', () => {
+    const controllers =
+      Reflect.getMetadata('controllers', ConfessionDraftModule) ?? [];
+    const providers =
+      Reflect.getMetadata('providers', ConfessionDraftModule) ?? [];
+
+    expect(controllers).toContain(ConfessionDraftController);
+    expect(providers).toEqual(
+      expect.arrayContaining([ConfessionDraftService, ConfessionDraftQueue]),
+    );
+  });
+});

--- a/xconfess-backend/src/confession-draft/confession-draft.module.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.module.ts
@@ -5,13 +5,16 @@ import { ConfessionDraft } from './entities/confession-draft.entity';
 import { ConfessionDraftService } from './confession-draft.service';
 import { ConfessionDraftController } from './confession-draft.controller';
 import { ConfessionModule } from '../confession/confession.module';
-import { ConfessionDraftQueue } from './confession-draft.queue';
+import {
+  CONFESSION_DRAFT_QUEUE,
+  ConfessionDraftQueue,
+} from './confession-draft.queue';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ConfessionDraft]),
     ConfessionModule,
-    BullModule.registerQueue({ name: 'confession-draft-publisher' }),
+    BullModule.registerQueue({ name: CONFESSION_DRAFT_QUEUE }),
   ],
   controllers: [ConfessionDraftController],
   providers: [ConfessionDraftService, ConfessionDraftQueue],

--- a/xconfess-backend/src/confession-draft/confession-draft.queue.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.queue.spec.ts
@@ -1,0 +1,131 @@
+import { ConfigService } from '@nestjs/config';
+import { Queue, Worker } from 'bullmq';
+import {
+  CONFESSION_DRAFT_QUEUE,
+  ConfessionDraftQueue,
+} from './confession-draft.queue';
+import { ConfessionDraftService } from './confession-draft.service';
+
+jest.mock('bullmq', () => ({
+  Worker: jest.fn().mockImplementation(() => ({
+    close: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn(),
+  })),
+}));
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('ConfessionDraftQueue', () => {
+  let queue: jest.Mocked<Pick<Queue, 'add' | 'close'>>;
+  let draftService: jest.Mocked<
+    Pick<
+      ConfessionDraftService,
+      'enqueueDueDraftIds' | 'publishScheduledDraftById'
+    >
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queue = {
+      add: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    draftService = {
+      enqueueDueDraftIds: jest.fn().mockResolvedValue(['draft-1', 'draft-2']),
+      publishScheduledDraftById: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it('does not start a worker when background jobs are disabled', () => {
+    const configService = {
+      get: jest.fn((key: string, fallback?: unknown) =>
+        key === 'ENABLE_BACKGROUND_JOBS' ? 'false' : fallback,
+      ),
+    } as unknown as ConfigService;
+
+    new ConfessionDraftQueue(
+      configService,
+      draftService as unknown as ConfessionDraftService,
+      queue as unknown as Queue,
+    );
+
+    expect(Worker).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('starts the publisher worker and schedules the recurring scan when jobs are enabled', async () => {
+    const configService = {
+      get: jest.fn((key: string, fallback?: unknown) => {
+        if (key === 'ENABLE_BACKGROUND_JOBS') return 'true';
+        if (key === 'REDIS_HOST') return 'redis.local';
+        if (key === 'REDIS_PORT') return 6380;
+        return fallback;
+      }),
+    } as unknown as ConfigService;
+
+    new ConfessionDraftQueue(
+      configService,
+      draftService as unknown as ConfessionDraftService,
+      queue as unknown as Queue,
+    );
+    await flushPromises();
+
+    expect(Worker).toHaveBeenCalledWith(
+      CONFESSION_DRAFT_QUEUE,
+      expect.any(Function),
+      { connection: { host: 'redis.local', port: 6380 } },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      'publish-due',
+      {},
+      {
+        repeat: { pattern: '* * * * *' },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
+  });
+
+  it('enqueues due drafts and publishes individual draft jobs', async () => {
+    const configService = {
+      get: jest.fn((key: string, fallback?: unknown) =>
+        key === 'ENABLE_BACKGROUND_JOBS' ? 'true' : fallback,
+      ),
+    } as unknown as ConfigService;
+
+    new ConfessionDraftQueue(
+      configService,
+      draftService as unknown as ConfessionDraftService,
+      queue as unknown as Queue,
+    );
+
+    const workerMock = Worker as unknown as jest.Mock;
+    const processor = workerMock.mock.calls[0][1] as (job: {
+      name: string;
+      data?: Record<string, string>;
+    }) => Promise<unknown>;
+
+    queue.add.mockClear();
+    await expect(processor({ name: 'publish-due' })).resolves.toEqual({
+      enqueued: 2,
+    });
+
+    expect(queue.add).toHaveBeenCalledTimes(2);
+    expect(queue.add).toHaveBeenCalledWith(
+      'publish-one',
+      { id: 'draft-1' },
+      {
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 1000 },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
+
+    await processor({ name: 'publish-one', data: { id: 'draft-2' } });
+
+    expect(draftService.publishScheduledDraftById).toHaveBeenCalledWith(
+      'draft-2',
+    );
+  });
+});

--- a/xconfess-backend/src/confession-draft/confession-draft.queue.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.queue.ts
@@ -1,28 +1,44 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
-import { BullModule, InjectQueue } from '@nestjs/bullmq';
+import { InjectQueue } from '@nestjs/bullmq';
 import { Queue, Worker, Job } from 'bullmq';
 import { ConfigService } from '@nestjs/config';
 import { ConfessionDraftService } from './confession-draft.service';
 
+export const CONFESSION_DRAFT_QUEUE = 'confession-draft-publisher';
+
+interface DraftPublishJobData {
+  id?: string;
+}
+
 @Injectable()
 export class ConfessionDraftQueue implements OnModuleDestroy {
-  private readonly worker: Worker;
+  private readonly worker?: Worker<DraftPublishJobData>;
   private readonly logger = new Logger(ConfessionDraftQueue.name);
 
   constructor(
     private readonly configService: ConfigService,
     private readonly draftService: ConfessionDraftService,
-    @InjectQueue('confession-draft-publisher')
+    @InjectQueue(CONFESSION_DRAFT_QUEUE)
     private readonly queue: Queue,
   ) {
+    const jobsEnabled =
+      this.configService.get<string>('ENABLE_BACKGROUND_JOBS') === 'true';
+
+    if (!jobsEnabled) {
+      this.logger.log(
+        'Confession draft publisher disabled because ENABLE_BACKGROUND_JOBS is not "true"',
+      );
+      return;
+    }
+
     const redisConfig = {
-      host: this.configService.get('REDIS_HOST', 'localhost'),
-      port: this.configService.get('REDIS_PORT', 6379),
+      host: this.configService.get<string>('REDIS_HOST', 'localhost'),
+      port: this.configService.get<number>('REDIS_PORT', 6379),
     };
 
-    this.worker = new Worker(
-      'confession-draft-publisher',
-      async (job: Job) => {
+    this.worker = new Worker<DraftPublishJobData>(
+      CONFESSION_DRAFT_QUEUE,
+      async (job: Job<DraftPublishJobData>) => {
         if (job.name === 'publish-due') {
           const ids = await this.draftService.enqueueDueDraftIds();
           await Promise.all(
@@ -43,7 +59,7 @@ export class ConfessionDraftQueue implements OnModuleDestroy {
         }
 
         if (job.name === 'publish-one') {
-          const id = job.data?.id as string;
+          const id = job.data.id;
           if (!id) return;
           await this.draftService.publishScheduledDraftById(id);
           return;
@@ -65,7 +81,7 @@ export class ConfessionDraftQueue implements OnModuleDestroy {
       );
     });
 
-    (async () => {
+    void (async () => {
       try {
         await this.queue.add(
           'publish-due',
@@ -87,7 +103,7 @@ export class ConfessionDraftQueue implements OnModuleDestroy {
   }
 
   async onModuleDestroy() {
-    await this.worker.close();
+    await this.worker?.close();
     await this.queue.close();
   }
 }

--- a/xconfess-backend/src/confession-draft/confession-draft.service.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.service.spec.ts
@@ -15,6 +15,7 @@ const AES_KEY = '12345678901234567890123456789012';
 describe('ConfessionDraftService', () => {
   let service: ConfessionDraftService;
   let repo: jest.Mocked<Repository<ConfessionDraft>>;
+  let confessionService: { create: jest.Mock };
 
   beforeEach(async () => {
     repo = {
@@ -26,11 +27,13 @@ describe('ConfessionDraftService', () => {
       remove: jest.fn(),
     } as any;
 
+    confessionService = { create: jest.fn() };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ConfessionDraftService,
         { provide: getRepositoryToken(ConfessionDraft), useValue: repo },
-        { provide: ConfessionService, useValue: { create: jest.fn() } },
+        { provide: ConfessionService, useValue: confessionService },
         {
           provide: ConfigService,
           useValue: {
@@ -71,6 +74,65 @@ describe('ConfessionDraftService', () => {
 
     const res = await service.createDraft(1, 'hello');
     expect(res.content).toBe('hello');
+  });
+
+  it('listDrafts returns decrypted drafts for the authenticated user', async () => {
+    repo.find.mockResolvedValue([
+      {
+        id: 'draft1',
+        userId: 1,
+        content: encryptConfession('hello from draft', AES_KEY),
+        revisions: [],
+        status: ConfessionDraftStatus.DRAFT,
+      } as any,
+    ]);
+
+    const res = await service.listDrafts(1);
+
+    expect(repo.find).toHaveBeenCalledWith({
+      where: { userId: 1 },
+      order: { updatedAt: 'DESC' },
+    });
+    expect(res).toEqual([
+      expect.objectContaining({
+        id: 'draft1',
+        content: 'hello from draft',
+      }),
+    ]);
+  });
+
+  it('publishNow creates a confession and marks the draft as posted', async () => {
+    const draft = {
+      id: 'draft1',
+      userId: 1,
+      content: encryptConfession('ready to publish', AES_KEY),
+      revisions: [],
+      status: ConfessionDraftStatus.DRAFT,
+      scheduledFor: new Date(),
+      publishAttempts: 2,
+      lastPublishError: 'previous failure',
+    } as any;
+
+    repo.findOne.mockResolvedValue(draft);
+    repo.save.mockImplementation(async (x: any) => x);
+    confessionService.create.mockResolvedValue({ id: 'confession1' });
+
+    const res = await service.publishNow(1, 'draft1');
+
+    expect(confessionService.create).toHaveBeenCalledWith(
+      { message: 'ready to publish' },
+      expect.any(Object),
+    );
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: ConfessionDraftStatus.POSTED,
+        scheduledFor: null,
+        publishAttempts: 0,
+        lastPublishError: null,
+      }),
+    );
+    expect(res.confession).toEqual({ id: 'confession1' });
+    expect(res.draft.content).toBe('ready to publish');
   });
 
   describe('updateDraft', () => {


### PR DESCRIPTION
## Closes

Closes #1114

---

## What changed

Registers `ConfessionDraftModule` in `AppModule` so the existing authenticated draft API routes and publisher provider are part of the backend application. The draft publisher now uses a shared queue name and only starts its BullMQ worker when `ENABLE_BACKGROUND_JOBS=true`, while still registering the `confession-draft-publisher` queue through the module. Added focused regression coverage for root module wiring, module providers, queue startup/processing behavior, and draft create/list/publish service happy paths.

## Why

The draft controller, service, and publisher already existed, but without the root module import the backend did not mount the draft API or activate the scheduled publisher path.

## How to test

1. From a fresh checkout, install backend dependencies.
2. Run the focused confession-draft specs listed below.
3. With Redis available and `ENABLE_BACKGROUND_JOBS=true`, boot the backend and exercise `POST /api/confessions/drafts`, `GET /api/confessions/drafts`, and draft publish/schedule paths.

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines <= 400 and files touched <= 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

N/A

---

## Evidence

### Tests

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable - manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output:

```bash
$ npx --yes jest@30.0.5 --config jest.config.js confession-draft.app-module.spec.ts confession-draft.module.spec.ts confession-draft.queue.spec.ts confession-draft.service.spec.ts --runInBand
PASS src/confession-draft/confession-draft.queue.spec.ts
PASS src/confession-draft/confession-draft.module.spec.ts
PASS src/confession-draft/confession-draft.app-module.spec.ts
PASS src/confession-draft/confession-draft.service.spec.ts

Test Suites: 4 passed, 4 total
Tests:       11 passed, 11 total
```

Additional checks:

```bash
$ pnpm exec eslint src/app.module.ts src/confession-draft/confession-draft.module.ts src/confession-draft/confession-draft.queue.ts src/confession-draft/confession-draft.service.spec.ts src/confession-draft/confession-draft.app-module.spec.ts src/confession-draft/confession-draft.module.spec.ts src/confession-draft/confession-draft.queue.spec.ts --max-warnings=0
# passed

$ git diff --check
# passed
```

Build note:

```text
pnpm build currently fails on existing unrelated TypeScript errors in admin, health, and tipping files before this PR's changed files are implicated.
```

### Screenshots (UI changes only)

N/A

---

## Checklist

- [x] Branch is up to date with `main`
- [ ] All CI checks pass
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)
