### PR TITLE
feat(frontend): recover stale reaction counts after reconnect

### DIFF
--- a/xconfess-frontend/app/components/confession/ReactionButtons.tsx
+++ b/xconfess-frontend/app/components/confession/ReactionButtons.tsx
@@ -20,7 +20,8 @@ export const ReactionButton = ({
 }: Props) => {
   const [isAnimating, setIsAnimating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { addReaction, isPending, optimisticState } = useReactions({
+  const { addReaction, isPending, optimisticState, liveCounts, connectionState } = useReactions({
+    confessionId,
     initialCounts: { like: 0, love: 0, [type]: count },
     initialUserReaction: isActive ? type : null,
   });
@@ -28,8 +29,9 @@ export const ReactionButton = ({
   // Use optimistic values when a mutation is in flight so that both the
   // count and the selected (active) state update immediately on click and
   // roll back cleanly if the server rejects the request.
-  const displayCount = optimisticState?.counts[type] ?? count;
+  const displayCount = optimisticState?.counts[type] ?? liveCounts[type] ?? count;
   const computedIsActive = optimisticState?.userReaction === type || isActive;
+  const statusLabel = `Reaction live status: ${connectionState}`;
 
   const react = async () => {
     setError(null);
@@ -74,6 +76,18 @@ export const ReactionButton = ({
         </span>
 
         <span className="text-sm font-medium">{displayCount}</span>
+
+        <span
+          role="status"
+          aria-label={statusLabel}
+          title={statusLabel}
+          className={cn(
+            "h-2 w-2 rounded-full",
+            connectionState === "connected" && "bg-emerald-400",
+            connectionState === "reconnecting" && "bg-amber-400 animate-pulse",
+            connectionState === "disconnected" && "bg-zinc-500"
+          )}
+        />
       </button>
 
       {error && (

--- a/xconfess-frontend/app/components/confession/__tests__/ReactionButton.test.tsx
+++ b/xconfess-frontend/app/components/confession/__tests__/ReactionButton.test.tsx
@@ -13,6 +13,31 @@ jest.mock("@/app/lib/api/reactions", () => ({
   addReaction: jest.fn(),
 }));
 
+let mockSocketHandlers: Record<string, (...args: unknown[]) => void> = {};
+
+const mockSocket = {
+  on: jest.fn(),
+  emit: jest.fn(),
+  disconnect: jest.fn(),
+  io: {
+    on: jest.fn(),
+  },
+};
+
+const mockIo = jest.fn(() => mockSocket);
+
+jest.mock("socket.io-client", () => ({
+  io: (...args: unknown[]) => mockIo(...args),
+}));
+
+jest.mock("@/app/lib/config", () => ({
+  getWsUrl: () => "ws://localhost:5000",
+}));
+
+function triggerSocketEvent(event: string, ...args: unknown[]) {
+  mockSocketHandlers[event]?.(...args);
+}
+
 // localStorage stub needed by the reactions API helper
 Object.defineProperty(window, "localStorage", {
   value: { getItem: jest.fn(() => "anon-user-1"), setItem: jest.fn(), removeItem: jest.fn() },
@@ -33,7 +58,17 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 }
 
 describe("ReactionButton — optimistic count and active state", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    mockSocketHandlers = {};
+    jest.clearAllMocks();
+
+    mockIo.mockReturnValue(mockSocket);
+    mockSocket.on.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+      mockSocketHandlers[event] = handler;
+      return mockSocket;
+    });
+    mockSocket.io.on.mockReturnValue(mockSocket.io);
+  });
 
   it("shows the initial count from the prop", () => {
     mockAddReaction.mockReturnValue(new Promise(() => {}));
@@ -217,5 +252,27 @@ describe("ReactionButton — optimistic count and active state", () => {
     await waitFor(() => {
       expect(screen.getByText("5")).toBeInTheDocument();
     });
+  });
+
+  it("reflects live websocket state in the reaction status indicator", async () => {
+    mockAddReaction.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <Wrapper>
+        <ReactionButton type="like" count={5} confessionId="c-live" />
+      </Wrapper>,
+    );
+
+    await act(async () => {
+      triggerSocketEvent("connect");
+    });
+
+    expect(screen.getByLabelText("Reaction live status: connected")).toBeInTheDocument();
+
+    await act(async () => {
+      triggerSocketEvent("disconnect");
+    });
+
+    expect(screen.getByLabelText("Reaction live status: reconnecting")).toBeInTheDocument();
   });
 });

--- a/xconfess-frontend/app/lib/hooks/__tests__/useReactions.test.tsx
+++ b/xconfess-frontend/app/lib/hooks/__tests__/useReactions.test.tsx
@@ -5,6 +5,7 @@ import {
   type InfiniteData,
 } from "@tanstack/react-query";
 import { useReactions } from "@/app/lib/hooks/useReactions";
+import { getConfessionById } from "@/app/lib/api/confessions";
 import type {
   GetConfessionByIdResult,
   GetConfessionsResult,
@@ -16,7 +17,44 @@ jest.mock("@/app/lib/api/reactions", () => ({
   addReaction: jest.fn(),
 }));
 
+let mockSocketHandlers: Record<string, (...args: unknown[]) => void> = {};
+let mockManagerHandlers: Record<string, (...args: unknown[]) => void> = {};
+
+const mockSocket = {
+  on: jest.fn(),
+  emit: jest.fn(),
+  disconnect: jest.fn(),
+  io: {
+    on: jest.fn(),
+  },
+};
+
+const mockIo = jest.fn(() => mockSocket);
+
+jest.mock("socket.io-client", () => ({
+  io: (...args: unknown[]) => mockIo(...args),
+}));
+
+jest.mock("@/app/lib/api/confessions", () => ({
+  getConfessionById: jest.fn(),
+}));
+
+jest.mock("@/app/lib/config", () => ({
+  getWsUrl: () => "ws://localhost:5000",
+}));
+
 const mockAddReaction = addReaction as jest.MockedFunction<typeof addReaction>;
+const mockGetConfessionById = getConfessionById as jest.MockedFunction<
+  typeof getConfessionById
+>;
+
+function triggerSocketEvent(event: string, ...args: unknown[]) {
+  mockSocketHandlers[event]?.(...args);
+}
+
+function triggerManagerEvent(event: string, ...args: unknown[]) {
+  mockManagerHandlers[event]?.(...args);
+}
 
 function buildConfession(reactions = { like: 2, love: 1 }) {
   return {
@@ -72,7 +110,23 @@ function seedConfessionCache(queryClient: QueryClient) {
 
 describe("useReactions", () => {
   beforeEach(() => {
+    mockSocketHandlers = {};
+    mockManagerHandlers = {};
     jest.clearAllMocks();
+
+    mockIo.mockReturnValue(mockSocket);
+    mockSocket.on.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+      mockSocketHandlers[event] = handler;
+      return mockSocket;
+    });
+    mockSocket.io.on.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+      mockManagerHandlers[event] = handler;
+      return mockSocket.io;
+    });
+    mockGetConfessionById.mockResolvedValue({
+      ok: true,
+      data: buildConfession(),
+    });
   });
 
   it("patches feed/detail caches immediately and avoids broad invalidation when server returns counts", async () => {
@@ -287,5 +341,148 @@ describe("useReactions", () => {
     // The hook skips optimistic update for already-reacted cases
     expect(optimisticList?.pages[0].confessions[0].reactions.like).toBe(2);
     expect(result.current.optimisticState).toBeNull();
+  });
+
+  it("subscribes to the reaction websocket and reports connection state", async () => {
+    const { wrapper } = createTestHarness();
+
+    const { result } = renderHook(
+      () => useReactions({
+        confessionId: "confession-1",
+        initialCounts: { like: 2, love: 1 },
+      }),
+      { wrapper },
+    );
+
+    expect(mockIo).toHaveBeenCalledWith(
+      "ws://localhost:5000/reactions",
+      expect.objectContaining({
+        reconnection: true,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 30000,
+      }),
+    );
+
+    await act(async () => {
+      triggerSocketEvent("connect");
+    });
+
+    expect(mockSocket.emit).toHaveBeenCalledWith("subscribe:confession", {
+      confessionId: "confession-1",
+    });
+    expect(result.current.connectionState).toBe("connected");
+
+    await act(async () => {
+      triggerSocketEvent("disconnect");
+    });
+
+    expect(result.current.connectionState).toBe("reconnecting");
+
+    await act(async () => {
+      triggerManagerEvent("reconnect_failed");
+    });
+
+    expect(result.current.connectionState).toBe("disconnected");
+  });
+
+  it("refetches visible reaction counts after reconnect and patches cached confessions", async () => {
+    const { queryClient, wrapper } = createTestHarness();
+    const { listKey, detailKey } = seedConfessionCache(queryClient);
+    mockGetConfessionById.mockResolvedValue({
+      ok: true,
+      data: buildConfession({ like: 8, love: 4 }),
+    });
+
+    const { result } = renderHook(
+      () => useReactions({
+        confessionId: "confession-1",
+        initialCounts: { like: 2, love: 1 },
+      }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      triggerSocketEvent("connect");
+    });
+
+    expect(mockGetConfessionById).not.toHaveBeenCalled();
+
+    await act(async () => {
+      triggerSocketEvent("disconnect");
+      triggerSocketEvent("connect");
+    });
+
+    await waitFor(() => {
+      expect(mockGetConfessionById).toHaveBeenCalledWith("confession-1");
+    });
+
+    const recoveredList =
+      queryClient.getQueryData<InfiniteData<GetConfessionsResult>>(listKey);
+    const recoveredDetail =
+      queryClient.getQueryData<GetConfessionByIdResult>(detailKey);
+
+    expect(recoveredList?.pages[0].confessions[0].reactions).toEqual({
+      like: 8,
+      love: 4,
+    });
+    expect(recoveredDetail?.reactions).toEqual({ like: 8, love: 4 });
+    expect(result.current.liveCounts).toEqual({ like: 8, love: 4 });
+  });
+
+  it("applies duplicate reaction events only once to visible UI state", async () => {
+    const { queryClient, wrapper } = createTestHarness();
+    const { detailKey } = seedConfessionCache(queryClient);
+    const duplicatePayload = {
+      confessionId: "confession-1",
+      reactionId: "reaction-duplicate-1",
+      reactionType: "like",
+      timestamp: "2026-06-18T00:00:00.000Z",
+    };
+
+    const { result } = renderHook(
+      () => useReactions({
+        confessionId: "confession-1",
+        initialCounts: { like: 2, love: 1 },
+      }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      triggerSocketEvent("reaction:added", duplicatePayload);
+      triggerSocketEvent("reaction:added", duplicatePayload);
+    });
+
+    const recoveredDetail =
+      queryClient.getQueryData<GetConfessionByIdResult>(detailKey);
+
+    expect(recoveredDetail?.reactions).toEqual({ like: 3, love: 1 });
+    expect(result.current.liveCounts).toEqual({ like: 3, love: 1 });
+  });
+
+  it("applies authoritative confession updated counts from the socket", async () => {
+    const { queryClient, wrapper } = createTestHarness();
+    const { detailKey } = seedConfessionCache(queryClient);
+
+    const { result } = renderHook(
+      () => useReactions({
+        confessionId: "confession-1",
+        initialCounts: { like: 2, love: 1 },
+      }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      triggerSocketEvent("confession:updated", {
+        confessionId: "confession-1",
+        reactionCounts: { like: 12, love: 5 },
+        timestamp: "2026-06-18T00:00:01.000Z",
+      });
+    });
+
+    const recoveredDetail =
+      queryClient.getQueryData<GetConfessionByIdResult>(detailKey);
+
+    expect(recoveredDetail?.reactions).toEqual({ like: 12, love: 5 });
+    expect(result.current.liveCounts).toEqual({ like: 12, love: 5 });
   });
 });

--- a/xconfess-frontend/app/lib/hooks/useReactions.ts
+++ b/xconfess-frontend/app/lib/hooks/useReactions.ts
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { io } from "socket.io-client";
 import { addReaction, type AddReactionResponse } from "@/app/lib/api/reactions";
+import { getConfessionById } from "@/app/lib/api/confessions";
 import {
   restoreQuerySnapshots,
   snapshotConfessionQueries,
@@ -10,6 +12,30 @@ import {
 } from "@/app/lib/api/confessionCache";
 import type { ReactionType, ReactionCounts } from "@/app/lib/types/reaction";
 import { queryKeys } from "@/app/lib/api/queryKeys";
+import { getWsUrl } from "@/app/lib/config";
+
+export type ReactionConnectionState = "disconnected" | "reconnecting" | "connected";
+
+type ReactionApiError = Extract<AddReactionResponse, { ok: false }>["error"];
+type ReactionMutationError = Error & { apiError?: ReactionApiError };
+
+type ReactionGatewayEventName =
+  | "reaction:added"
+  | "reaction:removed"
+  | "confession:updated";
+
+interface ReactionGatewayPayload {
+  confessionId?: string;
+  reactionId?: string;
+  reactionType?: string;
+  emoji?: string;
+  timestamp?: string | Date;
+  totalCount?: number;
+  reactionCounts?: Record<string, number>;
+}
+
+const REACTION_EVENT_CACHE_LIMIT = 500;
+const processedReactionEvents = new Set<string>();
 
 export interface ReactionState {
   counts: ReactionCounts;
@@ -17,6 +43,14 @@ export interface ReactionState {
 }
 
 export interface UseReactionsOptions {
+  /**
+   * Visible confession to subscribe to for live reaction updates.
+   */
+  confessionId?: string;
+  /**
+   * Enables the live reaction socket. Defaults to true when a confessionId is provided.
+   */
+  enableRealtime?: boolean;
   /**
    * Initial reaction counts for the confession
    */
@@ -61,6 +95,14 @@ export interface UseReactionsReturn {
    */
   optimisticState: ReactionState | null;
   /**
+   * Latest server/live counts known to this hook.
+   */
+  liveCounts: ReactionCounts;
+  /**
+   * Current reaction websocket state for connection indicators.
+   */
+  connectionState: ReactionConnectionState;
+  /**
    * Clear optimistic state (rollback)
    */
   clearOptimisticState: () => void;
@@ -79,6 +121,87 @@ function normalizeCounts(counts?: Partial<ReactionCounts> | null): ReactionCount
     like: Math.max(0, counts?.like ?? 0),
     love: Math.max(0, counts?.love ?? 0),
   };
+}
+
+function normalizeReactionType(value?: string | null): ReactionType | null {
+  const normalized = String(value ?? "").toLowerCase();
+
+  if (normalized.includes("love") || normalized.includes("heart") || normalized.includes("❤️")) {
+    return "love";
+  }
+
+  if (normalized.includes("like") || normalized.includes("thumb") || normalized.includes("👍")) {
+    return "like";
+  }
+
+  return null;
+}
+
+function normalizeGatewayCounts(
+  counts?: Record<string, number> | Partial<ReactionCounts> | null,
+): ReactionCounts | null {
+  if (!counts) {
+    return null;
+  }
+
+  return normalizeCounts({
+    like:
+      counts.like ??
+      counts["likes"] ??
+      counts["👍"] ??
+      counts["thumbs_up"] ??
+      counts["thumbsup"],
+    love:
+      counts.love ??
+      counts["loves"] ??
+      counts["❤️"] ??
+      counts["heart"] ??
+      counts["hearts"],
+  });
+}
+
+function rememberEventKey(
+  cache: Set<string>,
+  key: string,
+  limit = REACTION_EVENT_CACHE_LIMIT,
+) {
+  if (cache.has(key)) {
+    return false;
+  }
+
+  cache.add(key);
+
+  if (cache.size > limit) {
+    const oldest = cache.values().next().value;
+    if (oldest) {
+      cache.delete(oldest);
+    }
+  }
+
+  return true;
+}
+
+function getGatewayEventKey(
+  eventName: ReactionGatewayEventName,
+  payload: ReactionGatewayPayload,
+) {
+  const countFingerprint = payload.reactionCounts
+    ? JSON.stringify(payload.reactionCounts)
+    : "";
+
+  return [
+    eventName,
+    payload.confessionId ?? "",
+    payload.reactionId ?? "",
+    payload.reactionType ?? payload.emoji ?? "",
+    payload.timestamp ? String(payload.timestamp) : "",
+    payload.totalCount ?? "",
+    countFingerprint,
+  ].join(":");
+}
+
+function getReactionsSocketUrl() {
+  return `${getWsUrl().replace(/\/$/, "")}/reactions`;
 }
 
 function incrementReactionCount(
@@ -102,12 +225,182 @@ function incrementReactionCount(
  * - Exposed state for testing and debugging
  */
 export function useReactions(options: UseReactionsOptions = {}): UseReactionsReturn {
-  const { initialCounts, initialUserReaction, onSuccess, onError } = options;
+  const {
+    confessionId,
+    enableRealtime = Boolean(options.confessionId),
+    initialCounts,
+    initialUserReaction,
+    onSuccess,
+    onError,
+  } = options;
   const queryClient = useQueryClient();
   
   // Local state for optimistic UI updates (complements React Query cache)
   const [optimisticState, setOptimisticState] = useState<ReactionState | null>(null);
   const [localError, setLocalError] = useState<Error | null>(null);
+  const [liveCounts, setLiveCounts] = useState<ReactionCounts>(() =>
+    normalizeCounts(initialCounts),
+  );
+  const [connectionState, setConnectionState] =
+    useState<ReactionConnectionState>("disconnected");
+  const hasConnectedRef = useRef(false);
+  const localEventKeysRef = useRef(new Set<string>());
+
+  const initialLike = initialCounts?.like ?? 0;
+  const initialLove = initialCounts?.love ?? 0;
+
+  useEffect(() => {
+    setLiveCounts(normalizeCounts({ like: initialLike, love: initialLove }));
+  }, [initialLike, initialLove]);
+
+  const patchReactionCounts = useCallback((
+    targetConfessionId: string,
+    counts: ReactionCounts,
+  ) => {
+    updateConfessionQueries(
+      queryClient,
+      targetConfessionId,
+      (confession) => ({
+        ...confession,
+        reactions: counts,
+      }),
+    );
+  }, [queryClient]);
+
+  const refreshReactionCounts = useCallback(async () => {
+    if (!confessionId) {
+      return;
+    }
+
+    const response = await getConfessionById(confessionId);
+
+    if (!response.ok) {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.confessions.all,
+      });
+      return;
+    }
+
+    const serverCounts = normalizeCounts(response.data.reactions);
+    setLiveCounts(serverCounts);
+    patchReactionCounts(confessionId, serverCounts);
+  }, [confessionId, patchReactionCounts, queryClient]);
+
+  const applyGatewayEvent = useCallback((
+    eventName: ReactionGatewayEventName,
+    payload: ReactionGatewayPayload,
+  ) => {
+    if (!confessionId || payload.confessionId !== confessionId) {
+      return;
+    }
+
+    const eventKey = getGatewayEventKey(eventName, payload);
+    if (!rememberEventKey(localEventKeysRef.current, eventKey)) {
+      return;
+    }
+
+    const gatewayCounts = normalizeGatewayCounts(payload.reactionCounts);
+    const reactionType = normalizeReactionType(payload.reactionType ?? payload.emoji);
+
+    const nextCounts: ReactionCounts | null = gatewayCounts;
+
+    if (!nextCounts && reactionType) {
+      setLiveCounts((previous) => {
+        const current = normalizeCounts(previous);
+        const nextValue = Number.isFinite(payload.totalCount)
+          ? Math.max(0, Number(payload.totalCount))
+          : Math.max(
+              0,
+              current[reactionType] + (eventName === "reaction:removed" ? -1 : 1),
+            );
+        const updated = {
+          ...current,
+          [reactionType]: nextValue,
+        };
+
+        if (rememberEventKey(processedReactionEvents, eventKey)) {
+          patchReactionCounts(confessionId, updated);
+        }
+
+        return updated;
+      });
+      return;
+    }
+
+    if (!nextCounts) {
+      return;
+    }
+
+    setLiveCounts(nextCounts);
+
+    if (rememberEventKey(processedReactionEvents, eventKey)) {
+      patchReactionCounts(confessionId, nextCounts);
+    }
+  }, [confessionId, patchReactionCounts]);
+
+  useEffect(() => {
+    if (!enableRealtime || !confessionId) {
+      return;
+    }
+
+    const socket = io(getReactionsSocketUrl(), {
+      transports: ["websocket", "polling"],
+      reconnection: true,
+      reconnectionAttempts: Infinity,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 30000,
+      randomizationFactor: 0.3,
+      withCredentials: true,
+    });
+
+    setConnectionState("reconnecting");
+
+    socket.on("connect", () => {
+      setConnectionState("connected");
+      socket.emit("subscribe:confession", { confessionId });
+
+      if (hasConnectedRef.current) {
+        void refreshReactionCounts();
+      }
+
+      hasConnectedRef.current = true;
+    });
+
+    socket.on("disconnect", () => {
+      setConnectionState("reconnecting");
+    });
+
+    socket.io.on("reconnect_attempt", () => {
+      setConnectionState("reconnecting");
+    });
+
+    socket.io.on("reconnect_failed", () => {
+      setConnectionState("disconnected");
+    });
+
+    socket.on("connect_error", () => {
+      setConnectionState("reconnecting");
+    });
+
+    socket.on("reaction:added", (payload: ReactionGatewayPayload) => {
+      applyGatewayEvent("reaction:added", payload);
+    });
+
+    socket.on("reaction:removed", (payload: ReactionGatewayPayload) => {
+      applyGatewayEvent("reaction:removed", payload);
+    });
+
+    socket.on("confession:updated", (payload: ReactionGatewayPayload) => {
+      applyGatewayEvent("confession:updated", payload);
+    });
+
+    return () => {
+      socket.emit("unsubscribe:confession", { confessionId });
+      socket.disconnect();
+      hasConnectedRef.current = false;
+      setConnectionState("disconnected");
+    };
+  }, [applyGatewayEvent, confessionId, enableRealtime, refreshReactionCounts]);
 
   const mutation = useMutation({
     mutationFn: async ({
@@ -120,7 +413,11 @@ export function useReactions(options: UseReactionsOptions = {}): UseReactionsRet
       const result = await addReaction(confessionId, type);
 
       if (!result.ok) {
-        throw new Error(result.error.message || "Failed to add reaction");
+        const error = new Error(
+          result.error.message || "Failed to add reaction",
+        ) as ReactionMutationError;
+        error.apiError = result.error;
+        throw error;
       }
 
       return result;
@@ -151,6 +448,7 @@ export function useReactions(options: UseReactionsOptions = {}): UseReactionsRet
         counts: newCounts,
         userReaction: variables.type,
       });
+      setLiveCounts(newCounts);
       setLocalError(null);
 
       // Return context with previous values for rollback
@@ -169,6 +467,7 @@ export function useReactions(options: UseReactionsOptions = {}): UseReactionsRet
 
       // Clear optimistic state
       setOptimisticState(null);
+      setLiveCounts(normalizeCounts(initialCounts));
 
       // Call error callback
       if (onError) {
@@ -194,6 +493,7 @@ export function useReactions(options: UseReactionsOptions = {}): UseReactionsRet
           counts: serverCounts,
           userReaction: variables.type,
         });
+        setLiveCounts(serverCounts);
       } else {
         queryClient.invalidateQueries({
           queryKey: queryKeys.confessions.all,
@@ -219,6 +519,12 @@ export function useReactions(options: UseReactionsOptions = {}): UseReactionsRet
     if (alreadyReacted) {
       // Still call the API to get the latest state, but don't optimistically update
       const result = await addReaction(confessionId, type);
+
+      if (result.ok && result.data.reactions) {
+        const serverCounts = normalizeCounts(result.data.reactions);
+        setLiveCounts(serverCounts);
+        patchReactionCounts(confessionId, serverCounts);
+      }
       
       // Backend returns success with existing reaction (no change)
       // We don't need to do anything special here - the UI already shows the correct state
@@ -238,21 +544,28 @@ export function useReactions(options: UseReactionsOptions = {}): UseReactionsRet
 
       return result;
     } catch (error) {
+      const apiError = (error as ReactionMutationError).apiError;
       // Error is already handled in onError callback
       return {
         ok: false,
-        error: { 
-          message: error instanceof Error ? error.message : "Failed to add reaction",
-          code: "MUTATION_ERROR"
+        error: {
+          ...apiError,
+          message:
+            apiError?.message ||
+            (error instanceof Error ? error.message : "Failed to add reaction"),
+          code: "MUTATION_ERROR",
         },
       };
     }
-  }, [mutation, onSuccess, initialUserReaction]);
+  }, [mutation, onSuccess, initialUserReaction, patchReactionCounts]);
 
   const handleRemoveReaction = useCallback(async (
-    _confessionId: string,
-    _type: ReactionType
+    confessionId: string,
+    type: ReactionType
   ): Promise<AddReactionResponse> => {
+    void confessionId;
+    void type;
+
     const error = {
       message: "Removing reactions is not supported by the current API.",
       code: "UNSUPPORTED_OPERATION",
@@ -296,6 +609,8 @@ export function useReactions(options: UseReactionsOptions = {}): UseReactionsRet
     isError: mutation.isError,
     error: localError || mutation.error,
     optimisticState,
+    liveCounts,
+    connectionState,
     clearOptimisticState,
     updateOptimisticCounts,
     setErrorState,


### PR DESCRIPTION
## Summary
- subscribe visible reaction buttons to the existing `/reactions` socket namespace with reconnect/backoff options capped at 30s
- resubscribe and refetch the visible confession's reaction counts after reconnect so stale counts recover from missed socket events
- apply live reaction events to React Query caches with event de-duping, plus a compact connected/reconnecting/disconnected status indicator
- preserve reaction API retry metadata while keeping mutation rollback behavior intact

Closes Xconfess/Xconfess#1121

## Validation
- `npm test -- useReactions.test.tsx ReactionButton.test.tsx --runInBand`
- `npm run lint -- app/lib/hooks/useReactions.ts app/components/confession/ReactionButtons.tsx app/lib/hooks/__tests__/useReactions.test.tsx app/components/confession/__tests__/ReactionButton.test.tsx`
- `git diff --check`

## Build note
- `npm run build` is still blocked by existing main-branch issues unrelated to this PR:
  - `app/(dashboard)/admin/diagnostics/page.tsx:278` JSX parse error
  - `app/components/comparison/ComparisonTool.tsx` imports non-existent `ArrowClockwise` from `lucide-react`
