### PR TITLE
fix(frontend): align comment proxy contract

### DIFF
--- a/xconfess-frontend/app/api/comments/[confessionId]/__tests__/route.test.ts
+++ b/xconfess-frontend/app/api/comments/[confessionId]/__tests__/route.test.ts
@@ -1,0 +1,85 @@
+import { POST } from "../route";
+
+const mockFetch = jest.fn();
+
+describe("POST /api/comments/[confessionId]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch;
+  });
+
+  it("forwards cookie auth, bearer auth, and correlation id to the backend", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 42,
+          content: "A live backend comment",
+          createdAt: "2026-06-18T00:00:00.000Z",
+          confessionId: "confession-1",
+          parentId: null,
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const request = new Request("http://localhost/api/comments/confession-1", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer token-1",
+        Cookie: "session=secure-cookie",
+        "X-Correlation-ID": "cid-1",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        content: "A live backend comment",
+        anonymousContextId: "anon-1",
+      }),
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ confessionId: "confession-1" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/comments/confession-1"),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-1",
+          Cookie: "session=secure-cookie",
+          "X-Correlation-ID": "cid-1",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          content: "A live backend comment",
+          anonymousContextId: "anon-1",
+        }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      id: 42,
+      content: "A live backend comment",
+      createdAt: "2026-06-18T00:00:00.000Z",
+      author: "Anonymous",
+      confessionId: "confession-1",
+      parentId: null,
+    });
+  });
+
+  it("returns a 400 without calling the backend when content is empty", async () => {
+    const request = new Request("http://localhost/api/comments/confession-1", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "   " }),
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ confessionId: "confession-1" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/xconfess-frontend/app/api/comments/[confessionId]/route.ts
+++ b/xconfess-frontend/app/api/comments/[confessionId]/route.ts
@@ -34,6 +34,9 @@ export async function POST(
     }
 
     const authHeader = request.headers.get("Authorization");
+    const cookieHeader = request.headers.get("Cookie");
+    const correlationId =
+      request.headers.get("X-Correlation-ID") ?? crypto.randomUUID();
     const url = `${BASE_API_URL}/comments/${confessionId}`;
     const payload: Record<string, unknown> = {
       content: content.trim(),
@@ -45,7 +48,9 @@ export async function POST(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "X-Correlation-ID": correlationId,
         ...(authHeader ? { Authorization: authHeader } : {}),
+        ...(cookieHeader ? { Cookie: cookieHeader } : {}),
       },
       body: JSON.stringify(payload),
     });
@@ -83,6 +88,7 @@ export async function POST(
       return createApiErrorResponse(err, {
         status: response.status,
         fallbackMessage: "Failed to post comment",
+        correlationId,
         route: "POST /api/comments/[confessionId]"
       });
     }
@@ -138,4 +144,3 @@ export async function POST(
     });
   }
 }
-

--- a/xconfess-frontend/app/api/comments/by-confession/[confessionId]/__tests__/route.test.ts
+++ b/xconfess-frontend/app/api/comments/by-confession/[confessionId]/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+import { GET } from "../route";
+
+const mockFetch = jest.fn();
+
+describe("GET /api/comments/by-confession/[confessionId]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch;
+  });
+
+  it("normalizes backend data payloads and preserves backend hasMore", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 7,
+              content: "Persisted comment",
+              createdAt: "2026-06-18T00:00:00.000Z",
+              confessionId: "confession-1",
+              parentId: null,
+            },
+          ],
+          hasMore: true,
+          nextCursor: "cursor-2",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/comments/by-confession/confession-1?page=1&limit=1",
+      ),
+      { params: Promise.resolve({ confessionId: "confession-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/comments/by-confession/confession-1?page=1&limit=1"),
+      expect.objectContaining({ method: "GET" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      comments: [
+        {
+          id: 7,
+          content: "Persisted comment",
+          createdAt: "2026-06-18T00:00:00.000Z",
+          author: "Anonymous",
+          confessionId: "confession-1",
+          parentId: null,
+          replies: [],
+        },
+      ],
+      hasMore: true,
+      nextCursor: "cursor-2",
+    });
+  });
+
+  it("falls back to limit-based hasMore for legacy backend arrays", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: 8,
+            content: "Legacy comment",
+            createdAt: "2026-06-18T00:00:00.000Z",
+            parentId: null,
+          },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/comments/by-confession/confession-1?page=1&limit=1",
+      ),
+      { params: Promise.resolve({ confessionId: "confession-1" }) },
+    );
+
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ hasMore: true }),
+    );
+  });
+});

--- a/xconfess-frontend/app/api/comments/by-confession/[confessionId]/route.ts
+++ b/xconfess-frontend/app/api/comments/by-confession/[confessionId]/route.ts
@@ -150,13 +150,26 @@ export async function GET(
         : [],
     }));
 
-    // hasMore: if limit was requested and we received >= limit, assume more pages
-    const hasMore = limit ? comments.length >= Number(limit) : false;
+    const hasMore =
+      typeof data.hasMore === "boolean"
+        ? data.hasMore
+        : typeof data.meta?.hasMore === "boolean"
+          ? data.meta.hasMore
+          : limit
+            ? comments.length >= Number(limit)
+            : false;
 
-    return new Response(JSON.stringify({ comments, hasMore }), {
+    return new Response(
+      JSON.stringify({
+        comments,
+        hasMore,
+        nextCursor: data.nextCursor ?? data.meta?.nextCursor ?? null,
+      }),
+      {
       status: 200,
       headers: { "Content-Type": "application/json" },
-    });
+      },
+    );
   } catch (error) {
     const isDemoMode =
       process.env.NODE_ENV === "development" ||


### PR DESCRIPTION
## Summary
- forward secure session cookies, bearer auth, and correlation IDs from the comment POST proxy to the backend CommentController
- preserve backend `hasMore` / `nextCursor` values from the comment list proxy instead of deriving pagination only from page size
- add route handler tests for authenticated comment creation proxying and backend data payload normalization

Closes Xconfess/Xconfess#1115

## Validation
- `npx jest --no-coverage --runTestsByPath app/lib/hooks/__tests__/useComments.test.tsx 'app/api/comments/[confessionId]/__tests__/route.test.ts' 'app/api/comments/by-confession/[confessionId]/__tests__/route.test.ts' --runInBand`
- `npm run lint -- 'app/api/comments/[confessionId]/route.ts' 'app/api/comments/[confessionId]/__tests__/route.test.ts' 'app/api/comments/by-confession/[confessionId]/route.ts' 'app/api/comments/by-confession/[confessionId]/__tests__/route.test.ts' app/lib/hooks/useComments.ts app/components/confession/CommentSection.tsx app/components/confession/CommentItem.tsx`
- `git diff --cached --check`

## Build note
- `npm run build` is still blocked by existing main-branch issues unrelated to this PR:
  - `app/(dashboard)/admin/diagnostics/page.tsx:278` JSX parse error
  - `app/components/comparison/ComparisonTool.tsx` imports non-existent `ArrowClockwise` from `lucide-react`
