### PR TITLE
#1134: Add Redis readiness check for job mode

### DIFF
--- a/docs/HEALTH_ENDPOINT_QUICK_REFERENCE.md
+++ b/docs/HEALTH_ENDPOINT_QUICK_REFERENCE.md
@@ -4,11 +4,11 @@ The backend exposes two health endpoints under the global `/api` prefix.
 
 ## Endpoints
 
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/api/health/live` | GET | **Liveness probe** — returns 200 while the Node process is responsive. No external dependency checks. Safe to poll at high frequency. |
-| `/api/health/ready` | GET | **Readiness probe** — returns 200 only when Postgres, Redis, BullMQ queues, and confession-table schema are all healthy. Returns 503 with per-check detail on failure. |
-| `/api/health` | GET | Backward-compatible alias for `/api/health/ready`. Prefer `/api/health/ready` for new integrations. |
+| Endpoint            | Method | Purpose                                                                                                                                                                                                                                     |
+| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/health/live`  | GET    | **Liveness probe** — returns 200 while the Node process is responsive. No external dependency checks. Safe to poll at high frequency.                                                                                                       |
+| `/api/health/ready` | GET    | **Readiness probe** — returns 200 only when required dependencies are healthy. Postgres and schema are always checked; Redis and BullMQ queues are strict when `ENABLE_BACKGROUND_JOBS=true`. Returns 503 with per-check detail on failure. |
+| `/api/health`       | GET    | Backward-compatible alias for `/api/health/ready`. Prefer `/api/health/ready` for new integrations.                                                                                                                                         |
 
 ## Usage
 
@@ -47,9 +47,11 @@ readinessProbe:
 The readiness probe (`/api/health/ready`) checks:
 
 1. **Database** — Postgres connection via TypeORM ping
-2. **Redis** — Redis connection health
-3. **Queues** — BullMQ queue worker availability
+2. **Redis** — Redis `PING` when `ENABLE_BACKGROUND_JOBS=true`
+3. **Queues** — BullMQ queue worker availability when `ENABLE_BACKGROUND_JOBS=true`
 4. **Schema** — Confession table exists and matches expected schema
+
+When `ENABLE_BACKGROUND_JOBS` is not the exact string `"true"`, Redis and queue readiness return `status: "up"` with `mode: "disabled"` and an explanatory `reason`. This keeps local development and CI smoke checks from requiring Redis while still making production job mode strict.
 
 ## Response examples
 
@@ -57,7 +59,37 @@ The readiness probe (`/api/health/ready`) checks:
 
 ```json
 {
-  "status": "ok"
+  "status": "ok",
+  "info": {
+    "database": { "status": "up" },
+    "redis": { "status": "up", "host": "redis", "port": 6379 },
+    "queues": { "status": "up" },
+    "schema": { "status": "up" }
+  }
+}
+```
+
+### Jobs disabled (200)
+
+```json
+{
+  "status": "ok",
+  "info": {
+    "database": { "status": "up" },
+    "redis": {
+      "status": "up",
+      "mode": "disabled",
+      "reason": "ENABLE_BACKGROUND_JOBS is set to \"false\" (Redis readiness intentionally disabled)",
+      "severity": "info"
+    },
+    "queues": {
+      "status": "up",
+      "mode": "disabled",
+      "reason": "ENABLE_BACKGROUND_JOBS is set to \"false\" (background jobs intentionally disabled)",
+      "severity": "info"
+    },
+    "schema": { "status": "up" }
+  }
 }
 ```
 
@@ -66,10 +98,26 @@ The readiness probe (`/api/health/ready`) checks:
 ```json
 {
   "status": "error",
-  "details": [
-    { "database": { "status": "up" } },
-    { "redis": { "status": "down", "message": "Connection refused" } }
-  ]
+  "info": {
+    "database": { "status": "up" }
+  },
+  "error": {
+    "redis": {
+      "status": "down",
+      "host": "redis",
+      "port": 6379,
+      "error": "ECONNREFUSED",
+      "hint": "Verify REDIS_HOST, REDIS_PORT, and that Redis is reachable when ENABLE_BACKGROUND_JOBS=true."
+    }
+  },
+  "details": {
+    "redis": {
+      "status": "down",
+      "host": "redis",
+      "port": 6379,
+      "error": "ECONNREFUSED"
+    }
+  }
 }
 ```
 

--- a/xconfess-backend/src/health/health.controller.spec.ts
+++ b/xconfess-backend/src/health/health.controller.spec.ts
@@ -23,7 +23,9 @@ describe('HealthController', () => {
   const dbIndicator = {
     pingCheck: jest.fn().mockResolvedValue(UP('database')),
   };
-  const redisIndicator = { isHealthy: jest.fn().mockResolvedValue(UP('redis')) };
+  const redisIndicator = {
+    isHealthy: jest.fn().mockResolvedValue(UP('redis')),
+  };
   const schemaIndicator = {
     isHealthy: jest.fn().mockResolvedValue(UP('schema')),
   };

--- a/xconfess-backend/src/health/redis.health.spec.ts
+++ b/xconfess-backend/src/health/redis.health.spec.ts
@@ -1,56 +1,75 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { RedisHealthIndicator } from './redis.health';
 import { HealthCheckError } from '@nestjs/terminus';
 import Redis from 'ioredis';
+import { RedisHealthIndicator } from './redis.health';
 
-// Shared mocks for ioredis instance methods
 const mockConnect = jest.fn();
 const mockPing = jest.fn();
 const mockDisconnect = jest.fn();
 
-// Mock ioredis constructor
 jest.mock('ioredis', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      connect: mockConnect,
-      ping: mockPing,
-      disconnect: mockDisconnect,
-    };
-  });
+  return jest.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    ping: mockPing,
+    disconnect: mockDisconnect,
+  }));
 });
 
-describe('RedisHealthIndicator', () => {
-  let indicator: RedisHealthIndicator;
-  let configService: ConfigService;
+const MockRedis = Redis as unknown as jest.Mock;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        RedisHealthIndicator,
-        {
-          provide: ConfigService,
-          useValue: {
-            get: jest.fn().mockImplementation((key) => {
-              if (key === 'REDIS_HOST') return 'localhost';
-              if (key === 'REDIS_PORT') return 6379;
-              return null;
-            }),
-          },
+async function buildIndicator(config: Record<string, unknown>) {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      RedisHealthIndicator,
+      {
+        provide: ConfigService,
+        useValue: {
+          get: jest.fn((key: string, defaultValue?: unknown) =>
+            Object.prototype.hasOwnProperty.call(config, key)
+              ? config[key]
+              : defaultValue,
+          ),
         },
-      ],
-    }).compile();
+      },
+    ],
+  }).compile();
 
-    indicator = module.get<RedisHealthIndicator>(RedisHealthIndicator);
-    configService = module.get<ConfigService>(ConfigService);
+  return module.get<RedisHealthIndicator>(RedisHealthIndicator);
+}
 
-    // Reset shared mocks
+describe('RedisHealthIndicator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     mockConnect.mockReset();
     mockPing.mockReset();
     mockDisconnect.mockReset();
+    MockRedis.mockClear();
   });
 
-  it('should return up if Redis ping is successful', async () => {
+  it('returns up and skips Redis when background jobs are disabled', async () => {
+    const indicator = await buildIndicator({
+      ENABLE_BACKGROUND_JOBS: 'false',
+    });
+
+    const result = await indicator.isHealthy('redis');
+
+    expect(result.redis).toMatchObject({
+      status: 'up',
+      mode: 'disabled',
+      severity: 'info',
+    });
+    expect(result.redis.reason).toContain('"false"');
+    expect(MockRedis).not.toHaveBeenCalled();
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it('returns up if Redis ping is successful when jobs are enabled', async () => {
+    const indicator = await buildIndicator({
+      ENABLE_BACKGROUND_JOBS: 'true',
+      REDIS_HOST: 'redis.internal',
+      REDIS_PORT: '6380',
+    });
     mockConnect.mockResolvedValue(undefined);
     mockPing.mockResolvedValue('PONG');
 
@@ -59,16 +78,28 @@ describe('RedisHealthIndicator', () => {
     expect(result).toEqual({
       redis: {
         status: 'up',
-        host: 'localhost',
-        port: 6379,
+        host: 'redis.internal',
+        port: 6380,
       },
     });
+    expect(MockRedis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'redis.internal',
+        port: 6380,
+        lazyConnect: true,
+      }),
+    );
     expect(mockConnect).toHaveBeenCalled();
     expect(mockPing).toHaveBeenCalled();
     expect(mockDisconnect).toHaveBeenCalled();
   });
 
-  it('should throw HealthCheckError if Redis ping fails', async () => {
+  it('throws HealthCheckError if Redis ping fails when jobs are enabled', async () => {
+    const indicator = await buildIndicator({
+      ENABLE_BACKGROUND_JOBS: 'true',
+      REDIS_HOST: 'localhost',
+      REDIS_PORT: 6379,
+    });
     mockConnect.mockResolvedValue(undefined);
     mockPing.mockRejectedValue(new Error('Connection lost'));
 
@@ -78,8 +109,26 @@ describe('RedisHealthIndicator', () => {
     expect(mockDisconnect).toHaveBeenCalled();
   });
 
-  it('should throw HealthCheckError if Redis connection fails', async () => {
+  it('throws HealthCheckError if Redis connection fails when jobs are enabled', async () => {
+    const indicator = await buildIndicator({
+      ENABLE_BACKGROUND_JOBS: 'true',
+      REDIS_HOST: 'localhost',
+      REDIS_PORT: 6379,
+    });
     mockConnect.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(indicator.isHealthy('redis')).rejects.toThrow(
+      HealthCheckError,
+    );
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it('throws HealthCheckError for unexpected Redis ping responses', async () => {
+    const indicator = await buildIndicator({
+      ENABLE_BACKGROUND_JOBS: 'true',
+    });
+    mockConnect.mockResolvedValue(undefined);
+    mockPing.mockResolvedValue('NOPE');
 
     await expect(indicator.isHealthy('redis')).rejects.toThrow(
       HealthCheckError,

--- a/xconfess-backend/src/health/redis.health.ts
+++ b/xconfess-backend/src/health/redis.health.ts
@@ -1,128 +1,125 @@
 import {
+  HealthCheckError,
   HealthIndicator,
   HealthIndicatorResult,
-  HealthCheckError,
 } from '@nestjs/terminus';
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectQueue } from '@nestjs/bullmq';
-import { Queue } from 'bullmq';
 import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
 
-interface QueueDetail {
+interface RedisHealthDetail {
   status: 'up' | 'down';
-  workers?: number;
-  counts?: Record<string, number>;
+  host?: string;
+  port?: number;
+  mode?: 'disabled';
+  reason?: string;
+  severity?: 'info';
   error?: string;
   hint?: string;
 }
 
-@Injectable()
-export class QueueHealthIndicator extends HealthIndicator {
-  private readonly logger = new Logger(QueueHealthIndicator.name);
+function renderConfigValue(rawValue: unknown): string {
+  if (typeof rawValue === 'string') {
+    return rawValue;
+  }
 
-  constructor(
-    @InjectQueue('notifications') private readonly notifications: Queue,
-    @InjectQueue('notifications-dlq') private readonly dlq: Queue,
-    @InjectQueue('export-queue') private readonly exportQueue: Queue,
-    @InjectQueue('confession-draft-publisher')
-    private readonly draftQueue: Queue,
-    private readonly configService: ConfigService,
-  ) {
+  if (typeof rawValue === 'number' || typeof rawValue === 'boolean') {
+    return String(rawValue);
+  }
+
+  return 'non-string value';
+}
+
+function resolveDisabledReason(rawValue: unknown): string {
+  if (rawValue === 'false') {
+    return 'ENABLE_BACKGROUND_JOBS is set to "false" (Redis readiness intentionally disabled)';
+  }
+
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return 'ENABLE_BACKGROUND_JOBS is not set (Redis readiness defaults to disabled)';
+  }
+
+  return `ENABLE_BACKGROUND_JOBS is set to "${renderConfigValue(rawValue)}" (expected "true" to enable Redis readiness)`;
+}
+
+function parseRedisPort(rawValue: unknown): number {
+  if (typeof rawValue === 'number') {
+    return rawValue;
+  }
+
+  if (typeof rawValue === 'string' && rawValue.trim() !== '') {
+    const parsed = Number(rawValue);
+    return Number.isFinite(parsed) ? parsed : 6379;
+  }
+
+  return 6379;
+}
+
+@Injectable()
+export class RedisHealthIndicator extends HealthIndicator {
+  private readonly logger = new Logger(RedisHealthIndicator.name);
+
+  constructor(private readonly configService: ConfigService) {
     super();
   }
 
   async isHealthy(key: string): Promise<HealthIndicatorResult> {
-    const jobsEnabled =
-      this.configService.get<string>('ENABLE_BACKGROUND_JOBS') === 'true';
-
-    if (!jobsEnabled) {
-      return this.getStatus(key, true, {
-        mode: 'disabled',
-        reason: 'ENABLE_BACKGROUND_JOBS is not set to "true" — queue workers are not expected.',
-      });
-    }
-
-    const queues: Array<{
-      name: string;
-      queue: Queue;
-      requiresWorkers: boolean;
-    }> = [
-      {
-        name: 'notifications',
-        queue: this.notifications,
-        requiresWorkers: true,
-      },
-      // DLQ is a retention queue — no processor is expected to run against it.
-      {
-        name: 'notifications-dlq',
-        queue: this.dlq,
-        requiresWorkers: false,
-      },
-      {
-        name: 'export-queue',
-        queue: this.exportQueue,
-        requiresWorkers: true,
-      },
-      {
-        name: 'confession-draft-publisher',
-        queue: this.draftQueue,
-        requiresWorkers: true,
-      },
-    ];
-
-    const details: Record<string, QueueDetail> = {};
-    let allHealthy = true;
-
-    await Promise.all(
-      queues.map(async ({ name, queue, requiresWorkers }) => {
-        try {
-          const [counts, workers] = await Promise.all([
-            queue.getJobCounts('active', 'waiting', 'failed', 'delayed'),
-            queue.getWorkers(),
-          ]);
-
-          const workerCount = workers.length;
-          const healthy = !requiresWorkers || workerCount > 0;
-
-          if (!healthy) {
-            allHealthy = false;
-          }
-
-          details[name] = {
-            status: healthy ? 'up' : 'down',
-            workers: workerCount,
-            counts,
-            ...(healthy
-              ? {}
-              : {
-                  hint: `Queue "${name}" has no active workers. Ensure the processor service is running and ENABLE_BACKGROUND_JOBS=true is set.`,
-                }),
-          };
-        } catch (error: unknown) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          this.logger.error(
-            `Queue health check failed for "${name}": ${message}`,
-          );
-          allHealthy = false;
-          details[name] = {
-            status: 'down',
-            error: message,
-            hint: `Could not connect to queue "${name}". Verify REDIS_HOST, REDIS_PORT, and that the Bull queue name matches the registered queue in health.module.ts.`,
-          };
-        }
-      }),
+    const rawJobsConfig = this.configService.get<string | undefined>(
+      'ENABLE_BACKGROUND_JOBS',
     );
 
-    if (!allHealthy) {
-      // Surface per-queue breakdown so the contributor sees exactly which
-      // queues are down without needing to read server logs.
-      throw new HealthCheckError(
-        'One or more queues are unhealthy',
-        this.getStatus(key, false, details),
-      );
+    if (rawJobsConfig !== 'true') {
+      const detail: RedisHealthDetail = {
+        status: 'up',
+        mode: 'disabled',
+        reason: resolveDisabledReason(rawJobsConfig),
+        severity: 'info',
+      };
+
+      return this.getStatus(key, true, detail);
     }
 
-    return this.getStatus(key, true, details);
+    const redisHost = this.configService.get<string>('REDIS_HOST', 'localhost');
+    const redisPort = parseRedisPort(
+      this.configService.get<string | number>('REDIS_PORT', 6379),
+    );
+    const redisPassword = this.configService.get<string>('REDIS_PASSWORD');
+    const client = new Redis({
+      host: redisHost,
+      port: redisPort,
+      password: redisPassword,
+      connectTimeout: 2_000,
+      lazyConnect: true,
+      retryStrategy: () => null,
+    });
+
+    try {
+      await client.connect();
+      const response = await client.ping();
+
+      if (response !== 'PONG') {
+        throw new Error('Unexpected Redis PING response');
+      }
+
+      return this.getStatus(key, true, {
+        host: redisHost,
+        port: redisPort,
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Redis readiness check failed: ${message}`);
+
+      throw new HealthCheckError(
+        'Redis readiness check failed',
+        this.getStatus(key, false, {
+          host: redisHost,
+          port: redisPort,
+          error: message,
+          hint: 'Verify REDIS_HOST, REDIS_PORT, and that Redis is reachable when ENABLE_BACKGROUND_JOBS=true.',
+        }),
+      );
+    } finally {
+      client.disconnect();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- restores `RedisHealthIndicator` as a real Redis `PING` readiness check instead of the duplicated queue indicator implementation
- makes Redis readiness strict only when `ENABLE_BACKGROUND_JOBS=true`; otherwise it reports `redis.status=up` with `mode=disabled` and a clear reason
- keeps queue worker readiness separate in `QueueHealthIndicator`
- documents the jobs-enabled Redis/queue readiness behavior in `docs/HEALTH_ENDPOINT_QUICK_REFERENCE.md`

Closes #1134

## Validation
- `npx --yes jest@30.0.5 --config jest.config.js src/health/redis.health.spec.ts src/health/queue.health.spec.ts src/health/health.controller.spec.ts src/health/schema-readiness.health.spec.ts --runInBand` (23 tests passing)
- `npx eslint src/health/redis.health.ts src/health/redis.health.spec.ts src/health/health.controller.ts src/health/health.controller.spec.ts --max-warnings=0`
- `git diff --check`

## Known upstream blockers
- `pnpm build` no longer reports the previous health `RedisHealthIndicator` export mismatch. It is still blocked by existing TypeScript errors in `src/admin/services/admin.service.ts` and `src/tipping/chain-reconciliation.service.ts`.
- `npx --yes jest@30.0.5 --config ./test/jest-e2e.json api-error-contract.e2e-spec.ts --runInBand` now gets past the health import problem and is blocked by the existing namespace-style `supertest` import in that e2e file.