### PR TITLE
Show data export status in privacy settings

### DIFF
--- a/xconfess-frontend/app/(dashboard)/settings/data-export/DataExportRequest.tsx
+++ b/xconfess-frontend/app/(dashboard)/settings/data-export/DataExportRequest.tsx
@@ -18,7 +18,7 @@ const FOCUS_RECOVERY_DELAY = 1000;
 const CONFLICT_STATUS = 409;
 
 export default function DataExportRequest() {
-  const { addToast } = useGlobalToast();
+  const toast = useGlobalToast();
   const [history, setHistory] = useState<DataExportHistoryItem[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(true);
   const [requestingExport, setRequestingExport] = useState(false);
@@ -50,12 +50,17 @@ export default function DataExportRequest() {
         ? 'Your data export failed. Please try again.'
         : `Export status changed to ${newStatus.toLowerCase()}`;
       
-      // Use toast notification here - would need to integrate with toast system
-      addToast(message, newStatus === 'READY' ? 'success' : newStatus === 'FAILED' ? 'error' : 'info');
+      if (newStatus === 'READY') {
+        toast.success(message);
+      } else if (newStatus === 'FAILED') {
+        toast.error(message);
+      } else {
+        toast.info(message);
+      }
       
       setLastNotifiedStatus((prev: Record<string, DataExportStatus>) => ({ ...prev, [jobId]: newStatus }));
     }
-  }, [addToast]);
+  }, [toast]);
 
   const loadHistory = useCallback(async (isRefresh = false) => {
     if (isRefresh) {
@@ -66,6 +71,7 @@ export default function DataExportRequest() {
 
     try {
       const data = await dataExportApi.getHistory();
+      const previousStatuses = lastNotifiedStatus;
       setHistory(data.history);
       setError(null);
       
@@ -81,12 +87,19 @@ export default function DataExportRequest() {
       }
       
       // Check for status changes to show notifications
-      activeJobs.forEach((job: DataExportHistoryItem) => {
-        const prevStatus = lastNotifiedStatus[job.id];
+      data.history.forEach((job: DataExportHistoryItem) => {
+        const prevStatus = previousStatuses[job.id];
         if (prevStatus && prevStatus !== job.status) {
           handleStatusChange(job.id, job.status, prevStatus);
         }
       });
+
+      setLastNotifiedStatus(
+        data.history.reduce<Record<string, DataExportStatus>>((statuses, job) => {
+          statuses[job.id] = job.status;
+          return statuses;
+        }, {}),
+      );
       
     } catch {
       setError('Failed to load data export history. Please try again.');
@@ -104,11 +117,20 @@ export default function DataExportRequest() {
     const savedJobId = localStorage.getItem(STORAGE_KEY);
     
     const initialize = async () => {
-      await loadHistory();
+      const data = await dataExportApi.getHistory();
+      setHistory(data.history);
+      setLastNotifiedStatus(
+        data.history.reduce<Record<string, DataExportStatus>>((statuses, job) => {
+          statuses[job.id] = job.status;
+          return statuses;
+        }, {}),
+      );
+      setError(null);
+      setLoadingHistory(false);
       
       // If we had a saved job ID, check if it's still active
       if (savedJobId) {
-        const hasActiveJob = history.some((item: DataExportHistoryItem) => 
+        const hasActiveJob = data.history.some((item: DataExportHistoryItem) =>
           item.id === savedJobId && (item.status === 'PENDING' || item.status === 'PROCESSING')
         );
         
@@ -118,8 +140,11 @@ export default function DataExportRequest() {
       }
     };
     
-    initialize();
-  }, [loadHistory, history]);
+    initialize().catch(() => {
+      setError('Failed to load data export history. Please try again.');
+      setLoadingHistory(false);
+    });
+  }, []);
 
   const hasInProgressJob = useMemo(
     () => history.some((item: DataExportHistoryItem) => item.status === 'PENDING' || item.status === 'PROCESSING'),
@@ -206,7 +231,7 @@ export default function DataExportRequest() {
       if (response.requestId) {
         localStorage.setItem(STORAGE_KEY, response.requestId);
       }
-      addToast('Export request submitted successfully!', 'success');
+      toast.success('Export request submitted successfully!');
       await loadHistory(true);
     } catch (err: unknown) {
       const status = (err as { status?: number; response?: { status?: number } })?.status
@@ -214,7 +239,7 @@ export default function DataExportRequest() {
 
       if (status === CONFLICT_STATUS) {
         // Server already has an active job for this user — sync UI state.
-        addToast('An export is already in progress. Check the status below.', 'info');
+        toast.info('An export is already in progress. Check the status below.');
         await loadHistory(true);
       } else {
         setError('Unable to request a new archive right now. Please try again shortly.');
@@ -291,7 +316,9 @@ export default function DataExportRequest() {
       return 'Secure link expired. Request a new export link.';
     }
     if (item.status === 'FAILED') {
-      return 'Generation failed. Request a new export to retry.';
+      return item.progress?.lastFailureReason
+        ? `Generation failed: ${item.progress.lastFailureReason}`
+        : 'Generation failed. Request a new export to retry.';
     }
     return 'Archive retained for 24 hours once complete.';
   };
@@ -433,7 +460,11 @@ export default function DataExportRequest() {
       {latest?.status === 'FAILED' && (
         <div className="mt-4 flex items-center gap-2 text-red-600 text-sm">
           <AlertCircle size={16} />
-          <span>Something went wrong. Please try again in a few minutes.</span>
+          <span>
+            {latest.progress?.lastFailureReason
+              ? `Latest export failed: ${latest.progress.lastFailureReason}`
+              : 'Something went wrong. Please try again in a few minutes.'}
+          </span>
         </div>
       )}
     </div>

--- a/xconfess-frontend/app/(dashboard)/settings/privacy/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/settings/privacy/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { Shield, Eye, MessageSquare, Database, Save } from 'lucide-react';
 import { useGlobalToast } from '@/app/components/common/Toast';
+import DataExportRequest from '../data-export/DataExportRequest';
 
 interface PrivacySettings {
   isDiscoverable: boolean;
@@ -212,6 +213,10 @@ export default function PrivacySettingsPage() {
             />
           </label>
         </div>
+      </div>
+
+      <div className="mb-6">
+        <DataExportRequest />
       </div>
 
       <button

--- a/xconfess-frontend/app/lib/api/client.ts
+++ b/xconfess-frontend/app/lib/api/client.ts
@@ -132,6 +132,9 @@ export interface DataExportHistoryItem {
 	canRedownload: boolean;
 	canRequestNewLink: boolean;
 	downloadUrl: string | null;
+	progress?: {
+		lastFailureReason: string | null;
+	};
 }
 
 export interface DataExportHistoryResponse {


### PR DESCRIPTION
Closes #1124.

## Summary
- mount the existing data export request/status component on `/settings/privacy`
- fix export history initialization so it reconciles the saved active job against freshly loaded history instead of stale component state
- notify users when any tracked export transitions to ready or failed, not only while it remains pending/processing
- surface backend `progress.lastFailureReason` copy for failed exports
- extend the frontend data export history type with optional progress metadata

## Validation
- `git diff --check`

Attempted frontend validation:
- `npm run lint -- 'app/(dashboard)/settings/privacy/page.tsx' 'app/(dashboard)/settings/data-export/DataExportRequest.tsx' app/lib/api/client.ts`
- `npm run build`

Those could not run in this fresh checkout because dependencies are not installed (`eslint: command not found`, `next: command not found`). I attempted `npm ci --workspace=xconfess-frontend`, but npm fails before install with `npm error Invalid Version:`.

Payment details can be provided privately if this is accepted.
