### PR TITLE
Audit expired data export download links

### DIFF
--- a/xconfess-backend/src/audit-log/audit-log.entity.ts
+++ b/xconfess-backend/src/audit-log/audit-log.entity.ts
@@ -59,6 +59,7 @@ export enum AuditActionType {
   EXPORT_GENERATION_COMPLETED = 'export_generation_completed',
   EXPORT_LINK_REFRESHED = 'export_link_refreshed',
   EXPORT_DOWNLOADED = 'export_downloaded',
+  EXPORT_EXPIRED = 'export_expired',
 
   /** Privileged Stellar server-signed contract invocation */
   STELLAR_CONTRACT_INVOCATION = 'stellar_contract_invocation',

--- a/xconfess-backend/src/audit-log/audit-log.service.spec.ts
+++ b/xconfess-backend/src/audit-log/audit-log.service.spec.ts
@@ -316,6 +316,7 @@ describe('AuditLogService', () => {
           AuditActionType.EXPORT_GENERATION_COMPLETED,
           AuditActionType.EXPORT_LINK_REFRESHED,
           AuditActionType.EXPORT_DOWNLOADED,
+          AuditActionType.EXPORT_EXPIRED,
         ]),
       }),
     );

--- a/xconfess-backend/src/audit-log/audit-log.service.ts
+++ b/xconfess-backend/src/audit-log/audit-log.service.ts
@@ -55,7 +55,8 @@ export type ExportLifecycleAction =
   | 'request_created'
   | 'generation_completed'
   | 'link_refreshed'
-  | 'downloaded';
+  | 'downloaded'
+  | 'expired';
 
 export type ExportActorType = AuditActorType;
 
@@ -442,6 +443,8 @@ export class AuditLogService {
         return AuditActionType.EXPORT_LINK_REFRESHED;
       case 'downloaded':
         return AuditActionType.EXPORT_DOWNLOADED;
+      case 'expired':
+        return AuditActionType.EXPORT_EXPIRED;
       default:
         return AuditActionType.EXPORT_REQUEST_CREATED;
     }
@@ -1042,6 +1045,7 @@ export class AuditLogService {
         AuditActionType.EXPORT_GENERATION_COMPLETED,
         AuditActionType.EXPORT_LINK_REFRESHED,
         AuditActionType.EXPORT_DOWNLOADED,
+        AuditActionType.EXPORT_EXPIRED,
       ];
 
       const query = this.auditLogRepository

--- a/xconfess-backend/src/data-export/data-export-cleanup.spec.ts
+++ b/xconfess-backend/src/data-export/data-export-cleanup.spec.ts
@@ -10,7 +10,7 @@ import { AuditLogService } from '../audit-log/audit-log.service';
 describe('DataCleanupService', () => {
   let service: DataCleanupService;
   let mockExportRepository: jest.Mocked<Repository<ExportRequest>>;
-  let mockAuditLogService: { log: jest.Mock };
+  let mockAuditLogService: { logExportLifecycleEvent: jest.Mock };
   let loggerLogSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
 
@@ -21,7 +21,9 @@ describe('DataCleanupService', () => {
       findOne: jest.fn(),
       delete: jest.fn(),
     } as any;
-    mockAuditLogService = { log: jest.fn().mockResolvedValue(undefined) };
+    mockAuditLogService = {
+      logExportLifecycleEvent: jest.fn().mockResolvedValue(undefined),
+    };
     mockExportRepository.find.mockResolvedValue([
       {
         id: 'export-1',
@@ -312,6 +314,20 @@ describe('DataCleanupService', () => {
 
       expect(mockExportRepository.update).toHaveBeenCalled();
       expect(mockExportRepository.delete).not.toHaveBeenCalled();
+      expect(mockAuditLogService.logExportLifecycleEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'expired',
+          actorType: 'system',
+          actorId: 'retention-cleanup-scheduler',
+          requestId: 'export-1',
+          exportId: 'export-1',
+          metadata: expect.objectContaining({
+            previousStatus: 'READY',
+            newStatus: 'EXPIRED',
+            reason: 'retention_window_elapsed',
+          }),
+        }),
+      );
     });
 
     it('should mark expired exports clearly for users', async () => {

--- a/xconfess-backend/src/data-export/data-export-cleanup.ts
+++ b/xconfess-backend/src/data-export/data-export-cleanup.ts
@@ -109,20 +109,19 @@ export class DataCleanupService {
   ): Promise<void> {
     for (const exportRecord of exports) {
       try {
-        await this.auditLogService.log({
-          actionType: 'EXPORT_RETENTION_CLEANUP' as any,
+        await this.auditLogService.logExportLifecycleEvent({
+          action: 'expired',
+          actorType: 'system',
+          actorId: 'retention-cleanup-scheduler',
+          requestId: exportRecord.id,
+          exportId: exportRecord.id,
           metadata: {
-            entityType: 'data_export',
-            entityId: exportRecord.id,
-            exportId: exportRecord.id,
-            requestId: exportRecord.id,
             previousStatus: exportRecord.status,
             newStatus: 'EXPIRED',
             retentionPolicyDays: this.retentionDays,
             retentionCutoffDate: cutoff.toISOString(),
             cleanedUpAt: new Date().toISOString(),
-            actorType: 'system',
-            actorId: 'retention-cleanup-scheduler',
+            reason: 'retention_window_elapsed',
           },
         });
       } catch (auditError) {

--- a/xconfess-backend/src/data-export/data-export.controller.spec.ts
+++ b/xconfess-backend/src/data-export/data-export.controller.spec.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import {
   BadRequestException,
   ConflictException,
+  GoneException,
   UnauthorizedException,
   NotFoundException,
 } from '@nestjs/common';
@@ -115,7 +116,7 @@ describe('DataExportController', () => {
           token,
           {} as any,
         ),
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(GoneException);
     });
 
     it('should reject download requests with invalid signatures', async () => {

--- a/xconfess-backend/src/data-export/data-export.controller.ts
+++ b/xconfess-backend/src/data-export/data-export.controller.ts
@@ -6,6 +6,7 @@ import {
   Res,
   UnauthorizedException,
   BadRequestException,
+  GoneException,
   NotFoundException,
   Post,
   Req,
@@ -75,7 +76,10 @@ export class DataExportController {
     // 1. Check Expiration
     const expiresMs = parseInt(expires);
     if (isNaN(expiresMs) || Date.now() > expiresMs) {
-      throw new UnauthorizedException('Download link has expired.');
+      throw new GoneException({
+        error: 'Download link has expired.',
+        code: 'EXPORT_DOWNLOAD_EXPIRED',
+      });
     }
 
     // 2. Verify Signature

--- a/xconfess-backend/src/data-export/data-export.service.spec.ts
+++ b/xconfess-backend/src/data-export/data-export.service.spec.ts
@@ -834,6 +834,19 @@ describe('DataExportService', () => {
         requestId,
         expect.objectContaining({ downloadToken: null }),
       );
+      expect(mockAuditLogService.logExportLifecycleEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'expired',
+          actorType: 'system',
+          actorId: 'download-token-validator',
+          requestId,
+          exportId: requestId,
+          metadata: expect.objectContaining({
+            userId,
+            reason: 'download_window_elapsed',
+          }),
+        }),
+      );
     });
 
     it('returns false when token does not match', async () => {

--- a/xconfess-backend/src/data-export/data-export.service.ts
+++ b/xconfess-backend/src/data-export/data-export.service.ts
@@ -252,10 +252,23 @@ export class DataExportService {
 
     // Retention-window guard: export has exceeded its TTL.
     if (!this.isFileAvailable(record as Pick<ExportRequest, 'status' | 'createdAt'>)) {
+      const expiredAt = new Date();
       // Mark the token as expired so cleanup jobs can tell it apart from unused tokens.
       await this.exportRepository.update(requestId, {
         downloadToken: null,
-        expiredAt: new Date(),
+        expiredAt,
+      });
+      await this.auditLogService?.logExportLifecycleEvent({
+        action: 'expired',
+        actorType: 'system',
+        actorId: 'download-token-validator',
+        requestId,
+        exportId: requestId,
+        metadata: {
+          userId,
+          expiredAt: expiredAt.toISOString(),
+          reason: 'download_window_elapsed',
+        },
       });
       return false;
     }

--- a/xconfess-backend/src/migrations/20260617000001-add-export-expired-audit-action.ts
+++ b/xconfess-backend/src/migrations/20260617000001-add-export-expired-audit-action.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddExportExpiredAuditAction20260617000001
+  implements MigrationInterface
+{
+  name = 'AddExportExpiredAuditAction20260617000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        ALTER TYPE "public"."audit_logs_action_enum"
+          ADD VALUE IF NOT EXISTS 'export_expired';
+      END $$;
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // PostgreSQL cannot safely remove enum values in a reversible migration.
+  }
+}


### PR DESCRIPTION
Closes #1123.

## Summary
- return a stable `410 Gone` response with `EXPORT_DOWNLOAD_EXPIRED` for expired signed export download URLs
- add an `export_expired` audit lifecycle action and Postgres enum migration
- log expiry through the shared export lifecycle audit path when token validation discovers an expired download window and when retention cleanup expires exports
- include expired lifecycle events in export access trail queries
- update data-export and audit-log tests for the new expiry behavior

## Validation
- `git diff --check`

Attempted targeted backend tests:
- `npm test -- data-export.controller.spec.ts --runInBand`
- `npm test -- data-export.service.spec.ts --runInBand`
- `npm test -- audit-log.service.spec.ts --runInBand`

Those could not run in this fresh checkout because dependencies were not installed (`jest: command not found`). I then attempted `npm ci` from both `xconfess-backend/` and the workspace root, but both fail before install with `npm error Invalid Version:`.

Payment details can be provided privately if this is accepted.
