### PR TITLE
#1133: Harden tipping verification states

### DIFF
--- a/xconfess-frontend/app/api/confessions/[id]/tips/stats/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/tips/stats/route.ts
@@ -1,0 +1,43 @@
+import { getApiBaseUrl } from "@/app/lib/config";
+import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+
+const BASE_API_URL = getApiBaseUrl();
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await context.params;
+
+    if (!id) {
+      return createApiErrorResponse("Confession ID is required", { status: 400 });
+    }
+
+    const response = await fetch(`${BASE_API_URL}/confessions/${id}/tips/stats`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      next: { revalidate: 0 },
+    });
+
+    const text = await response.text();
+    const payload = text ? JSON.parse(text) : {};
+
+    if (!response.ok) {
+      return createApiErrorResponse(payload, {
+        status: response.status,
+        route: "GET /api/confessions/[id]/tips/stats",
+      });
+    }
+
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    return createApiErrorResponse(error, {
+      status: 500,
+      route: "GET /api/confessions/[id]/tips/stats",
+    });
+  }
+}

--- a/xconfess-frontend/app/api/confessions/[id]/tips/verify/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/tips/verify/route.ts
@@ -1,0 +1,53 @@
+import { getApiBaseUrl } from "@/app/lib/config";
+import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+
+const BASE_API_URL = getApiBaseUrl();
+const TX_ID_PATTERN = /^[a-fA-F0-9]{64}$/;
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await context.params;
+    const body = await request.json().catch(() => ({}));
+    const txId = typeof body?.txId === "string" ? body.txId : body?.txHash;
+
+    if (!id) {
+      return createApiErrorResponse("Confession ID is required", { status: 400 });
+    }
+
+    if (typeof txId !== "string" || !TX_ID_PATTERN.test(txId)) {
+      return createApiErrorResponse("Transaction ID must be a valid 64-character hex string", {
+        status: 400,
+        route: "POST /api/confessions/[id]/tips/verify",
+      });
+    }
+
+    const response = await fetch(`${BASE_API_URL}/confessions/${id}/tips/verify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ txId }),
+    });
+
+    const text = await response.text();
+    const payload = text ? JSON.parse(text) : {};
+
+    if (!response.ok) {
+      return createApiErrorResponse(payload, {
+        status: response.status,
+        route: "POST /api/confessions/[id]/tips/verify",
+      });
+    }
+
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    return createApiErrorResponse(error, {
+      status: 500,
+      route: "POST /api/confessions/[id]/tips/verify",
+    });
+  }
+}

--- a/xconfess-frontend/app/components/confession/TipButton.tsx
+++ b/xconfess-frontend/app/components/confession/TipButton.tsx
@@ -25,6 +25,13 @@ const MIN_TIP_AMOUNT = 0.1;
 const TIP_STEP = 0.1;
 const TIP_UNIT = "XLM";
 
+type TipLifecycleState = "idle" | "submitting" | "verifying" | "success" | "failed";
+
+interface SubmittedTip {
+  hash: string;
+  amount: number;
+}
+
 function parseTipAmount(rawAmount: string): number | null {
   if (rawAmount.trim() === "") return null;
   const amount = Number(rawAmount);
@@ -61,9 +68,11 @@ export const TipButton = ({
   const [isOpen, setIsOpen] = useState(false);
   const [tipAmount, setTipAmount] = useState(String(MIN_TIP_AMOUNT));
   const [isSending, setIsSending] = useState(false);
+  const [tipState, setTipState] = useState<TipLifecycleState>("idle");
   const [error, setError] = useState<string | null>(null);
   const [confirmedTx, setConfirmedTx] = useState<{ hash: string; amount: number } | null>(null);
-  const [pendingTxHash, setPendingTxHash] = useState<string | null>(null);
+  const [pendingTip, setPendingTip] = useState<SubmittedTip | null>(null);
+  const [pendingActivityId, setPendingActivityId] = useState<string | null>(null);
   const [stats, setStats] = useState<TipStats | null>(initialStats || null);
 
   const wallet = useWallet();
@@ -109,8 +118,11 @@ export const TipButton = ({
     }
 
     setIsSending(true);
+    setTipState("submitting");
     setError(null);
     setConfirmedTx(null);
+    setPendingTip(null);
+    setPendingActivityId(null);
 
     const activityId = uuidv4();
     addActivity({
@@ -121,7 +133,9 @@ export const TipButton = ({
       confessionId,
       amount,
     });
+    setPendingActivityId(activityId);
 
+    let submittedTip: SubmittedTip | null = null;
     try {
       const result = await sendTip(confessionId, amount, recipientAddress);
 
@@ -130,17 +144,25 @@ export const TipButton = ({
       }
 
       updateActivity(activityId, { txHash: result.txHash });
+      submittedTip = { hash: result.txHash, amount };
+      setPendingTip(submittedTip);
+      setTipState("verifying");
 
       const verifyResult = await verifyTip(confessionId, result.txHash);
 
       if (!verifyResult.success) {
-        setPendingTxHash(result.txHash);
-
         updateActivity(activityId, {
-          status: "submitted",
+          status: verifyResult.status === "failed" ? "failed" : "submitted",
           updatedAt: Date.now(),
         });
 
+        setTipState(verifyResult.status === "failed" ? "failed" : "verifying");
+        setError(
+          verifyResult.error ??
+            (verifyResult.status === "failed"
+              ? "Tip verification failed. You can retry verification below."
+              : "Backend verification is still pending. Retry verification in a moment."),
+        );
         return;
       }
 
@@ -150,14 +172,18 @@ export const TipButton = ({
       });
 
       setConfirmedTx({ hash: result.txHash, amount });
+      setTipState("success");
       setTipAmount(String(MIN_TIP_AMOUNT));
-      setPendingTxHash(null);
+      setPendingTip(null);
+      setPendingActivityId(null);
       await refreshStats();
     } catch (err: any) {
       updateActivity(activityId, {
         status: "failed",
         updatedAt: Date.now(),
       });
+      setTipState("failed");
+      if (submittedTip) setPendingTip(submittedTip);
 
       if (err.message === "Verification pending") {
         setError(
@@ -173,22 +199,49 @@ export const TipButton = ({
   };
 
   const handleVerify = async () => {
-    if (isSending || !pendingTxHash) return;
+    if (isSending || !pendingTip) return;
 
     setIsSending(true);
+    setTipState("verifying");
     setError(null);
 
     try {
-      const verifyResult = await verifyTip(confessionId, pendingTxHash);
+      const verifyResult = await verifyTip(confessionId, pendingTip.hash);
 
       if (!verifyResult.success) {
-        throw new Error("Verification still pending");
+        if (verifyResult.status === "failed") {
+          setTipState("failed");
+          if (pendingActivityId) {
+            updateActivity(pendingActivityId, {
+              status: "failed",
+              updatedAt: Date.now(),
+            });
+          }
+          setError(verifyResult.error ?? "Tip verification failed. You can retry verification below.");
+          return;
+        }
+
+        setError(
+          verifyResult.error ??
+            "Backend verification is still pending. Retry verification in a moment.",
+        );
+        return;
       }
 
-      setConfirmedTx({ hash: pendingTxHash, amount: parseFloat(tipAmount) });
-      setPendingTxHash(null);
+      if (pendingActivityId) {
+        updateActivity(pendingActivityId, {
+          status: "confirmed",
+          updatedAt: Date.now(),
+        });
+      }
+      setConfirmedTx({ hash: pendingTip.hash, amount: pendingTip.amount });
+      setTipState("success");
+      setPendingTip(null);
+      setPendingActivityId(null);
+      setTipAmount(String(MIN_TIP_AMOUNT));
       await refreshStats();
-    } catch (err: any) {
+    } catch {
+      setTipState("failed");
       setError(
         "Verification not yet confirmed. The transaction may still be processing on the Stellar network. " +
         "Please wait a moment and try again, or check the explorer link below.",
@@ -201,8 +254,8 @@ export const TipButton = ({
   const totalAmount = stats?.totalAmount || 0;
   const tipCount = stats?.totalCount || 0;
 
-  const explorerUrl = pendingTxHash
-    ? getStellarExplorerUrl(pendingTxHash)
+  const explorerUrl = pendingTip
+    ? getStellarExplorerUrl(pendingTip.hash)
     : confirmedTx
       ? getStellarExplorerUrl(confirmedTx.hash)
       : null;
@@ -281,6 +334,9 @@ export const TipButton = ({
                 <span>Tip confirmed</span>
               </div>
               <p className="text-green-300 text-xs mt-1">
+                Tip sent successfully.
+              </p>
+              <p className="text-green-300 text-xs mt-1">
                 {confirmedTx.amount} XLM sent
               </p>
               {confirmedTx.hash && (
@@ -297,14 +353,14 @@ export const TipButton = ({
           )}
 
           {/* Pending verification state */}
-          {pendingTxHash && (
+          {pendingTip && tipState === "verifying" && (
             <div className="mb-3 p-3 rounded-lg bg-yellow-900/30 border border-yellow-700/50">
               <div className="flex items-center gap-2 text-yellow-400 font-medium text-sm">
                 <Spinner />
                 <span>Verifying transaction</span>
               </div>
               <p className="text-yellow-300 text-xs mt-1">
-                Checking Stellar network confirmation status
+                Backend verification is still pending for {pendingTip.amount} XLM.
               </p>
               <div className="flex gap-2 mt-2">
                 <button
@@ -328,8 +384,40 @@ export const TipButton = ({
             </div>
           )}
 
+          {/* Failed verification state */}
+          {pendingTip && tipState === "failed" && (
+            <div className="mb-3 p-3 rounded-lg bg-red-900/30 border border-red-700/50">
+              <div className="flex items-center gap-2 text-red-300 font-medium text-sm">
+                <AlertCircle className="h-4 w-4" />
+                <span>Verification failed</span>
+              </div>
+              <p className="text-red-300 text-xs mt-1">
+                {error ?? "Tip verification failed. You can retry verification below."}
+              </p>
+              <div className="flex gap-2 mt-2">
+                <button
+                  onClick={handleVerify}
+                  disabled={isSending}
+                  className="flex-1 text-xs bg-red-700 hover:bg-red-600 disabled:opacity-50 py-1.5 rounded text-white transition-colors"
+                >
+                  {isSending ? "Checking..." : "Retry Verification"}
+                </button>
+                {explorerUrl && (
+                  <a
+                    href={explorerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs bg-zinc-700 hover:bg-zinc-600 py-1.5 px-2 rounded text-zinc-300 transition-colors"
+                  >
+                    View on Explorer
+                  </a>
+                )}
+              </div>
+            </div>
+          )}
+
           {/* Error state */}
-          {error && !pendingTxHash && !confirmedTx && (
+          {error && !pendingTip && !confirmedTx && (
             <div className="mb-3 p-3 rounded-lg bg-red-900/30 border border-red-700/50">
               <p className="text-red-400 text-xs">{error}</p>
               <button
@@ -342,11 +430,12 @@ export const TipButton = ({
           )}
 
           {/* Input */}
-          {!confirmedTx && (
+          {!confirmedTx && !pendingTip && (
             <>
               <div className="relative">
                 <input
-                  type="number"
+                  type="text"
+                  inputMode="decimal"
                   value={tipAmount}
                   onChange={(e) => {
                     setTipAmount(e.target.value);
@@ -388,7 +477,9 @@ export const TipButton = ({
                 )}
                 aria-label={
                   isSending
-                    ? "Sending tip"
+                    ? tipState === "verifying"
+                      ? "Verifying tip"
+                      : "Sending tip"
                     : walletCTA.status === "not-connected"
                       ? "Connect Wallet to Tip"
                       : walletCTA.status === "not-installed"
@@ -399,7 +490,7 @@ export const TipButton = ({
                 {isSending ? (
                   <>
                     <Spinner />
-                    <span>Sending...</span>
+                    <span>{tipState === "verifying" ? "Verifying..." : "Sending..."}</span>
                   </>
                 ) : walletCTA.status === "not-connected" ? (
                   <>

--- a/xconfess-frontend/lib/services/tipping.service.ts
+++ b/xconfess-frontend/lib/services/tipping.service.ts
@@ -53,6 +53,15 @@ export interface Tip {
   createdAt: string;
 }
 
+export interface VerifyTipResult {
+  success: boolean;
+  status: TipStatus;
+  error?: string;
+  tip?: Tip;
+  isIdempotent?: boolean;
+  canRetry?: boolean;
+}
+
 // -------------------- Helpers --------------------
 
 function getStellarNetwork(): string {
@@ -84,6 +93,80 @@ function classifyTipError(error: unknown): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeTipStatus(payload: any): TipStatus {
+  const rawStatus = String(
+    payload?.status ??
+      payload?.verificationStatus ??
+      payload?.tip?.verificationStatus ??
+      "",
+  ).toLowerCase();
+
+  if (["verified", "confirmed", "completed", "success"].includes(rawStatus)) {
+    return "confirmed";
+  }
+
+  if (["rejected", "failed", "conflict"].includes(rawStatus)) {
+    return "failed";
+  }
+
+  if (rawStatus === "stale_pending") {
+    return "stale_pending";
+  }
+
+  if (rawStatus === "pending" || rawStatus === "submitted") {
+    return "pending";
+  }
+
+  return payload?.tip || payload?.txId || payload?.id ? "confirmed" : "pending";
+}
+
+function normalizeTipStats(payload: any): TipStats {
+  const totalAmount = Number(payload?.totalAmount ?? 0);
+  const totalCount = Number(payload?.totalCount ?? payload?.tipCount ?? 0);
+  const averageAmount = Number(
+    payload?.averageAmount ??
+      (totalCount > 0 ? totalAmount / totalCount : 0),
+  );
+
+  return {
+    totalAmount: Number.isFinite(totalAmount) ? totalAmount : 0,
+    totalCount: Number.isFinite(totalCount) ? totalCount : 0,
+    averageAmount: Number.isFinite(averageAmount) ? averageAmount : 0,
+  };
+}
+
+function extractTipError(payload: any, fallback: string): string {
+  if (typeof payload === "string") return payload;
+  if (typeof payload?.message === "string") return payload.message;
+  if (typeof payload?.error === "string") return payload.error;
+  if (typeof payload?.error?.message === "string") return payload.error.message;
+  return fallback;
+}
+
+function isReplaySuccess(status: number, payload: any): boolean {
+  if (status !== 409) return false;
+  if (payload?.canRetry || payload?.conflictReason === "ALREADY_PROCESSING") {
+    return false;
+  }
+
+  const message = extractTipError(payload, "").toLowerCase();
+  return (
+    payload?.isIdempotent === true ||
+    payload?.conflictReason === "ALREADY_VERIFIED" ||
+    message.includes("duplicate") ||
+    message.includes("idempotent") ||
+    message.includes("replay") ||
+    (message.includes("already") &&
+      (message.includes("verified") ||
+        message.includes("processed") ||
+        message.includes("recorded")))
+  );
+}
+
+function isTransientVerifyStatus(status: number): boolean {
+  return [408, 429, 502, 503, 504].includes(status);
 }
 
 // -------------------- Fake Checker --------------------
@@ -162,30 +245,86 @@ export async function sendTip(
 export async function verifyTip(
   confessionId: string,
   txHash: string
-): Promise<{ success: boolean; error?: string }> {
-  try {
-    const res = await fetch(`/api/confessions/${confessionId}/verify-tip`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ txHash }),
-    });
-    if (!res.ok) {
+): Promise<VerifyTipResult> {
+  const maxAttempts = 2;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const res = await fetch(`/api/confessions/${confessionId}/tips/verify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ txId: txHash }),
+      });
       const data = await res.json().catch(() => ({}));
-      return { success: false, error: data?.message || "Verification failed" };
+
+      if (res.ok) {
+        const status = normalizeTipStatus(data);
+        return {
+          success: status === "confirmed",
+          status,
+          tip: data?.tip ?? data,
+          isIdempotent: Boolean(data?.isIdempotent),
+          error: status === "confirmed" ? undefined : "Backend verification is still pending.",
+        };
+      }
+
+      if (isReplaySuccess(res.status, data)) {
+        return {
+          success: true,
+          status: "confirmed",
+          isIdempotent: true,
+          tip: data?.tip,
+        };
+      }
+
+      if (res.status === 409 && (data?.canRetry || data?.conflictReason === "ALREADY_PROCESSING")) {
+        return {
+          success: false,
+          status: "pending",
+          error: extractTipError(data, "Transaction is still being processed. Retry verification in a moment."),
+          canRetry: true,
+        };
+      }
+
+      if (isTransientVerifyStatus(res.status) && attempt < maxAttempts) {
+        await sleep(100);
+        continue;
+      }
+
+      return {
+        success: false,
+        status: normalizeTipStatus(data),
+        error: extractTipError(data, "Verification failed"),
+        canRetry: data?.canRetry,
+      };
+    } catch (err: any) {
+      if (attempt < maxAttempts) {
+        await sleep(100);
+        continue;
+      }
+
+      return {
+        success: false,
+        status: "failed",
+        error: err.message,
+      };
     }
-    return { success: true };
-  } catch (err: any) {
-    return { success: false, error: err.message };
   }
+
+  return {
+    success: false,
+    status: "failed",
+    error: "Verification failed",
+  };
 }
 
 // -------------------- Get Tip Stats --------------------
 
 export async function getTipStats(confessionId: string): Promise<TipStats | null> {
   try {
-    const res = await fetch(`/api/confessions/${confessionId}/tip-stats`);
+    const res = await fetch(`/api/confessions/${confessionId}/tips/stats`);
     if (!res.ok) return null;
-    return (await res.json()) as TipStats;
+    return normalizeTipStats(await res.json());
   } catch {
     return null;
   }

--- a/xconfess-frontend/tests/tipping/tip-button.spec.tsx
+++ b/xconfess-frontend/tests/tipping/tip-button.spec.tsx
@@ -102,8 +102,8 @@ describe("TipButton", () => {
     const user = userEvent.setup();
     mockSendTip.mockResolvedValue({ success: true, txHash: "tx-retry-1" });
     mockVerifyTip
-      .mockResolvedValueOnce({ success: false, error: "temporary backend timeout" })
-      .mockResolvedValueOnce({ success: true, tip: undefined });
+      .mockResolvedValueOnce({ success: false, status: "pending", error: "temporary backend timeout" })
+      .mockResolvedValueOnce({ success: true, status: "confirmed", tip: undefined });
 
     renderTipButton();
 
@@ -114,6 +114,60 @@ describe("TipButton", () => {
       await screen.findByText(/backend verification is still pending/i),
     ).toBeInTheDocument();
     expect(mockVerifyTip).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: /retry verification/i }));
+
+    await waitFor(() => {
+      expect(mockVerifyTip).toHaveBeenCalledTimes(2);
+    });
+    expect(mockSendTip).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByText(/tip sent successfully/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows verifying state while backend confirmation is in-flight", async () => {
+    const user = userEvent.setup();
+    mockSendTip.mockResolvedValue({ success: true, txHash: "tx-verifying-1" });
+
+    let resolveVerify: (value: any) => void;
+    mockVerifyTip.mockReturnValue(
+      new Promise((resolve) => {
+        resolveVerify = resolve;
+      }),
+    );
+
+    renderTipButton();
+
+    await user.click(screen.getByRole("button", { name: /tip confession/i }));
+    await user.click(screen.getByRole("button", { name: /send 0.1 xlm tip/i }));
+
+    expect(await screen.findByText(/verifying transaction/i)).toBeInTheDocument();
+    expect(screen.getByText(/backend verification is still pending/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /checking/i })).toBeDisabled();
+    expect(screen.getByText(/view on explorer/i)).toBeInTheDocument();
+
+    resolveVerify!({ success: true, status: "confirmed", tip: undefined });
+
+    expect(
+      await screen.findByText(/tip sent successfully/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows failed verification recovery without resending the tip", async () => {
+    const user = userEvent.setup();
+    mockSendTip.mockResolvedValue({ success: true, txHash: "tx-failed-verify" });
+    mockVerifyTip
+      .mockResolvedValueOnce({ success: false, status: "failed", error: "Backend rejected this tip" })
+      .mockResolvedValueOnce({ success: true, status: "confirmed", tip: undefined });
+
+    renderTipButton();
+
+    await user.click(screen.getByRole("button", { name: /tip confession/i }));
+    await user.click(screen.getByRole("button", { name: /send 0.1 xlm tip/i }));
+
+    expect(await screen.findByText(/verification failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/backend rejected this tip/i)).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /retry verification/i }));
 
@@ -166,7 +220,7 @@ describe("TipButton", () => {
     
     // Setup initial failed verification to show the retry button
     mockSendTip.mockResolvedValue({ success: true, txHash: "tx-verif-retry" });
-    mockVerifyTip.mockResolvedValueOnce({ success: false, error: "pending" });
+    mockVerifyTip.mockResolvedValueOnce({ success: false, status: "pending", error: "pending" });
 
     renderTipButton();
 
@@ -194,7 +248,7 @@ describe("TipButton", () => {
     expect(mockVerifyTip).toHaveBeenCalledTimes(2);
 
     // Resolve
-    resolveVerify!({ success: true, tip: undefined });
+    resolveVerify!({ success: true, status: "confirmed", tip: undefined });
 
     await waitFor(() => {
       expect(screen.getByText(/tip sent successfully/i)).toBeInTheDocument();

--- a/xconfess-frontend/tests/tipping/tipping.service.spec.ts
+++ b/xconfess-frontend/tests/tipping/tipping.service.spec.ts
@@ -1,4 +1,4 @@
-import { verifyTip } from "@/lib/services/tipping.service";
+import { getTipStats, verifyTip } from "@/lib/services/tipping.service";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -27,7 +27,16 @@ describe("tipping.service verifyTip", () => {
     const result = await verifyTip("confession-1", "tx-dup-1");
 
     expect(result.success).toBe(true);
+    expect(result.status).toBe("confirmed");
+    expect(result.isIdempotent).toBe(true);
     expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/confessions/confession-1/tips/verify",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ txId: "tx-dup-1" }),
+      }),
+    );
   });
 
   it("retries transient backend errors and succeeds", async () => {
@@ -49,7 +58,45 @@ describe("tipping.service verifyTip", () => {
     const result = await verifyTip("confession-1", "tx-1");
 
     expect(result.success).toBe(true);
+    expect(result.status).toBe("confirmed");
     expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns pending state for backend processing conflicts", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      jsonResponse(
+        {
+          message: "Transaction is currently being processed",
+          conflictReason: "ALREADY_PROCESSING",
+          canRetry: true,
+        },
+        409,
+      ),
+    );
+
+    const result = await verifyTip("confession-1", "tx-pending-1");
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe("pending");
+    expect(result.canRetry).toBe(true);
+    expect(result.error).toMatch(/currently being processed/i);
+  });
+
+  it("normalizes rejected backend status as failed verification", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      jsonResponse({
+        tip: {
+          id: "tip-rejected",
+          verificationStatus: "rejected",
+        },
+        message: "Transaction was rejected",
+      }),
+    );
+
+    const result = await verifyTip("confession-1", "tx-rejected-1");
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe("failed");
   });
 
   it("returns actionable error when verification ultimately fails", async () => {
@@ -62,5 +109,35 @@ describe("tipping.service verifyTip", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/gateway timeout/i);
     expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("tipping.service getTipStats", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn() as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("loads canonical tip stats and accepts legacy tipCount", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      jsonResponse({ totalAmount: 1.5, tipCount: 3 }),
+    );
+
+    const result = await getTipStats("confession-1");
+
+    expect(result).toEqual({
+      totalAmount: 1.5,
+      totalCount: 3,
+      averageAmount: 0.5,
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/confessions/confession-1/tips/stats",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add explicit tipping lifecycle handling for submitting, backend verification, confirmed, and failed verification states
- keep submitted tx hash/amount stable across verification retries, with explorer links and no repeat `sendTip` calls
- normalize tipping service verification responses for confirmed, pending, failed, and duplicate/idempotent replay cases
- switch the frontend service to canonical `/tips/verify` and `/tips/stats` proxy routes backed by the existing backend tipping controller

Closes Xconfess/Xconfess#1133

## Validation
- `npm test -- tip-button.spec.tsx tipping.service.spec.ts TipButton.spec.tsx --runInBand`
- `npm run lint -- 'lib/services/tipping.service.ts' 'app/components/confession/TipButton.tsx' 'app/api/confessions/[id]/tips/verify/route.ts' 'app/api/confessions/[id]/tips/stats/route.ts' 'tests/tipping/tip-button.spec.tsx' 'tests/tipping/tipping.service.spec.ts'`
- `git diff --check`

## Notes
- `npm run build` is still blocked by existing main-branch issues in `app/(dashboard)/admin/diagnostics/page.tsx` and `app/components/comparison/ComparisonTool.tsx`.
- `npm test -- wallet-readiness-parity.spec.tsx --runInBand` is blocked by an existing missing Jest module mapping for `@/app/lib/hooks/useStellarWallet`.
