### PR TITLE
feat(scripts): add local demo seed command

### DIFF
--- a/docs/local-demo-data-seed-guide.md
+++ b/docs/local-demo-data-seed-guide.md
@@ -3,9 +3,9 @@
 ## Overview
 
 Use this guide to prepare local data for the Wave 5 walkthrough in
-[`docs/DEMO_SCRIPT.md`](./DEMO_SCRIPT.md). The repository does not currently
-include a one-shot demo seed script, so prepare the dataset with the local
-stack, the UI, and the existing backend API/database surfaces listed below.
+[`docs/DEMO_SCRIPT.md`](./DEMO_SCRIPT.md). The backend includes an idempotent
+demo seed command that creates local users, visible confessions, reactions,
+comments, and sample tip records for repeatable contributor walkthroughs.
 
 Keep all data local and disposable. Do not use production exports, real user
 content, live private keys, or private URLs in demo records.
@@ -50,40 +50,46 @@ content, live private keys, or private URLs in demo records.
    ./scripts/smoke-test.sh
    ```
 
-## Running Seed Scripts
+## Running the Demo Seed
 
-There is no dedicated demo-data seed command in `package.json` or
-`xconfess-backend/package.json` at the time of writing. Relevant existing
-helpers are:
+Run the seed after the database schema exists. For the default local setup,
+copy `xconfess-backend/.env.example` to `xconfess-backend/.env`; it includes the
+local `CONFESSION_AES_KEY` used by the app to decrypt demo confession content.
 
-- `compose.yaml` for local Postgres and Redis.
-- `xconfess-backend/.env.example` for local database and Redis settings.
-- `xconfess-backend/data-source.ts` plus `xconfess-backend/migrations/` for
-  TypeORM migration setup.
-- `scripts/smoke-test.sh` for confirming the local frontend and backend are up.
-- Backend Swagger at `http://localhost:5000/api/api-docs` after the backend
-  starts.
+```bash
+npm run seed:demo --workspace=xconfess-backend
+```
 
-For a clean local demo, reset the Docker volume if needed, then recreate the
-schema with `TYPEORM_SYNCHRONIZE=true` in `xconfess-backend/.env`.
+The command is safe to re-run. It upserts the demo users, refreshes the seeded
+confession and tip records, and skips reaction/comment rows that already exist.
+If the database is unreachable or required local encryption settings are
+missing, the command exits non-zero.
 
 ## Minimum Demo Dataset
 
 Prepare at least:
 
-| Area          | Minimum records                                               | How to create                                                                                |
-| ------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Users         | 1 regular user, 1 admin user                                  | UI/API, then promote admin locally in DB                                                     |
-| Confessions   | 3 visible confessions with distinct text and tags             | UI or `POST /api/confessions`                                                                |
-| Reactions     | 2 reactions on one confession and 1 reaction on another       | UI or `POST /api/reactions`                                                                  |
-| Comments      | 2 top-level comments and 1 reply                              | UI or `POST /api/comments/:confessionId`                                                     |
-| Reports       | 1 pending report tied to a visible confession                 | UI or report API                                                                             |
-| Notifications | 2 notifications for the regular user, one unread and one read | Direct DB insert                                                                             |
-| Tips          | 1 verified or pending local tip tied to a confession          | Direct DB insert, or `POST /api/confessions/:id/tips/verify` with a real testnet transaction |
+| Area        | Minimum records                                         | How to create                                    |
+| ----------- | ------------------------------------------------------- | ------------------------------------------------ |
+| Users       | 2 regular users, 1 admin user                           | `npm run seed:demo --workspace=xconfess-backend` |
+| Confessions | 3 visible confessions with distinct demo text           | `npm run seed:demo --workspace=xconfess-backend` |
+| Reactions   | 2 reactions on one confession and 1 reaction on another | `npm run seed:demo --workspace=xconfess-backend` |
+| Comments    | 2 top-level comments and 1 nested reply                 | `npm run seed:demo --workspace=xconfess-backend` |
+| Tips        | 1 verified sample tip and 1 pending sample tip          | `npm run seed:demo --workspace=xconfess-backend` |
+
+## Demo Credentials
+
+All seeded accounts use the local-only password `Wave5DemoPass!2026`.
+
+| Role         | Username       | Email                       |
+| ------------ | -------------- | --------------------------- |
+| Regular user | `wave5_user`   | `wave5-user@example.test`   |
+| Regular user | `wave5_friend` | `wave5-friend@example.test` |
+| Admin        | `wave5_admin`  | `wave5-admin@example.test`  |
 
 ## UI-Created Data
 
-Use the UI for the records that the Wave 5 demo is meant to exercise directly:
+Use the UI for extra records that are not covered by the seed command:
 
 1. Register or log in as a regular user at `http://localhost:3000`.
 2. Create at least three confessions from the composer.

--- a/xconfess-backend/.env.example
+++ b/xconfess-backend/.env.example
@@ -27,8 +27,9 @@ APP_SECRET=change-me-to-a-long-local-app-secret
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
-# Confession encryption key: 64-character hex string
+# Confession encryption keys
 CONFESSION_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
+CONFESSION_AES_KEY=12345678901234567890123456789012
 
 # Stellar
 # Set to true in environments that require on-chain anchoring/tipping (all contract IDs below become required).

--- a/xconfess-backend/package.json
+++ b/xconfess-backend/package.json
@@ -13,6 +13,7 @@
     "start:dev": "ts-node -r tsconfig-paths/register src/main.ts",
     "start:debug": "node --inspect -r ts-node/register -r tsconfig-paths/register src/main.ts",
     "start:prod": "node dist/main",
+    "seed:demo": "ts-node -r tsconfig-paths/register scripts/seed-demo.ts",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings=0",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest --config jest.config.js",

--- a/xconfess-backend/scripts/seed-demo.ts
+++ b/xconfess-backend/scripts/seed-demo.ts
@@ -1,0 +1,433 @@
+import 'reflect-metadata';
+
+import { createHash } from 'crypto';
+import * as bcrypt from 'bcryptjs';
+import { DataSource } from 'typeorm';
+import { CryptoUtil } from '../src/common/crypto.util';
+import { Gender } from '../src/confession/dto/get-confessions.dto';
+import { TipVerificationStatus } from '../src/tipping/entities/tip.entity';
+import { UserRole } from '../src/user/entities/user.entity';
+import { encryptConfession } from '../src/utils/confession-encryption';
+
+const DEMO_PASSWORD = 'Wave5DemoPass!2026';
+const BUCKETS = [
+  'users',
+  'anonymousUsers',
+  'confessions',
+  'reactions',
+  'comments',
+  'tips',
+] as const;
+
+type Bucket = (typeof BUCKETS)[number];
+type Action = 'created' | 'updated' | 'skipped';
+type SeedReport = Record<Bucket, Record<Action, number>>;
+type QueryRow = Record<string, unknown>;
+type Records = ReturnType<typeof buildDemoRecords>;
+
+export function stableDemoHex(seed: string): string {
+  return createHash('sha256').update(seed).digest('hex');
+}
+
+export function stableDemoUuid(seed: string): string {
+  const hex = stableDemoHex(seed);
+  const variant = ((parseInt(hex[16], 16) & 0x3) | 0x8).toString(16);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-${variant}${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}
+
+export function buildDemoRecords() {
+  // prettier-ignore
+  const userRows = [
+    ['regular', 'wave5_user', 'wave5-user@example.test', UserRole.USER],
+    ['friend', 'wave5_friend', 'wave5-friend@example.test', UserRole.USER],
+    ['admin', 'wave5_admin', 'wave5-admin@example.test', UserRole.ADMIN],
+  ] as const;
+  // prettier-ignore
+  const confessionRows = [
+    ['launch-checkin', 'regular', 'Wave 5 demo: shipping a calmer launch after a long week.', Gender.OTHER],
+    ['team-support', 'friend', 'Wave 5 demo: a teammate helped turn a rough day around.', Gender.FEMALE],
+    ['tip-readiness', 'regular', 'Wave 5 demo: validating anonymous tips before the walkthrough.', Gender.MALE],
+  ] as const;
+  const users = userRows.map(([key, username, email, role]) => ({
+    key,
+    username,
+    email,
+    role,
+    password: DEMO_PASSWORD,
+    anonymousUserId: stableDemoUuid(`anon:${key}`),
+  }));
+  const confessions = confessionRows.map(
+    ([key, ownerKey, message, gender]) => ({
+      key,
+      ownerKey,
+      message,
+      gender,
+      id: stableDemoUuid(`confession:${key}`),
+      idempotencyKey: `wave5-demo-confession-${key}`,
+    }),
+  );
+
+  return {
+    users,
+    confessions,
+    // prettier-ignore
+    reactions: [
+      ['friend', 'launch-checkin', 'like'],
+      ['admin', 'launch-checkin', 'heart'],
+      ['regular', 'team-support', 'support'],
+    ].map(([actorKey, confessionKey, emoji]) => ({
+      actorKey, confessionKey, emoji, id: stableDemoUuid(`reaction:${actorKey}:${confessionKey}:${emoji}`),
+    })),
+    // prettier-ignore
+    comments: [
+      ['launch-support', 'friend', 'launch-checkin', 'Rooting for this launch. The checklist looks solid.'],
+      ['team-thanks', 'regular', 'team-support', 'This is exactly the kind of support worth calling out.'],
+      ['launch-admin-reply', 'admin', 'launch-checkin', 'Admin demo reply for nested comment moderation checks.', 'launch-support'],
+    ].map(([key, actorKey, confessionKey, content, parentKey]) => ({
+      key, actorKey, confessionKey, content, parentKey,
+    })),
+    // prettier-ignore
+    tips: [
+      ['launch-checkin', 'tip-1', 1.25, TipVerificationStatus.VERIFIED],
+      ['tip-readiness', 'tip-2', 2.5, TipVerificationStatus.PENDING],
+    ].map(([confessionKey, key, amount, status]) => ({
+      confessionKey, key, amount, status, id: stableDemoUuid(`tip:${key}`),
+      txId: stableDemoHex(`xconfess-wave5-demo-${key}`), idempotencyKey: `xconfess-wave5-demo-${key}`,
+    })),
+  };
+}
+
+function createReport(): SeedReport {
+  return Object.fromEntries(
+    BUCKETS.map((bucket) => [bucket, { created: 0, updated: 0, skipped: 0 }]),
+  ) as SeedReport;
+}
+
+function mark(report: SeedReport, bucket: Bucket, action: Action): void {
+  report[bucket][action] += 1;
+}
+
+function confessionAesKey(): string {
+  const key = process.env.CONFESSION_AES_KEY;
+  if (!key || key.length !== 32) {
+    throw new Error(
+      'CONFESSION_AES_KEY must be set to the 32-character local confession AES key before seeding.',
+    );
+  }
+  return key;
+}
+
+async function one(
+  dataSource: DataSource,
+  sql: string,
+  params: unknown[] = [],
+): Promise<QueryRow | undefined> {
+  const rows = (await dataSource.query(sql, params)) as QueryRow[];
+  return rows[0];
+}
+
+async function upsertUsers(
+  dataSource: DataSource,
+  records: Records,
+  report: SeedReport,
+) {
+  const userIds = new Map<string, number>();
+
+  for (const user of records.users) {
+    const email = user.email.toLowerCase();
+    const emailHash = CryptoUtil.hash(email);
+    const usernameConflict = await one(
+      dataSource,
+      'select id from "user" where username = $1 and email_hash <> $2',
+      [user.username, emailHash],
+    );
+    if (usernameConflict)
+      throw new Error(
+        `Demo username ${user.username} is already used by another local account.`,
+      );
+
+    const encryptedEmail = CryptoUtil.encrypt(email);
+    const row = await one(
+      dataSource,
+      `insert into "user" (
+        username, password, email_encrypted, email_iv, email_tag, email_hash, role,
+        is_active, notification_preferences, privacy_settings, "createdAt", "updatedAt"
+      ) values ($1, $2, $3, $4, $5, $6, $7, true, '{}'::jsonb, $8::jsonb, now(), now())
+      on conflict (email_hash) do update set
+        username = excluded.username,
+        password = excluded.password,
+        email_encrypted = excluded.email_encrypted,
+        email_iv = excluded.email_iv,
+        email_tag = excluded.email_tag,
+        role = excluded.role,
+        is_active = true,
+        notification_preferences = excluded.notification_preferences,
+        privacy_settings = excluded.privacy_settings,
+        "updatedAt" = now()
+      returning id, (xmax = 0) as inserted`,
+      [
+        user.username,
+        await bcrypt.hash(user.password, 10),
+        encryptedEmail.encrypted,
+        encryptedEmail.iv,
+        encryptedEmail.tag,
+        emailHash,
+        user.role,
+        JSON.stringify({
+          isDiscoverable: true,
+          canReceiveReplies: true,
+          showReactions: true,
+          dataProcessingConsent: true,
+        }),
+      ],
+    );
+
+    userIds.set(user.key, Number(row?.id));
+    mark(report, 'users', row?.inserted ? 'created' : 'updated');
+  }
+
+  return userIds;
+}
+
+async function seedAnonymousUsers(
+  dataSource: DataSource,
+  records: Records,
+  userIds: Map<string, number>,
+  report: SeedReport,
+) {
+  const anonymousIds = new Map<string, string>();
+
+  for (const user of records.users) {
+    await dataSource.query(
+      'insert into anonymous_user (id, "createdAt") values ($1, now()) on conflict (id) do nothing',
+      [user.anonymousUserId],
+    );
+    const linkId = stableDemoUuid(`link:${user.key}`);
+    const rows = (await dataSource.query(
+      `insert into user_anonymous_users (id, user_id, anonymous_user_id, "createdAt")
+       values ($1, $2, $3, now()) on conflict (id) do nothing returning id`,
+      [linkId, userIds.get(user.key), user.anonymousUserId],
+    )) as QueryRow[];
+
+    anonymousIds.set(user.key, user.anonymousUserId);
+    mark(report, 'anonymousUsers', rows.length ? 'created' : 'skipped');
+  }
+
+  return anonymousIds;
+}
+
+async function seedConfessions(
+  dataSource: DataSource,
+  records: Records,
+  anonymousIds: Map<string, string>,
+  report: SeedReport,
+) {
+  const confessions = new Map<string, string>();
+  const key = confessionAesKey();
+
+  for (const confession of records.confessions) {
+    const row = await one(
+      dataSource,
+      `insert into anonymous_confessions (
+        id, message, gender, anonymous_user_id, view_count, "isDeleted", deleted_at,
+        deleted_by, moderation_score, moderation_flags, moderation_status,
+        requires_review, is_hidden, moderation_details, idempotency_key, created_at
+      ) values ($1, $2, $3, $4, 0, false, null, null, 0, '', 'approved', false, false, '{}'::json, $5, now())
+      on conflict (idempotency_key) do update set
+        message = excluded.message,
+        gender = excluded.gender,
+        anonymous_user_id = excluded.anonymous_user_id,
+        "isDeleted" = false,
+        deleted_at = null,
+        deleted_by = null,
+        moderation_score = 0,
+        moderation_flags = '',
+        moderation_status = 'approved',
+        requires_review = false,
+        is_hidden = false,
+        moderation_details = '{}'::json
+      returning id, (xmax = 0) as inserted`,
+      [
+        confession.id,
+        encryptConfession(confession.message, key),
+        confession.gender,
+        anonymousIds.get(confession.ownerKey),
+        confession.idempotencyKey,
+      ],
+    );
+
+    confessions.set(confession.key, String(row?.id));
+    mark(report, 'confessions', row?.inserted ? 'created' : 'updated');
+  }
+
+  return confessions;
+}
+
+async function seedReactions(
+  dataSource: DataSource,
+  records: Records,
+  anonymousIds: Map<string, string>,
+  confessionIds: Map<string, string>,
+  report: SeedReport,
+) {
+  for (const reaction of records.reactions) {
+    const rows = (await dataSource.query(
+      `insert into reaction (id, emoji, confession_id, anonymous_user_id, created_at)
+       values ($1, $2, $3, $4, now()) on conflict (id) do nothing returning id`,
+      [
+        reaction.id,
+        reaction.emoji,
+        confessionIds.get(reaction.confessionKey),
+        anonymousIds.get(reaction.actorKey),
+      ],
+    )) as QueryRow[];
+    mark(report, 'reactions', rows.length ? 'created' : 'skipped');
+  }
+}
+
+async function seedComments(
+  dataSource: DataSource,
+  records: Records,
+  anonymousIds: Map<string, string>,
+  confessionIds: Map<string, string>,
+  report: SeedReport,
+) {
+  const commentIds = new Map<string, number>();
+
+  for (const comment of records.comments) {
+    const parentId = comment.parentKey
+      ? commentIds.get(comment.parentKey)
+      : null;
+    const existing = await one(
+      dataSource,
+      `select id from comments where content = $1 and "confessionId" = $2 and anonymous_user_id = $3
+       and (($4::int is null and parent_id is null) or parent_id = $4::int)`,
+      [
+        comment.content,
+        confessionIds.get(comment.confessionKey),
+        anonymousIds.get(comment.actorKey),
+        parentId,
+      ],
+    );
+
+    if (existing) {
+      commentIds.set(comment.key, Number(existing.id));
+      mark(report, 'comments', 'skipped');
+      continue;
+    }
+
+    const row = await one(
+      dataSource,
+      `insert into comments (content, "createdAt", anonymous_user_id, "confessionId", "anonymousContextId", parent_id, "isDeleted")
+       values ($1, now(), $2, $3, $4, $5, false) returning id`,
+      [
+        comment.content,
+        anonymousIds.get(comment.actorKey),
+        confessionIds.get(comment.confessionKey),
+        anonymousIds.get(comment.actorKey),
+        parentId,
+      ],
+    );
+    commentIds.set(comment.key, Number(row?.id));
+    mark(report, 'comments', 'created');
+  }
+}
+
+async function seedTips(
+  dataSource: DataSource,
+  records: Records,
+  confessionIds: Map<string, string>,
+  report: SeedReport,
+) {
+  for (const tip of records.tips) {
+    const verifiedAt =
+      tip.status === TipVerificationStatus.VERIFIED ? 'now()' : 'null';
+    const row = await one(
+      dataSource,
+      `insert into tips (
+        id, confession_id, amount, tx_id, idempotency_key, sender_address,
+        verification_status, verified_at, rejection_reason, retry_count,
+        last_chain_status, last_checked_at, reconciliation_metadata, created_at
+      ) values ($1, $2, $3, $4, $5, null, $6, ${verifiedAt}, null, 0, $6, ${verifiedAt}, '{"source":"local-demo-seed"}'::jsonb, now())
+      on conflict (tx_id) do update set
+        confession_id = excluded.confession_id,
+        amount = excluded.amount,
+        idempotency_key = excluded.idempotency_key,
+        verification_status = excluded.verification_status,
+        verified_at = excluded.verified_at,
+        rejection_reason = null,
+        retry_count = 0,
+        last_chain_status = excluded.last_chain_status,
+        last_checked_at = excluded.last_checked_at,
+        reconciliation_metadata = excluded.reconciliation_metadata
+      returning (xmax = 0) as inserted`,
+      [
+        tip.id,
+        confessionIds.get(String(tip.confessionKey)),
+        tip.amount,
+        tip.txId,
+        tip.idempotencyKey,
+        tip.status,
+      ],
+    );
+    mark(report, 'tips', row?.inserted ? 'created' : 'updated');
+  }
+}
+
+export async function seedDemoRecords(
+  dataSource: DataSource,
+  records = buildDemoRecords(),
+): Promise<SeedReport> {
+  const report = createReport();
+  const userIds = await upsertUsers(dataSource, records, report);
+  const anonymousIds = await seedAnonymousUsers(
+    dataSource,
+    records,
+    userIds,
+    report,
+  );
+  const confessionIds = await seedConfessions(
+    dataSource,
+    records,
+    anonymousIds,
+    report,
+  );
+
+  await seedReactions(dataSource, records, anonymousIds, confessionIds, report);
+  await seedComments(dataSource, records, anonymousIds, confessionIds, report);
+  await seedTips(dataSource, records, confessionIds, report);
+
+  return report;
+}
+
+function printReport(report: SeedReport): void {
+  console.log('Seeded Wave 5 local demo data.');
+  for (const bucket of BUCKETS) {
+    const value = report[bucket];
+    console.log(
+      `- ${bucket}: created ${value.created}, updated ${value.updated}, skipped ${value.skipped}`,
+    );
+  }
+  console.log(
+    `\nDemo credentials:\n- wave5_user / ${DEMO_PASSWORD}\n- wave5_friend / ${DEMO_PASSWORD}\n- wave5_admin / ${DEMO_PASSWORD}`,
+  );
+}
+
+async function main(): Promise<void> {
+  const module = await import('../data-source');
+  const dataSource = module.default;
+  try {
+    await dataSource.initialize();
+    printReport(await seedDemoRecords(dataSource));
+  } finally {
+    if (dataSource.isInitialized) await dataSource.destroy();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to seed Wave 5 demo data: ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/xconfess-backend/src/config/app.config.ts
+++ b/xconfess-backend/src/config/app.config.ts
@@ -12,6 +12,7 @@ export default registerAs('app', () => ({
   backendUrl: process.env.BACKEND_URL ?? '',
   appSecret: process.env.APP_SECRET ?? '',
   confessionEncryptionKey: process.env.CONFESSION_ENCRYPTION_KEY ?? '',
+  confessionAesKey: process.env.CONFESSION_AES_KEY ?? '',
 
   /**
    * Search observability settings.

--- a/xconfess-backend/src/scripts/seed-demo.spec.ts
+++ b/xconfess-backend/src/scripts/seed-demo.spec.ts
@@ -1,0 +1,35 @@
+import {
+  buildDemoRecords,
+  stableDemoHex,
+  stableDemoUuid,
+} from '../../scripts/seed-demo';
+
+describe('Wave 5 demo seed records', () => {
+  it('builds deterministic demo records for the local walkthrough', () => {
+    const records = buildDemoRecords();
+
+    expect(records.users).toHaveLength(3);
+    expect(records.confessions).toHaveLength(3);
+    expect(records.reactions).toHaveLength(3);
+    expect(records.comments).toHaveLength(3);
+    expect(records.tips).toHaveLength(2);
+    expect(records.users.map((user) => user.username)).toEqual([
+      'wave5_user',
+      'wave5_friend',
+      'wave5_admin',
+    ]);
+    expect(new Set(records.users.map((user) => user.email)).size).toBe(3);
+    expect(records.tips.every((tip) => /^[a-f0-9]{64}$/.test(tip.txId))).toBe(
+      true,
+    );
+  });
+
+  it('uses stable identifiers for idempotent re-runs', () => {
+    expect(stableDemoHex('xconfess-wave5-demo-tip-1')).toBe(
+      stableDemoHex('xconfess-wave5-demo-tip-1'),
+    );
+    expect(stableDemoUuid('anon:regular')).toMatch(
+      /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/,
+    );
+  });
+});


### PR DESCRIPTION
﻿## Closes

Closes #1117

---

## What changed

Adds a backend `seed:demo` command that creates repeatable Wave 5 local demo users, visible confessions, reactions, comments, and sample tip records. The seed data uses deterministic IDs and idempotency keys so re-runs refresh or skip existing records instead of creating duplicates.

The PR also documents the command in the local demo seed guide, adds a local `CONFESSION_AES_KEY` sample used by the existing confession read path, and covers the deterministic seed definitions with a focused Jest spec.

## Why

The Wave 5 demo flow currently requires manual UI/API/database setup, which makes contributor onboarding and maintainer walkthroughs slower and less reproducible.

## How to test

1. Copy `xconfess-backend/.env.example` to `xconfess-backend/.env`.
2. Start local Postgres/Redis with `docker compose -f compose.yaml up -d`.
3. Create the local schema through the existing migration/synchronize flow.
4. Run `npm run seed:demo --workspace=xconfess-backend`.
5. Start the app and confirm the feed has the seeded demo confessions, reactions, comments, and tip state.
6. Run the seed command again and confirm it exits successfully without duplicate-key errors.

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [ ] Changed lines <= 400 and files touched <= 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

The PR stays within 8 files, but the line count is above the guideline because the issue requires the seed command, its local documentation, and regression coverage together. Splitting the script from its usage docs or test would leave the issue only partially reviewable.

---

## Evidence

### Tests

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable - manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output:

```text
npx.cmd eslint src\config\app.config.ts src\scripts\seed-demo.spec.ts scripts\seed-demo.ts --max-warnings=0
# passed

npx.cmd jest --config jest.config.js --testMatch "**/src/scripts/seed-demo.spec.ts" --runInBand
# Test Suites: 1 passed, 1 total
# Tests: 2 passed, 2 total

npx.cmd tsc --ignoreConfig --noEmit --pretty false --skipLibCheck --target ES2022 --module commonjs --moduleResolution node --ignoreDeprecations 6.0 --experimentalDecorators --emitDecoratorMetadata --esModuleInterop --allowSyntheticDefaultImports --strictNullChecks --strictPropertyInitialization false --types node,jest scripts\seed-demo.ts src\scripts\seed-demo.spec.ts
# passed

git diff --check
# passed

DB_HOST=127.0.0.1 DB_PORT=1 DB_USERNAME=postgres DB_PASSWORD=postgres DB_NAME=xconfess CONFESSION_AES_KEY=12345678901234567890123456789012 npm run seed:demo --workspace=xconfess-backend
# exits 1 with ECONNREFUSED, verifying the DB failure path exits non-zero
```

Full backend build was also checked, but current `main` has unrelated TypeScript failures in admin, health, and tipping modules, so it does not complete in this checkout.

### Screenshots (UI changes only)

N/A - no UI changes.

---

## Checklist

- [x] Branch is up to date with `main`
- [ ] All CI checks pass
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)
