### PR TITLE
#1128: Validate search API error contract

### DIFF
--- a/xconfess-backend/src/confession/confession.controller.ts
+++ b/xconfess-backend/src/confession/confession.controller.ts
@@ -31,6 +31,13 @@ import { SearchConfessionDto } from './dto/search-confession.dto';
 import { UpdateConfessionDto } from './dto/update-confession.dto';
 import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
 import { SearchDiscoveryService } from '../search-discovery/search-discovery.service';
+import { searchValidationPipe } from '../search-discovery/search-validation.pipe';
+
+type SearchRequest = Request & {
+  user?: {
+    id?: number;
+  };
+};
 
 @ApiTags('Confessions')
 @Controller('confessions')
@@ -62,7 +69,11 @@ export class ConfessionController {
       },
     },
   })
-  @ApiResponse({ status: 400, description: 'Validation error — message exceeds 1000 chars or invalid enum.' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Validation error — message exceeds 1000 chars or invalid enum.',
+  })
   @UsePipes(new ValidationPipe({ whitelist: true }))
   create(@Body() dto: CreateConfessionDto) {
     // Only allow canonical contract
@@ -99,11 +110,12 @@ export class ConfessionController {
   @Get('search')
   @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({ summary: 'Search confessions (hybrid)' })
-  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
-  async search(@Query() dto: SearchConfessionDto, @Req() req: any) {
+  @UsePipes(searchValidationPipe)
+  async search(@Query() dto: SearchConfessionDto, @Req() req: SearchRequest) {
     const result = await this.service.search(dto);
-    if (req.user && req.user.id) {
-      await this.searchDiscoveryService.recordSearch(req.user.id, dto);
+    const userId = req.user?.id;
+    if (typeof userId === 'number') {
+      await this.searchDiscoveryService.recordSearch(userId, dto);
     }
     return result;
   }
@@ -111,11 +123,15 @@ export class ConfessionController {
   @Get('search/fulltext')
   @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({ summary: 'Full-text search confessions' })
-  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
-  async fullTextSearch(@Query() dto: SearchConfessionDto, @Req() req: any) {
+  @UsePipes(searchValidationPipe)
+  async fullTextSearch(
+    @Query() dto: SearchConfessionDto,
+    @Req() req: SearchRequest,
+  ) {
     const result = await this.service.fullTextSearch(dto);
-    if (req.user && req.user.id) {
-      await this.searchDiscoveryService.recordSearch(req.user.id, dto);
+    const userId = req.user?.id;
+    if (typeof userId === 'number') {
+      await this.searchDiscoveryService.recordSearch(userId, dto);
     }
     return result;
   }

--- a/xconfess-backend/src/confession/dto/search-confession.dto.ts
+++ b/xconfess-backend/src/confession/dto/search-confession.dto.ts
@@ -3,6 +3,7 @@ import {
   IsString,
   IsNotEmpty,
   MinLength,
+  MaxLength,
   IsOptional,
   IsInt,
   Min,
@@ -13,9 +14,82 @@ import {
   IsEnum,
   IsArray,
   ValidateIf,
+  ValidateBy,
+  ValidationOptions,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+const SEARCH_QUERY_MAX_LENGTH = 120;
+
+const trimSearchQuery = (value: unknown): unknown =>
+  typeof value === 'string' ? value.trim() : value;
+
+const parseOptionalInt = (value: unknown): number | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    if (value.trim() === '') {
+      return Number.NaN;
+    }
+
+    return parseInt(value, 10);
+  }
+
+  return Number.NaN;
+};
+
+const parseOptionalBoolean = (value: unknown): boolean | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value === 'true';
+  }
+
+  return value === true;
+};
+
+const normalizeTags = (value: unknown): unknown[] => {
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+  }
+
+  return Array.isArray(value) ? [...(value as unknown[])] : [];
+};
+
+const hasUnsupportedControlCharacter = (value: string): boolean =>
+  Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint < 32 || codePoint === 127);
+  });
+
+const IsPrintableSearchQuery = (
+  validationOptions?: ValidationOptions,
+): PropertyDecorator =>
+  ValidateBy(
+    {
+      name: 'isPrintableSearchQuery',
+      validator: {
+        validate(value: unknown): boolean {
+          return (
+            typeof value === 'string' && !hasUnsupportedControlCharacter(value)
+          );
+        },
+      },
+    },
+    validationOptions,
+  );
 
 export enum SortBy {
   REACTIONS = 'reactions',
@@ -29,10 +103,18 @@ export class SearchConfessionDto {
     description: 'Search query string',
     example: 'work stress',
     minLength: 1,
+    maxLength: SEARCH_QUERY_MAX_LENGTH,
   })
+  @Transform(({ value }: { value: unknown }) => trimSearchQuery(value))
   @IsString()
-  @IsNotEmpty()
-  @MinLength(1)
+  @IsNotEmpty({ message: 'q must not be empty' })
+  @MinLength(1, { message: 'q must contain at least 1 character' })
+  @MaxLength(SEARCH_QUERY_MAX_LENGTH, {
+    message: 'q must be 120 characters or fewer',
+  })
+  @IsPrintableSearchQuery({
+    message: 'q contains unsupported control characters',
+  })
   q: string;
 
   @ApiPropertyOptional({
@@ -42,7 +124,7 @@ export class SearchConfessionDto {
     default: 1,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(({ value }: { value: unknown }) => parseOptionalInt(value))
   @IsInt()
   @Min(1)
   page?: number = 1;
@@ -55,7 +137,7 @@ export class SearchConfessionDto {
     default: 10,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(({ value }: { value: unknown }) => parseOptionalInt(value))
   @IsInt()
   @Min(1)
   @Max(50)
@@ -88,7 +170,7 @@ export class SearchConfessionDto {
   @IsOptional()
   @Type(() => Date)
   @IsDate()
-  @ValidateIf((o) => o.startDate !== undefined)
+  @ValidateIf((dto: SearchConfessionDto) => dto.startDate !== undefined)
   endDate?: Date;
 
   @ApiPropertyOptional({
@@ -97,7 +179,7 @@ export class SearchConfessionDto {
     minimum: 0,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(({ value }: { value: unknown }) => parseOptionalInt(value))
   @IsNumber()
   @Min(0)
   minReactions?: number;
@@ -108,10 +190,10 @@ export class SearchConfessionDto {
     minimum: 0,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(({ value }: { value: unknown }) => parseOptionalInt(value))
   @IsNumber()
   @Min(0)
-  @ValidateIf((o) => o.minReactions !== undefined)
+  @ValidateIf((dto: SearchConfessionDto) => dto.minReactions !== undefined)
   maxReactions?: number;
 
   @ApiPropertyOptional({
@@ -120,7 +202,7 @@ export class SearchConfessionDto {
     minimum: 0,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(({ value }: { value: unknown }) => parseOptionalInt(value))
   @IsNumber()
   @Min(0)
   minViews?: number;
@@ -131,10 +213,10 @@ export class SearchConfessionDto {
     minimum: 0,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(({ value }: { value: unknown }) => parseOptionalInt(value))
   @IsNumber()
   @Min(0)
-  @ValidateIf((o) => o.minViews !== undefined)
+  @ValidateIf((dto: SearchConfessionDto) => dto.minViews !== undefined)
   maxViews?: number;
 
   @ApiPropertyOptional({
@@ -145,15 +227,7 @@ export class SearchConfessionDto {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      return value
-        .split(',')
-        .map((tag) => tag.trim())
-        .filter((tag) => tag.length > 0);
-    }
-    return Array.isArray(value) ? value : [];
-  })
+  @Transform(({ value }: { value: unknown }) => normalizeTags(value))
   tags?: string[];
 
   @ApiPropertyOptional({
@@ -162,12 +236,7 @@ export class SearchConfessionDto {
     default: false,
   })
   @IsOptional()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      return value === 'true';
-    }
-    return value === true;
-  })
+  @Transform(({ value }: { value: unknown }) => parseOptionalBoolean(value))
   @IsBoolean()
   anonymousOnly?: boolean;
 
@@ -187,12 +256,7 @@ export class SearchConfessionDto {
     default: false,
   })
   @IsOptional()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      return value === 'true';
-    }
-    return value === true;
-  })
+  @Transform(({ value }: { value: unknown }) => parseOptionalBoolean(value))
   @IsBoolean()
   requiresReview?: boolean;
 

--- a/xconfess-backend/src/search-discovery/search-validation.pipe.spec.ts
+++ b/xconfess-backend/src/search-discovery/search-validation.pipe.spec.ts
@@ -1,0 +1,132 @@
+import {
+  Controller,
+  Get,
+  INestApplication,
+  Query,
+  UsePipes,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request, { Response } from 'supertest';
+import { SearchConfessionDto } from '../confession/dto/search-confession.dto';
+import { HttpExceptionFilter } from '../common/filters/http-exception.filter';
+import { RequestIdMiddleware } from '../middleware/request-id.middleware';
+import { searchValidationPipe } from './search-validation.pipe';
+
+@Controller('confessions')
+class SearchValidationContractController {
+  @Get('search')
+  @UsePipes(searchValidationPipe)
+  search(@Query() dto: SearchConfessionDto) {
+    return {
+      q: dto.q,
+      page: dto.page,
+      limit: dto.limit,
+    };
+  }
+}
+
+describe('Search validation API error contract', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [SearchValidationContractController],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    const requestIdMiddleware = new RequestIdMiddleware();
+    app.use(requestIdMiddleware.use.bind(requestIdMiddleware));
+    app.useGlobalFilters(new HttpExceptionFilter());
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const expectErrorEnvelope = (response: Response, expectedStatus: number) => {
+    expect(response.status).toBe(expectedStatus);
+    expect(response.body).toHaveProperty('status', expectedStatus);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body).toHaveProperty('code');
+    expect(response.body).toHaveProperty('timestamp');
+    expect(response.body).toHaveProperty('requestId');
+    expect(typeof response.body.message).toBe('string');
+    expect(typeof response.body.code).toBe('string');
+    expect(new Date(response.body.timestamp).getTime()).not.toBeNaN();
+    expect(response.body.requestId).not.toBe('unknown');
+  };
+
+  it('returns field-level validation details for empty search queries', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/confessions/search')
+      .query({ q: '   ' });
+
+    expectErrorEnvelope(response, 400);
+    expect(response.body.code).toBe('VALIDATION_FAILED');
+    expect(response.body.message).toBe('Search query validation failed');
+    expect(response.body.details).toEqual({
+      fields: [
+        {
+          field: 'q',
+          messages: expect.arrayContaining([
+            'q must not be empty',
+            'q must contain at least 1 character',
+          ]),
+        },
+      ],
+    });
+  });
+
+  it('rejects over-max search limits with field-level details', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/confessions/search')
+      .query({ q: 'stress', limit: 51 });
+
+    expectErrorEnvelope(response, 400);
+    expect(response.body.code).toBe('VALIDATION_FAILED');
+    expect(response.body.details.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'limit',
+          messages: expect.arrayContaining([
+            'limit must not be greater than 50',
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it('rejects unsupported search query characters', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/confessions/search')
+      .query({ q: 'stress\u0007' });
+
+    expectErrorEnvelope(response, 400);
+    expect(response.body.code).toBe('VALIDATION_FAILED');
+    expect(response.body.details.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'q',
+          messages: expect.arrayContaining([
+            'q contains unsupported control characters',
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it('trims valid search queries before controller handling', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/confessions/search')
+      .query({ q: '  stress  ', limit: 10 });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      q: 'stress',
+      page: 1,
+      limit: 10,
+    });
+  });
+});

--- a/xconfess-backend/src/search-discovery/search-validation.pipe.ts
+++ b/xconfess-backend/src/search-discovery/search-validation.pipe.ts
@@ -1,0 +1,19 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+import type { ValidationError } from 'class-validator';
+import { ErrorCode } from '../common/errors/error-codes';
+
+export const searchValidationPipe = new ValidationPipe({
+  transform: true,
+  whitelist: true,
+  exceptionFactory: (errors: ValidationError[]) =>
+    new BadRequestException({
+      message: 'Search query validation failed',
+      code: ErrorCode.VALIDATION_FAILED,
+      details: {
+        fields: errors.map((error) => ({
+          field: error.property,
+          messages: Object.values(error.constraints ?? {}),
+        })),
+      },
+    }),
+});

--- a/xconfess-backend/test/api-error-contract.e2e-spec.ts
+++ b/xconfess-backend/test/api-error-contract.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
+import request, { Response } from 'supertest';
 import { AppModule } from './../src/app.module';
 import { HttpExceptionFilter } from './../src/common/filters/http-exception.filter';
 import { ThrottlerExceptionFilter } from './../src/common/filters/throttler-exception.filter';
@@ -35,10 +35,7 @@ describe('API Error Contract (e2e)', () => {
     await app.close();
   });
 
-  const expectErrorEnvelope = (
-    response: request.Response,
-    expectedStatus: number,
-  ) => {
+  const expectErrorEnvelope = (response: Response, expectedStatus: number) => {
     expect(response.status).toBe(expectedStatus);
     expect(response.body).toHaveProperty('status', expectedStatus);
     expect(response.body).toHaveProperty('message');
@@ -62,6 +59,65 @@ describe('API Error Contract (e2e)', () => {
 
       expectErrorEnvelope(response, 400);
       expect(response.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('should return field-level validation details for empty search queries', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: '   ' });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('VALIDATION_FAILED');
+      expect(response.body.message).toBe('Search query validation failed');
+      expect(response.body.details).toEqual({
+        fields: [
+          {
+            field: 'q',
+            messages: expect.arrayContaining([
+              'q must not be empty',
+              'q must contain at least 1 character',
+            ]),
+          },
+        ],
+      });
+    });
+
+    it('should reject over-max search limit with field-level details', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: 'stress', limit: 51 });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('VALIDATION_FAILED');
+      expect(response.body.details.fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            field: 'limit',
+            messages: expect.arrayContaining([
+              'limit must not be greater than 50',
+            ]),
+          }),
+        ]),
+      );
+    });
+
+    it('should reject unsupported search query characters', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: 'stress\u0007' });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('VALIDATION_FAILED');
+      expect(response.body.details.fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            field: 'q',
+            messages: expect.arrayContaining([
+              'q contains unsupported control characters',
+            ]),
+          }),
+        ]),
+      );
     });
   });
 
@@ -136,7 +192,11 @@ describe('API Error Contract (e2e)', () => {
       // This verifies the structure of rate limit error responses
       const response = await request(app.getHttpServer())
         .post('/reactions')
-        .send({ confessionId: 'test-id', anonymousUserId: 'test-user', emoji: 'like' });
+        .send({
+          confessionId: 'test-id',
+          anonymousUserId: 'test-user',
+          emoji: 'like',
+        });
       // The endpoint may return 404 (route exists but validation fails) or other status
       // Key point: any 429 response should have the predictable envelope
       expect(response.body).toHaveProperty('status');


### PR DESCRIPTION
## Summary
- trims and validates search query text before the service layer
- rejects empty/whitespace-only queries, over-max limits, and control characters with a structured `VALIDATION_FAILED` response
- shares a dedicated search validation pipe across hybrid and full-text search endpoints
- extends `api-error-contract.e2e-spec.ts` and adds a focused search validation contract spec that exercises the real HTTP error envelope

Closes #1128

## Validation
- `npx --yes jest@30.0.5 --config jest.config.js src/search-discovery/search-validation.pipe.spec.ts src/confession/confession.search.spec.ts src/confession/confession.controller.gas-regression.spec.ts --runInBand` (35 tests passing)
- `npx eslint src/confession/confession.controller.ts src/confession/dto/search-confession.dto.ts src/search-discovery/search-validation.pipe.ts src/search-discovery/search-validation.pipe.spec.ts test/api-error-contract.e2e-spec.ts --max-warnings=0`
- `git diff --check`

## Known upstream blockers
- `npx --yes jest@30.0.5 --config ./test/jest-e2e.json api-error-contract.e2e-spec.ts --runInBand` is blocked before test execution by the existing `src/health/health.module.ts` import of missing `RedisHealthIndicator` from `./redis.health`.
- `pnpm build` is blocked by existing TypeScript errors in admin, health, and tipping modules, including the same `RedisHealthIndicator` export mismatch.