### PR TITLE
#1129: Align search proxy params

### DIFF
--- a/xconfess-frontend/app/api/confessions/search/__tests__/searchParams.test.ts
+++ b/xconfess-frontend/app/api/confessions/search/__tests__/searchParams.test.ts
@@ -1,0 +1,48 @@
+import { buildBackendSearchParams } from "../searchParams";
+
+describe("buildBackendSearchParams", () => {
+  it("serializes frontend search filters to backend SearchConfessionDto fields", () => {
+    const params = buildBackendSearchParams(
+      new URLSearchParams({
+        q: "  stellar demo  ",
+        page: "2",
+        limit: "25",
+        sort: "reactions",
+        dateFrom: "2026-01-01T00:00:00.000Z",
+        dateTo: "2026-02-01T00:00:00.000Z",
+        minReactions: "5",
+        gender: "other",
+      }),
+    );
+
+    expect(params.toString()).toBe(
+      "page=2&limit=25&q=stellar+demo&sortBy=reactions&startDate=2026-01-01T00%3A00%3A00.000Z&endDate=2026-02-01T00%3A00%3A00.000Z&minReactions=5&gender=other",
+    );
+  });
+
+  it("accepts legacy query while still sending backend q", () => {
+    const params = buildBackendSearchParams(
+      new URLSearchParams({
+        query: "wallet",
+        sort: "newest",
+      }),
+    );
+
+    expect(params.get("q")).toBe("wallet");
+    expect(params.get("sortBy")).toBe("date");
+    expect(params.has("query")).toBe(false);
+    expect(params.has("sort")).toBe(false);
+  });
+
+  it("bounds pagination to backend limits", () => {
+    const params = buildBackendSearchParams(
+      new URLSearchParams({
+        page: "-3",
+        limit: "999",
+      }),
+    );
+
+    expect(params.get("page")).toBe("1");
+    expect(params.get("limit")).toBe("50");
+  });
+});

--- a/xconfess-frontend/app/api/confessions/search/route.ts
+++ b/xconfess-frontend/app/api/confessions/search/route.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl } from "@/app/lib/config";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { buildBackendSearchParams } from "./searchParams";
 
 const BASE_API_URL = getApiBaseUrl();
 
@@ -24,25 +25,9 @@ function parseBoolean(value: unknown, fallback = false): boolean {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const q = searchParams.get("q") ?? "";
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10) || 1);
-  const limit = Math.max(1, Math.min(50, parseInt(searchParams.get("limit") ?? "10", 10) || 10));
-  const sort = searchParams.get("sort") ?? "newest";
-  const dateFrom = searchParams.get("dateFrom") ?? undefined;
-  const dateTo = searchParams.get("dateTo") ?? undefined;
-  const minReactions = searchParams.get("minReactions") ?? undefined;
-  const gender = searchParams.get("gender") ?? undefined;
-
-  const backendParams = new URLSearchParams();
-  backendParams.set("page", String(page));
-  backendParams.set("limit", String(limit));
-  backendParams.set("sort", sort);
-  if (q) backendParams.set("q", q);
-  if (dateFrom) backendParams.set("dateFrom", dateFrom);
-  if (dateTo) backendParams.set("dateTo", dateTo);
-  if (minReactions != null && minReactions !== "")
-    backendParams.set("minReactions", minReactions);
-  if (gender) backendParams.set("gender", gender);
+  const backendParams = buildBackendSearchParams(searchParams);
+  const page = parseNumber(backendParams.get("page"), 1);
+  const limit = parseNumber(backendParams.get("limit"), 10);
 
   const searchUrl = `${BASE_API_URL}/confessions/search?${backendParams}`;
 

--- a/xconfess-frontend/app/api/confessions/search/searchParams.ts
+++ b/xconfess-frontend/app/api/confessions/search/searchParams.ts
@@ -1,0 +1,60 @@
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+function parseBoundedInt(
+  value: string | null,
+  fallback: number,
+  min: number,
+  max?: number,
+): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  const finite = Number.isFinite(parsed) ? parsed : fallback;
+  return Math.max(min, max == null ? finite : Math.min(max, finite));
+}
+
+function mapSortToBackendSortBy(sort: string | null): string | null {
+  switch (sort) {
+    case "reactions":
+      return "reactions";
+    case "oldest":
+    case "newest":
+      return "date";
+    default:
+      return null;
+  }
+}
+
+export function buildBackendSearchParams(
+  searchParams: URLSearchParams,
+): URLSearchParams {
+  const page = parseBoundedInt(searchParams.get("page"), DEFAULT_PAGE, 1);
+  const limit = parseBoundedInt(
+    searchParams.get("limit"),
+    DEFAULT_LIMIT,
+    1,
+    MAX_LIMIT,
+  );
+  const q = searchParams.get("q") ?? searchParams.get("query") ?? "";
+  const sortBy = mapSortToBackendSortBy(searchParams.get("sort"));
+  const startDate =
+    searchParams.get("startDate") ?? searchParams.get("dateFrom");
+  const endDate = searchParams.get("endDate") ?? searchParams.get("dateTo");
+  const minReactions = searchParams.get("minReactions");
+  const gender = searchParams.get("gender");
+
+  const backendParams = new URLSearchParams();
+  backendParams.set("page", String(page));
+  backendParams.set("limit", String(limit));
+
+  if (q.trim()) backendParams.set("q", q.trim());
+  if (sortBy) backendParams.set("sortBy", sortBy);
+  if (startDate) backendParams.set("startDate", startDate);
+  if (endDate) backendParams.set("endDate", endDate);
+  if (minReactions != null && minReactions !== "") {
+    backendParams.set("minReactions", minReactions);
+  }
+  if (gender) backendParams.set("gender", gender);
+
+  return backendParams;
+}


### PR DESCRIPTION
## Closes

Closes #1129

---

## What changed

Extracts the frontend search proxy parameter serialization into a tested helper and aligns forwarded query params with backend `SearchConfessionDto`: `q`, `page`, `limit`, `sortBy`, `startDate`, `endDate`, `minReactions`, and `gender`. The proxy also accepts legacy `query` input while still sending `q` to the backend.

## Why

The search page used frontend filter names like `dateFrom`, `dateTo`, and `sort`, while the backend DTO expects `startDate`, `endDate`, and `sortBy`, so some filters were silently ignored by the backend search endpoint.

## How to test

1. Search from the UI with a text query and filters.
2. Compare the frontend proxy request with an equivalent direct backend request using `q`, `startDate`, `endDate`, `sortBy`, `page`, and `limit`.
3. Run the focused serialization test below.

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines <= 400 and files touched <= 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

N/A

---

## Evidence

### Tests

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable - manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output:

```bash
$ npm test -- searchParams.test.ts --runInBand
PASS app/api/confessions/search/__tests__/searchParams.test.ts

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

Additional checks:

```bash
$ npm run lint -- app/api/confessions/search/route.ts app/api/confessions/search/searchParams.ts app/api/confessions/search/__tests__/searchParams.test.ts
# passed

$ git diff --check
# passed
```

Build note:

```text
npm run build currently fails on existing unrelated frontend issues:
- app/(dashboard)/admin/diagnostics/page.tsx has a malformed trailing JSX block around line 278.
- app/components/comparison/ComparisonTool.tsx imports ArrowClockwise from lucide-react, but that export does not exist in the installed lucide-react package.
```

### Screenshots (UI changes only)

N/A

---

## Checklist

- [x] Branch is up to date with `main`
- [ ] All CI checks pass
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)
