### PR TITLE
#1122: Harden search and trending UI states

### DIFF
--- a/xconfess-frontend/app/(dashboard)/search/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/search/page.tsx
@@ -10,30 +10,14 @@ import ErrorState from "@/app/components/common/ErrorState";
 import { useDebounce } from "@/app/lib/hooks/useDebounce";
 import { useSearch } from "@/app/lib/hooks/useSearch";
 import { useAuth } from "@/app/lib/hooks/useAuth"; // Added to handle authenticated saved searches
-import { Card } from "@/app/components/ui/card"; // Reusing your UI package system
 import { Button } from "@/app/components/ui/button";
 import { DEFAULT_FILTERS, type SearchFilters } from "@/app/lib/types/search";
 import type { FilterChipKey } from "@/app/components/search/FilterChips";
-import {
-  Filter,
-  X,
-  HelpCircle,
-  Save,
-  HelpCircle as TooltipIcon,
-} from "lucide-react";
+import { Filter, X, HelpCircle, Save } from "lucide-react";
 import { cn } from "@/app/lib/utils/cn";
 import { useFocusTrap } from "@/app/lib/hooks/useFocusTrap";
 
 const DEBOUNCE_MS = 300;
-
-// Example clickable query seeds requested by Wave 5 criteria
-const EXAMPLE_SUGGESTIONS = [
-  "crypto",
-  "stellar",
-  "secret",
-  "developer",
-  "node",
-];
 
 function parseFiltersFromParams(params: URLSearchParams): SearchFilters {
   const sort = params.get("sort");
@@ -307,6 +291,7 @@ export default function SearchPage() {
                 type="button"
                 size="sm"
                 variant={user ? "default" : "outline"} //  "outline" matches your component rules
+                onClick={handleSaveSearch}
                 disabled={!user || !query.trim()}
                 className={cn(
                   "gap-2 transition-all duration-200",
@@ -436,57 +421,6 @@ export default function SearchPage() {
                       onPrimaryAction={handleClearAll}
                     />
                   </div>
-                )}
-
-                {/* ========================================================= */}
-                {/* CRITERIA 1: EXPLICIT ACTIONABLE EMPTY RESULT FALLBACK       */}
-                {/* ========================================================= */}
-                {isEmpty && (
-                  <Card className="p-6 md:p-8 text-center border border-zinc-800 bg-zinc-900/50 mb-6 max-w-2xl mx-auto">
-                    <div className="mx-auto w-12 h-12 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
-                      <HelpCircle className="h-6 w-6 text-zinc-400" />
-                    </div>
-                    <h3 className="text-lg font-medium text-zinc-200 mb-2">
-                      No matches found
-                    </h3>
-                    <p className="text-sm text-zinc-400 mb-6">
-                      Your current selection filters may be too narrow or the
-                      sequence doesn't exist. Try expanding your parameters or
-                      running an example query suggestion.
-                    </p>
-
-                    {/* Action Hub – Reset and interactive quick tokens */}
-                    <div className="flex flex-col items-center justify-center gap-4">
-                      {hasActiveFilterValues && (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={handleClearAll}
-                          className="border-zinc-700 hover:bg-zinc-800 text-zinc-300"
-                        >
-                          Clear Active Search Filters
-                        </Button>
-                      )}
-
-                      <div className="w-full pt-4 border-t border-zinc-800/60">
-                        <span className="text-xs text-zinc-500 uppercase tracking-wider block mb-2.5">
-                          Try searching popular trends:
-                        </span>
-                        <div className="flex flex-wrap justify-center gap-2">
-                          {EXAMPLE_SUGGESTIONS.map((tag) => (
-                            <button
-                              key={tag}
-                              type="button"
-                              onClick={() => handleSuggestion(tag)}
-                              className="px-2.5 py-1 text-xs font-medium rounded-full bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white transition-colors border border-zinc-700/50"
-                            >
-                              #{tag}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </Card>
                 )}
 
                 <SearchResults

--- a/xconfess-frontend/app/components/analytics/LoadingState.tsx
+++ b/xconfess-frontend/app/components/analytics/LoadingState.tsx
@@ -9,6 +9,7 @@ export const AnalyticsLoadingSkeleton = () => {
       <div className="max-w-7xl mx-auto px-4 py-8">
         {/* Header skeleton */}
         <div className="mb-8">
+          <p className="sr-only">Loading analytics...</p>
           <div className="h-10 w-64 bg-zinc-800 rounded-lg animate-pulse mb-2" />
           <div className="h-5 w-96 bg-zinc-800 rounded-lg animate-pulse" />
         </div>

--- a/xconfess-frontend/app/components/analytics/TrendingConfessionCard.tsx
+++ b/xconfess-frontend/app/components/analytics/TrendingConfessionCard.tsx
@@ -23,6 +23,14 @@ export const TrendingConfessionCard = ({ confession, rank }: Props) => {
     return rank;
   };
 
+  const createdAt = new Date(confession.createdAt);
+  const formattedDate = Number.isNaN(createdAt.getTime())
+    ? "Unknown date"
+    : createdAt.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      });
+
   return (
     <div className="bg-zinc-800 border border-zinc-700 rounded-xl p-5 hover:border-purple-500/50 transition-all">
       <div className="flex gap-4">
@@ -56,10 +64,7 @@ export const TrendingConfessionCard = ({ confession, rank }: Props) => {
 
             {/* Date */}
             <span className="text-gray-500 ml-auto">
-              {new Date(confession.createdAt).toLocaleDateString('en-US', {
-                month: 'short',
-                day: 'numeric'
-              })}
+              {formattedDate}
             </span>
           </div>
         </div>

--- a/xconfess-frontend/app/components/analytics/TrendingDashboard.tsx
+++ b/xconfess-frontend/app/components/analytics/TrendingDashboard.tsx
@@ -1,13 +1,117 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { AnalyticsData } from "@/app/lib/types/analytics.types";
+import {
+  AnalyticsData,
+  DailyActivity,
+  ReactionDistribution,
+  TrendingConfession,
+} from "@/app/lib/types/analytics.types";
 import { TrendingConfessionCard } from "./TrendingConfessionCard";
 import { ReactionChart } from "./ReactionChart";
 import { ActivityChart } from "./ActivityChart";
 import { MetricsOverview } from "./MetricsOverview";
 import { AnalyticsLoadingSkeleton } from "./LoadingState";
 import { TrendingUp, Calendar } from "lucide-react";
+
+type AnalyticsApiResponse = Partial<AnalyticsData> & {
+  generatedAt?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeTrending(value: unknown): TrendingConfession[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter(isRecord)
+    .map((item, index) => {
+      const reactions = isRecord(item.reactions) ? item.reactions : {};
+      const like = asNumber(reactions.like);
+      const love = asNumber(reactions.love);
+      const reactionCount = asNumber(item.reactionCount, like + love);
+      const content =
+        typeof item.content === "string"
+          ? item.content
+          : typeof item.message === "string"
+            ? item.message
+            : "Untitled confession";
+
+      return {
+        id: typeof item.id === "string" ? item.id : `trending-${index}`,
+        content,
+        createdAt:
+          typeof item.createdAt === "string"
+            ? item.createdAt
+            : new Date(0).toISOString(),
+        reactionCount,
+        reactions: { like, love },
+      };
+    });
+}
+
+function normalizeReactionDistribution(value: unknown): ReactionDistribution[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isRecord).map((item) => ({
+    type: typeof item.type === "string" ? item.type : "unknown",
+    count: asNumber(item.count),
+    percentage: asNumber(item.percentage),
+  }));
+}
+
+function normalizeDailyActivity(value: unknown): DailyActivity[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isRecord).map((item) => ({
+    date: typeof item.date === "string" ? item.date : "",
+    confessions: asNumber(item.confessions),
+    reactions: asNumber(item.reactions),
+    activeUsers: asNumber(item.activeUsers),
+  }));
+}
+
+function normalizeAnalyticsData(
+  payload: unknown,
+  fallbackPeriod: "7days" | "30days",
+): AnalyticsData {
+  const source: AnalyticsApiResponse = isRecord(payload) ? payload : {};
+  const trending = normalizeTrending(source.trending);
+  const reactionDistribution = normalizeReactionDistribution(
+    source.reactionDistribution,
+  );
+  const dailyActivity = normalizeDailyActivity(source.dailyActivity);
+  const metrics = isRecord(source.totalMetrics) ? source.totalMetrics : {};
+
+  return {
+    trending,
+    reactionDistribution,
+    dailyActivity,
+    totalMetrics: {
+      totalConfessions: asNumber(metrics.totalConfessions, trending.length),
+      totalReactions: asNumber(
+        metrics.totalReactions,
+        trending.reduce((sum, item) => sum + item.reactionCount, 0),
+      ),
+      totalUsers: asNumber(metrics.totalUsers),
+    },
+    period: source.period === "30days" || source.period === "7days"
+      ? source.period
+      : fallbackPeriod,
+  };
+}
 
 export const TrendingDashboard = () => {
   const [data, setData] = useState<AnalyticsData | null>(null);
@@ -26,16 +130,23 @@ export const TrendingDashboard = () => {
 
       if (!res.ok) throw new Error('Failed to fetch analytics');
 
-      const analyticsData = await res.json();
+      const rawAnalyticsData = await res.json();
+      const analyticsData = normalizeAnalyticsData(rawAnalyticsData, period);
       setData(analyticsData);
 
       // Prefer backend-provided timestamp header or body field when available
-      const headerDate = res.headers.get('x-generated-at');
+      const headerDate =
+        typeof res.headers?.get === "function"
+          ? res.headers.get("x-generated-at")
+          : null;
       if (headerDate) {
         const ts = Date.parse(headerDate);
         if (!isNaN(ts)) setFetchedAt(ts);
-      } else if ((analyticsData as any).generatedAt) {
-        const ts = Date.parse((analyticsData as any).generatedAt);
+      } else if (
+        isRecord(rawAnalyticsData) &&
+        typeof rawAnalyticsData.generatedAt === "string"
+      ) {
+        const ts = Date.parse(rawAnalyticsData.generatedAt);
         if (!isNaN(ts)) setFetchedAt(ts);
       } else {
         setFetchedAt(Date.now());
@@ -52,8 +163,15 @@ export const TrendingDashboard = () => {
   }, [fetchAnalytics]);
 
   const isStale = fetchedAt ? Date.now() - fetchedAt > STALE_MS : false;
-  const isInitialLoad = !data && loading;
   const showSkeleton = !data;
+  const trending = data?.trending ?? [];
+  const reactionDistribution = data?.reactionDistribution ?? [];
+  const dailyActivity = data?.dailyActivity ?? [];
+  const totalMetrics = data?.totalMetrics ?? {
+    totalConfessions: 0,
+    totalReactions: 0,
+    totalUsers: 0,
+  };
 
   return (
     <div className="min-h-screen bg-black text-white">
@@ -110,17 +228,21 @@ export const TrendingDashboard = () => {
 
         {/* Error banner */}
         {error && (
-          <div className="mb-6 rounded-xl border px-4 py-3 bg-red-900/20 border-red-800 text-sm flex items-center justify-between">
+          <div
+            className="mb-6 rounded-xl border px-4 py-3 bg-red-900/20 border-red-800 text-sm flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+            role="alert"
+          >
             <div>
-              <strong className="mr-2">Failed to load analytics</strong>
+              <strong className="mr-2">Failed to Load Analytics</strong>
               <span className="text-red-200">{error}</span>
             </div>
             <div>
               <button
                 onClick={fetchAnalytics}
+                disabled={loading}
                 className="px-3 py-1 bg-red-600 hover:bg-red-700 rounded text-white"
               >
-                Retry
+                {loading ? "Retrying..." : "Retry"}
               </button>
             </div>
           </div>
@@ -130,7 +252,7 @@ export const TrendingDashboard = () => {
         {showSkeleton ? (
           <AnalyticsLoadingSkeleton />
         ) : (
-          <MetricsOverview metrics={data?.totalMetrics ?? { totalConfessions: 0, totalReactions: 0, totalUsers: 0 }} period={period} />
+          <MetricsOverview metrics={totalMetrics} period={period} />
         )}
 
         {/* Charts Section */}
@@ -141,7 +263,7 @@ export const TrendingDashboard = () => {
               <div className="h-64 bg-zinc-800 rounded-lg animate-pulse" />
             </div>
           ) : (
-            <ReactionChart data={data?.reactionDistribution ?? []} />
+            <ReactionChart data={reactionDistribution} />
           )}
 
           {showSkeleton ? (
@@ -150,7 +272,7 @@ export const TrendingDashboard = () => {
               <div className="h-64 bg-zinc-800 rounded-lg animate-pulse" />
             </div>
           ) : (
-            <ActivityChart data={data?.dailyActivity ?? []} />
+            <ActivityChart data={dailyActivity} />
           )}
         </div>
 
@@ -175,7 +297,7 @@ export const TrendingDashboard = () => {
                 </div>
               ))
             ) : (
-              data?.trending.map((confession, index) => (
+              trending.map((confession, index) => (
                 <TrendingConfessionCard
                   key={confession.id}
                   confession={confession}
@@ -185,10 +307,25 @@ export const TrendingDashboard = () => {
             )}
           </div>
 
-          {!loading && data && data.trending.length === 0 && (
-            <div className="text-center py-12">
-              <div className="text-6xl mb-4">📭</div>
-              <p className="text-gray-400">No trending confessions yet</p>
+          {!loading && data && trending.length === 0 && (
+            <div className="text-center py-12" role="status" aria-live="polite">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg border border-zinc-700 bg-zinc-800 text-zinc-300">
+                <TrendingUp className="h-6 w-6" aria-hidden />
+              </div>
+              <p className="text-gray-200 font-medium">
+                No trending confessions yet
+              </p>
+              <p className="mx-auto mt-2 max-w-md text-sm text-gray-400">
+                Try a different time period, refresh the dashboard, or seed demo
+                data before a GrantFox walkthrough.
+              </p>
+              <button
+                type="button"
+                onClick={fetchAnalytics}
+                className="mt-4 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
+              >
+                Refresh trending
+              </button>
             </div>
           )}
         </div>

--- a/xconfess-frontend/app/components/analytics/__tests__/TrendingDashboard.test.tsx
+++ b/xconfess-frontend/app/components/analytics/__tests__/TrendingDashboard.test.tsx
@@ -107,7 +107,7 @@ jest.mock('../TrendingConfessionCard', () => ({
     rank: number;
   }) => (
     <div data-testid={`confession-card-${rank}`}>
-      {rank}. {(confession.content || confession.message || '').substring(0, 30)}
+      {rank}. {confession.content || confession.message || ''}
     </div>
   ),
 }));

--- a/xconfess-frontend/app/components/search/__tests__/SearchResults.test.tsx
+++ b/xconfess-frontend/app/components/search/__tests__/SearchResults.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SearchResults } from "../SearchResults";
+import type { SearchConfession } from "@/app/lib/types/search";
+
+jest.mock("../SearchResultItem", () => ({
+  SearchResultItem: ({
+    confession,
+  }: {
+    confession: SearchConfession;
+    searchQuery?: string;
+  }) => <div data-testid="search-result-item">{confession.content}</div>,
+}));
+
+jest.mock("@/app/components/confession/LoadingSkeleton", () => ({
+  SkeletonCard: () => <div data-testid="search-skeleton" />,
+}));
+
+const result: SearchConfession = {
+  id: "confession-1",
+  content: "A searchable confession",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  reactions: { like: 4, love: 0 },
+  commentCount: 1,
+};
+
+describe("SearchResults states", () => {
+  it("shows skeleton rows during first-page loading", () => {
+    render(
+      <SearchResults
+        results={[]}
+        isLoading
+        isEmpty={false}
+        hasSearched
+        page={1}
+        hasMore={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("status", { name: "Loading search results" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId("search-skeleton")).toHaveLength(3);
+  });
+
+  it("shows helpful empty state actions for zero results", () => {
+    const onRetry = jest.fn();
+    const onClearFilters = jest.fn();
+    const onUseSuggestion = jest.fn();
+
+    render(
+      <SearchResults
+        results={[]}
+        isLoading={false}
+        isEmpty
+        hasSearched
+        page={1}
+        hasMore={false}
+        hasActiveFilters
+        onRetry={onRetry}
+        onClearFilters={onClearFilters}
+        onUseSuggestion={onUseSuggestion}
+      />,
+    );
+
+    expect(screen.getByText("No confessions match your search.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry search" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear filters" }));
+    fireEvent.click(screen.getByRole("button", { name: 'Try "secret"' }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onClearFilters).toHaveBeenCalledTimes(1);
+    expect(onUseSuggestion).toHaveBeenCalledWith("secret");
+  });
+
+  it("keeps existing results visible with degraded retry UI", () => {
+    const onRetry = jest.fn();
+
+    render(
+      <SearchResults
+        results={[result]}
+        query="searchable"
+        isLoading={false}
+        isEmpty={false}
+        hasSearched
+        page={1}
+        hasMore={false}
+        statusMeta={{
+          partial: false,
+          degraded: true,
+          message: "Search service timed out",
+          warnings: [],
+          searchType: "error",
+        }}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByText("Search is in a degraded state")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-item")).toHaveTextContent(
+      "A searchable confession",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize trending analytics API payloads before rendering so malformed or partial responses fall back to safe empty datasets
- add accessible loading, error, retry, and actionable empty states for trending analytics
- remove the duplicate search empty-state card so SearchResults owns search skeleton/empty/degraded states, with focused coverage

Closes #1122

## Validation
- npm test -- TrendingDashboard.test.tsx SearchResults.test.tsx --runInBand
- npm run lint -- app/components/analytics/TrendingDashboard.tsx app/components/analytics/TrendingConfessionCard.tsx app/components/analytics/LoadingState.tsx app/components/analytics/__tests__/TrendingDashboard.test.tsx app/components/search/SearchResults.tsx app/components/search/__tests__/SearchResults.test.tsx app/(dashboard)/search/page.tsx
- git diff --check

## Note
- npm run build is currently blocked by unrelated existing main-branch errors in app/(dashboard)/admin/diagnostics/page.tsx and app/components/comparison/ComparisonTool.tsx (ArrowClockwise lucide export).
