### PR TITLE
feat(frontend): autosave drafts through API

### DIFF
--- a/xconfess-frontend/app/api/confessions/drafts/[id]/route.ts
+++ b/xconfess-frontend/app/api/confessions/drafts/[id]/route.ts
@@ -1,0 +1,43 @@
+import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { proxyDraftRequest, readDraftPayload } from "../proxy";
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  if (!id) {
+    return createApiErrorResponse("Draft ID is required", { status: 400 });
+  }
+
+  const payload = await readDraftPayload(request);
+  if (!payload.ok) {
+    return payload.response;
+  }
+
+  if (typeof payload.body.version !== "number") {
+    return createApiErrorResponse("Draft version is required", { status: 400 });
+  }
+
+  return proxyDraftRequest(request, `/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      content: payload.body.content,
+      version: payload.body.version,
+    }),
+  });
+}
+
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  if (!id) {
+    return createApiErrorResponse("Draft ID is required", { status: 400 });
+  }
+
+  return proxyDraftRequest(request, `/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+}

--- a/xconfess-frontend/app/api/confessions/drafts/proxy.ts
+++ b/xconfess-frontend/app/api/confessions/drafts/proxy.ts
@@ -1,0 +1,105 @@
+import { getApiBaseUrl } from "@/app/lib/config";
+import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+
+const BASE_API_URL = getApiBaseUrl();
+
+function buildForwardHeaders(request: Request) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  const authorization = request.headers.get("authorization");
+  const cookie = request.headers.get("cookie");
+  const correlationId =
+    request.headers.get("x-correlation-id") ?? crypto.randomUUID();
+
+  headers["X-Correlation-ID"] = correlationId;
+  if (authorization) headers.Authorization = authorization;
+  if (cookie) headers.Cookie = cookie;
+
+  return headers;
+}
+
+async function readJsonBody(request: Request) {
+  return request.json().catch(() => ({}));
+}
+
+function safeJsonParse(text: string) {
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { message: text };
+  }
+}
+
+export async function proxyDraftRequest(
+  request: Request,
+  path = "",
+  init: RequestInit = {},
+) {
+  const correlationId =
+    request.headers.get("x-correlation-id") ?? crypto.randomUUID();
+
+  try {
+    const response = await fetch(`${BASE_API_URL}/confessions/drafts${path}`, {
+      ...init,
+      headers: {
+        ...buildForwardHeaders(request),
+        ...(init.headers as Record<string, string> | undefined),
+      },
+      cache: "no-store",
+    });
+
+    const text = await response.text();
+    const data = safeJsonParse(text);
+
+    if (!response.ok) {
+      return createApiErrorResponse(data, {
+        status: response.status,
+        fallbackMessage: "Failed to sync confession draft",
+        correlationId,
+        route: `draft-proxy ${init.method ?? "GET"} ${path || "/"}`,
+      });
+    }
+
+    return new Response(JSON.stringify(data), {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    return createApiErrorResponse(error, {
+      status: 503,
+      fallbackMessage: "Backend service unreachable",
+      correlationId,
+      route: `draft-proxy ${init.method ?? "GET"} ${path || "/"}`,
+    });
+  }
+}
+
+export async function readDraftPayload(request: Request) {
+  const body = await readJsonBody(request);
+  const content = body.content ?? body.body ?? body.message;
+
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return {
+      ok: false as const,
+      response: createApiErrorResponse("Draft content is required", {
+        status: 400,
+        route: "draft-proxy payload",
+      }),
+    };
+  }
+
+  return {
+    ok: true as const,
+    body: {
+      content,
+      scheduledFor:
+        typeof body.scheduledFor === "string" ? body.scheduledFor : undefined,
+      timezone: typeof body.timezone === "string" ? body.timezone : undefined,
+      version: typeof body.version === "number" ? body.version : undefined,
+    },
+  };
+}

--- a/xconfess-frontend/app/api/confessions/drafts/route.ts
+++ b/xconfess-frontend/app/api/confessions/drafts/route.ts
@@ -1,0 +1,23 @@
+import { proxyDraftRequest, readDraftPayload } from "./proxy";
+
+export async function GET(request: Request) {
+  return proxyDraftRequest(request, "", {
+    method: "GET",
+  });
+}
+
+export async function POST(request: Request) {
+  const payload = await readDraftPayload(request);
+  if (!payload.ok) {
+    return payload.response;
+  }
+
+  return proxyDraftRequest(request, "", {
+    method: "POST",
+    body: JSON.stringify({
+      content: payload.body.content,
+      scheduledFor: payload.body.scheduledFor,
+      timezone: payload.body.timezone,
+    }),
+  });
+}

--- a/xconfess-frontend/app/components/confession/DraftManager.tsx
+++ b/xconfess-frontend/app/components/confession/DraftManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useDrafts, Draft } from "@/app/lib/hooks/useDrafts";
 import { Button } from "@/app/components/ui/button";
 import { Modal } from "@/app/components/ui/modal";
@@ -9,6 +9,14 @@ import { useGlobalToast } from "@/app/components/common/Toast";
 import { Trash2, Clock, FileText } from "lucide-react";
 import { formatDate } from "@/app/lib/utils/formatDate";
 import { Gender } from "@/app/lib/utils/validation";
+import { useAuthStore } from "@/app/lib/store/authStore";
+import {
+  createConfessionDraft,
+  deleteConfessionDraft,
+  listConfessionDrafts,
+  updateConfessionDraft,
+  type ConfessionDraftRecord,
+} from "@/app/lib/api/confessionDrafts";
 
 interface DraftManagerProps {
   currentDraft: {
@@ -18,12 +26,32 @@ interface DraftManagerProps {
   };
   onLoadDraft: (draft: Draft) => void;
   autoSaveInterval?: number; // in milliseconds
+  submittedAt?: number;
+}
+
+function toLocalDraft(remoteDraft: ConfessionDraftRecord): Draft {
+  const savedAt = Date.parse(remoteDraft.updatedAt ?? remoteDraft.createdAt ?? "");
+  const body = remoteDraft.content ?? "";
+
+  return {
+    id: remoteDraft.id,
+    body,
+    savedAt: Number.isFinite(savedAt) ? savedAt : Date.now(),
+    characterCount: body.length,
+    scheduledFor: remoteDraft.scheduledFor ?? undefined,
+    timezone: remoteDraft.timezone ?? undefined,
+  };
+}
+
+function getDraftTimestamp(remoteDraft: ConfessionDraftRecord) {
+  return Date.parse(remoteDraft.updatedAt ?? remoteDraft.createdAt ?? "") || 0;
 }
 
 export const DraftManager: React.FC<DraftManagerProps> = ({
   currentDraft,
   onLoadDraft,
-  autoSaveInterval = 30000, // 30 seconds
+  autoSaveInterval = 3000, // 3 seconds after typing stops
+  submittedAt = 0,
 }) => {
   const {
     drafts,
@@ -35,12 +63,23 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
   } = useDrafts();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentDraftId, setCurrentDraftId] = useState<string | null>(null);
+  const [remoteDraftId, setRemoteDraftId] = useState<string | null>(null);
+  const [remoteDraftVersion, setRemoteDraftVersion] = useState<number | null>(null);
   const [clearDraftsOpen, setClearDraftsOpen] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved' | 'failed'>('saved');
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const currentDraftRef = useRef(currentDraft);
   const lastSavedRef = useRef<string>("");
+  const lastSeenContentRef = useRef<string>("");
+  const hasRestoredCloudDraftRef = useRef(false);
+  const lastSubmittedAtRef = useRef(0);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const toast = useGlobalToast();
+
+  useEffect(() => {
+    currentDraftRef.current = currentDraft;
+  }, [currentDraft]);
 
   useEffect(() => {
     if (currentDraftId && !loadDraft(currentDraftId)) {
@@ -49,7 +88,67 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [drafts]);
 
-  const persistDraft = async () => {
+  useEffect(() => {
+    if (!isAuthenticated || hasRestoredCloudDraftRef.current) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const restoreLatestCloudDraft = async () => {
+      const response = await listConfessionDrafts();
+      if (cancelled || !response.ok || response.data.length === 0) {
+        return;
+      }
+
+      const [latestDraft] = [...response.data].sort(
+        (a, b) => getDraftTimestamp(b) - getDraftTimestamp(a),
+      );
+
+      setRemoteDraftId(latestDraft.id);
+      setRemoteDraftVersion(latestDraft.version);
+      hasRestoredCloudDraftRef.current = true;
+
+      const latestComposerDraft = currentDraftRef.current;
+      const composerIsEmpty =
+        !latestComposerDraft.title?.trim() && !latestComposerDraft.body.trim();
+
+      if (composerIsEmpty) {
+        onLoadDraft(toLocalDraft(latestDraft));
+      }
+    };
+
+    void restoreLatestCloudDraft();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, onLoadDraft]);
+
+  useEffect(() => {
+    if (!submittedAt || submittedAt === lastSubmittedAtRef.current) {
+      return;
+    }
+
+    lastSubmittedAtRef.current = submittedAt;
+
+    if (currentDraftId) {
+      deleteDraft(currentDraftId);
+    }
+
+    if (isAuthenticated && remoteDraftId) {
+      void deleteConfessionDraft(remoteDraftId);
+    }
+
+    setCurrentDraftId(null);
+    setRemoteDraftId(null);
+    setRemoteDraftVersion(null);
+    setSaveStatus('saved');
+    setSaveMessage(null);
+    lastSavedRef.current = JSON.stringify({ title: "", body: "", gender: undefined });
+  }, [currentDraftId, deleteDraft, isAuthenticated, remoteDraftId, submittedAt]);
+
+  const persistDraft = useCallback(async () => {
     const currentContent = JSON.stringify(currentDraft);
     if (currentContent === lastSavedRef.current) {
       return true;
@@ -72,10 +171,10 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
     setSaveMessage('Saving draft...');
 
     const existingDraft = currentDraftId ? loadDraft(currentDraftId) : null;
-    let success = false;
+    let localSaved = false;
 
     if (existingDraft && currentDraftId) {
-      success = updateDraft(currentDraftId, draftToSave);
+      localSaved = updateDraft(currentDraftId, draftToSave);
     } else {
       if (currentDraftId) {
         setCurrentDraftId(null);
@@ -83,29 +182,72 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
       const newDraftId = saveDraft(draftToSave);
       if (newDraftId) {
         setCurrentDraftId(newDraftId);
-        success = true;
+        localSaved = true;
       }
     }
 
-    if (success) {
+    let cloudSaved = !isAuthenticated;
+
+    if (isAuthenticated) {
+      const response =
+        remoteDraftId && remoteDraftVersion
+          ? await updateConfessionDraft(remoteDraftId, {
+              content: currentDraft.body,
+              version: remoteDraftVersion,
+            })
+          : await createConfessionDraft({
+              content: currentDraft.body,
+            });
+
+      if (response.ok) {
+        setRemoteDraftId(response.data.id);
+        setRemoteDraftVersion(response.data.version);
+        cloudSaved = true;
+      } else {
+        cloudSaved = false;
+      }
+    }
+
+    if (cloudSaved) {
       setSaveStatus('saved');
-      setSaveMessage('Draft saved.');
+      setSaveMessage(
+        isAuthenticated ? 'Draft saved.' : 'Draft saved on this device.',
+      );
       lastSavedRef.current = currentContent;
       return true;
+    }
+
+    if (localSaved) {
+      setSaveStatus('failed');
+      setSaveMessage('Saved on this device. Cloud sync failed.');
+      return false;
     }
 
     setSaveStatus('failed');
     setSaveMessage('Failed to save draft.');
     return false;
-  };
+  }, [
+    currentDraft,
+    currentDraftId,
+    isAuthenticated,
+    loadDraft,
+    remoteDraftId,
+    remoteDraftVersion,
+    saveDraft,
+    updateDraft,
+  ]);
 
   useEffect(() => {
     const currentContent = JSON.stringify(currentDraft);
 
-    if (currentContent !== lastSavedRef.current) {
+    if (
+      currentContent !== lastSeenContentRef.current &&
+      currentContent !== lastSavedRef.current
+    ) {
       setSaveStatus('unsaved');
       setSaveMessage('Unsaved changes');
     }
+    lastSeenContentRef.current = currentContent;
 
     if (autoSaveTimerRef.current) {
       clearTimeout(autoSaveTimerRef.current);
@@ -123,10 +265,7 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
   }, [
     currentDraft,
     autoSaveInterval,
-    currentDraftId,
-    saveDraft,
-    updateDraft,
-    loadDraft,
+    persistDraft,
   ]);
 
   const handleLoadDraft = (draft: Draft) => {
@@ -191,7 +330,7 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
           )}
           {saveStatus === 'failed' && (
             <span className="text-rose-300">
-              Failed to save draft.{' '}
+              {saveMessage ?? 'Failed to save draft.'}{' '}
               <button
                 type="button"
                 onClick={() => void persistDraft()}
@@ -212,7 +351,7 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
         <div className="space-y-4">
           {drafts.length === 0 ? (
             <p className="text-center text-zinc-400 py-8">
-              No saved drafts yet. Your drafts will be auto-saved every 30
+              No saved drafts yet. Your drafts will be auto-saved after 3
               seconds.
             </p>
           ) : (

--- a/xconfess-frontend/app/components/confession/EnhancedConfessionForm.tsx
+++ b/xconfess-frontend/app/components/confession/EnhancedConfessionForm.tsx
@@ -109,6 +109,7 @@ export const EnhancedConfessionForm: React.FC<EnhancedConfessionFormProps> = ({
     scheduledFor?: string;
     updatedAt?: string;
   } | null>(null);
+  const [draftSubmittedAt, setDraftSubmittedAt] = useState(0);
   const submitSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
@@ -262,6 +263,7 @@ export const EnhancedConfessionForm: React.FC<EnhancedConfessionFormProps> = ({
       });
 
       setSubmitSuccess(true);
+      setDraftSubmittedAt(Date.now());
       toast.success("Confession submitted successfully!");
 
       if (onSubmit) {
@@ -414,6 +416,7 @@ export const EnhancedConfessionForm: React.FC<EnhancedConfessionFormProps> = ({
                 <DraftManager
                   currentDraft={{ title, body, gender }}
                   onLoadDraft={handleLoadDraft}
+                  submittedAt={draftSubmittedAt}
                 />
                 <Button
                   type="button"

--- a/xconfess-frontend/app/components/confession/__tests__/DraftManager.test.tsx
+++ b/xconfess-frontend/app/components/confession/__tests__/DraftManager.test.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DraftManager } from "../DraftManager";
+import { useDrafts } from "@/app/lib/hooks/useDrafts";
+import {
+  createConfessionDraft,
+  deleteConfessionDraft,
+  listConfessionDrafts,
+} from "@/app/lib/api/confessionDrafts";
+
+jest.mock("@/app/lib/hooks/useDrafts", () => ({
+  useDrafts: jest.fn(),
+}));
+
+let mockAuthState = { isAuthenticated: true };
+
+jest.mock("@/app/lib/store/authStore", () => ({
+  useAuthStore: (selector: (state: typeof mockAuthState) => unknown) =>
+    selector(mockAuthState),
+}));
+
+jest.mock("@/app/lib/api/confessionDrafts", () => ({
+  createConfessionDraft: jest.fn(),
+  updateConfessionDraft: jest.fn(),
+  deleteConfessionDraft: jest.fn(),
+  listConfessionDrafts: jest.fn(),
+}));
+
+jest.mock("@/app/components/common/Toast", () => ({
+  useGlobalToast: () => ({
+    success: jest.fn(),
+  }),
+}));
+
+jest.mock("@/app/components/ui/modal", () => ({
+  Modal: ({ isOpen, title, children }: {
+    isOpen: boolean;
+    title: string;
+    children: React.ReactNode;
+  }) => (isOpen ? <section aria-label={title}>{children}</section> : null),
+}));
+
+jest.mock("@/app/components/admin/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+const mockUseDrafts = useDrafts as jest.MockedFunction<typeof useDrafts>;
+const mockCreateDraft = createConfessionDraft as jest.MockedFunction<
+  typeof createConfessionDraft
+>;
+const mockDeleteDraft = deleteConfessionDraft as jest.MockedFunction<
+  typeof deleteConfessionDraft
+>;
+const mockListDrafts = listConfessionDrafts as jest.MockedFunction<
+  typeof listConfessionDrafts
+>;
+
+const localDraftStore = {
+  saveDraft: jest.fn(() => "local-draft-1"),
+  updateDraft: jest.fn(() => true),
+  deleteDraft: jest.fn(),
+  clearDrafts: jest.fn(),
+  loadDraft: jest.fn(),
+};
+
+function renderDraftManager(props: Partial<React.ComponentProps<typeof DraftManager>> = {}) {
+  return render(
+    <DraftManager
+      currentDraft={{ title: "A title", body: "This draft should autosave." }}
+      onLoadDraft={jest.fn()}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  mockAuthState = { isAuthenticated: true };
+
+  localDraftStore.saveDraft.mockReturnValue("local-draft-1");
+  localDraftStore.updateDraft.mockReturnValue(true);
+  localDraftStore.loadDraft.mockReturnValue(undefined);
+
+  mockUseDrafts.mockReturnValue({
+    drafts: [],
+    ...localDraftStore,
+  });
+
+  mockListDrafts.mockResolvedValue({ ok: true, data: [] });
+  mockCreateDraft.mockResolvedValue({
+    ok: true,
+    data: {
+      id: "remote-draft-1",
+      content: "This draft should autosave.",
+      version: 1,
+      updatedAt: "2026-06-18T00:00:00.000Z",
+    },
+  });
+  mockDeleteDraft.mockResolvedValue({ ok: true, data: { message: "Draft deleted" } });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("DraftManager autosave", () => {
+  it("autosaves authenticated drafts to the backend within the debounce window", async () => {
+    renderDraftManager();
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    await waitFor(() => {
+      expect(localDraftStore.saveDraft).toHaveBeenCalledWith({
+        title: "A title",
+        body: "This draft should autosave.",
+        gender: undefined,
+      });
+      expect(mockCreateDraft).toHaveBeenCalledWith({
+        content: "This draft should autosave.",
+      });
+    });
+
+    expect(await screen.findByText("Draft saved.")).toBeInTheDocument();
+  });
+
+  it("keeps the local draft and shows retry when cloud sync fails", async () => {
+    mockCreateDraft.mockResolvedValue({
+      ok: false,
+      error: { message: "Backend offline", code: "NETWORK_ERROR" },
+    });
+
+    renderDraftManager();
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(
+      await screen.findByText("Saved on this device. Cloud sync failed.", {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    });
+
+    await waitFor(() => expect(mockCreateDraft).toHaveBeenCalledTimes(2));
+  });
+
+  it("restores the latest cloud draft on mount when the composer is empty", async () => {
+    const onLoadDraft = jest.fn();
+    mockListDrafts.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: "remote-draft-older",
+          content: "Older cloud draft",
+          version: 1,
+          updatedAt: "2026-06-17T00:00:00.000Z",
+        },
+        {
+          id: "remote-draft-newer",
+          content: "Latest cloud draft",
+          version: 3,
+          updatedAt: "2026-06-18T00:00:00.000Z",
+        },
+      ],
+    });
+
+    renderDraftManager({
+      currentDraft: { body: "" },
+      onLoadDraft,
+    });
+
+    await waitFor(() => {
+      expect(onLoadDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "remote-draft-newer",
+          body: "Latest cloud draft",
+          characterCount: "Latest cloud draft".length,
+        }),
+      );
+    });
+  });
+
+  it("clears the saved local and cloud draft after successful submission", async () => {
+    const { rerender } = renderDraftManager();
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    await waitFor(() => expect(mockCreateDraft).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <DraftManager
+        currentDraft={{ title: "", body: "" }}
+        onLoadDraft={jest.fn()}
+        submittedAt={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(localDraftStore.deleteDraft).toHaveBeenCalledWith("local-draft-1");
+      expect(mockDeleteDraft).toHaveBeenCalledWith("remote-draft-1");
+    });
+  });
+});

--- a/xconfess-frontend/app/lib/api/confessionDrafts.ts
+++ b/xconfess-frontend/app/lib/api/confessionDrafts.ts
@@ -1,0 +1,85 @@
+import { normalizeApiError, type ApiError } from "./errors";
+
+const API_BASE = "/api/confessions/drafts";
+
+export interface ConfessionDraftRecord {
+  id: string;
+  content: string;
+  version: number;
+  createdAt?: string;
+  updatedAt?: string;
+  scheduledFor?: string | null;
+  timezone?: string | null;
+  status?: "draft" | "scheduled" | "posted" | string;
+}
+
+export type DraftApiResponse<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: ApiError };
+
+async function requestDraftApi<T>(
+  path = "",
+  init: RequestInit = {},
+): Promise<DraftApiResponse<T>> {
+  try {
+    const response = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      return { ok: false, error: await normalizeApiError(response) };
+    }
+
+    const data = (await response.json()) as T;
+    return { ok: true, data };
+  } catch (error) {
+    return {
+      ok: false,
+      error: await normalizeApiError(
+        error instanceof Error ? error : new Error(String(error)),
+      ),
+    };
+  }
+}
+
+export function listConfessionDrafts() {
+  return requestDraftApi<ConfessionDraftRecord[]>("", {
+    method: "GET",
+    cache: "no-store",
+  });
+}
+
+export function createConfessionDraft(params: {
+  content: string;
+  scheduledFor?: string;
+  timezone?: string;
+}) {
+  return requestDraftApi<ConfessionDraftRecord>("", {
+    method: "POST",
+    body: JSON.stringify(params),
+  });
+}
+
+export function updateConfessionDraft(
+  id: string,
+  params: {
+    content: string;
+    version: number;
+  },
+) {
+  return requestDraftApi<ConfessionDraftRecord>(`/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify(params),
+  });
+}
+
+export function deleteConfessionDraft(id: string) {
+  return requestDraftApi<{ message: string }>(`/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+}


### PR DESCRIPTION
## Summary
- add same-origin `/api/confessions/drafts` proxy routes for list/create/update/delete against the backend draft controller
- add a typed frontend draft API helper used by `DraftManager`
- change `DraftManager` autosave to a 3s debounce, save authenticated users to the backend, keep local draft fallback, and show retry when cloud sync fails
- restore the latest cloud draft on mount when the composer is empty, without overwriting user input if the restore request returns late
- clear the current local/cloud draft after a successful confession submission

Closes Xconfess/Xconfess#1116

## Validation
- `npm test -- DraftManager.test.tsx EnhancedConfessionForm.test.tsx EnhancedConfessionForm.loading.test.tsx --runInBand`
- `npm run lint -- app/components/confession/DraftManager.tsx app/components/confession/EnhancedConfessionForm.tsx app/components/confession/__tests__/DraftManager.test.tsx app/lib/api/confessionDrafts.ts app/api/confessions/drafts/route.ts 'app/api/confessions/drafts/[id]/route.ts' app/api/confessions/drafts/proxy.ts`
- `git diff --cached --check`

## Build note
- `npm run build` is still blocked by existing main-branch issues unrelated to this PR:
  - `app/(dashboard)/admin/diagnostics/page.tsx:278` JSX parse error
  - `app/components/comparison/ComparisonTool.tsx` imports non-existent `ArrowClockwise` from `lucide-react`
