### PR TITLE
feat(admin): wire notification DLQ replay UI

### DIFF
--- a/xconfess-backend/src/notifications/dlq-admin.controller.spec.ts
+++ b/xconfess-backend/src/notifications/dlq-admin.controller.spec.ts
@@ -1,0 +1,43 @@
+import { DlqAdminController } from './dlq-admin.controller';
+import { JobManagementService } from './services/job-management.service';
+
+describe('DlqAdminController', () => {
+  let controller: DlqAdminController;
+  let jobManagementService: jest.Mocked<Pick<JobManagementService, 'replayDlqJob'>>;
+
+  beforeEach(() => {
+    jobManagementService = {
+      replayDlqJob: jest.fn().mockResolvedValue({
+        id: 'dlq-1',
+        outcome: 'replayed',
+        replayJobId: 'dlq-replay:orig-dlq-1',
+        newJobId: 'dlq-replay:orig-dlq-1',
+      }),
+    };
+    controller = new DlqAdminController(jobManagementService as any);
+  });
+
+  it('passes replay reason and audit context to the job management service', async () => {
+    const req = {
+      user: { id: 42 },
+      requestId: 'req-dlq-retry',
+      ip: '127.0.0.1',
+      headers: {
+        'user-agent': 'jest',
+      },
+    };
+
+    await controller.retry('dlq-1', 'manual replay after SMTP fix', req);
+
+    expect(jobManagementService.replayDlqJob).toHaveBeenCalledWith(
+      'dlq-1',
+      '42',
+      'manual replay after SMTP fix',
+      {
+        requestId: 'req-dlq-retry',
+        ipAddress: '127.0.0.1',
+        userAgent: 'jest',
+      },
+    );
+  });
+});

--- a/xconfess-backend/src/notifications/dlq-admin.controller.ts
+++ b/xconfess-backend/src/notifications/dlq-admin.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Body,
   Get,
   Post,
   Param,
@@ -50,12 +51,16 @@ export class DlqAdminController {
   }
 
   @Post(':id/retry')
-  async retry(@Param('id') id: string, @Req() req: any) {
+  async retry(
+    @Param('id') id: string,
+    @Body('reason') reason: string | undefined,
+    @Req() req: any,
+  ) {
     const actorId = String(req.user?.id);
     return this.jobManagementService.replayDlqJob(
       id,
       actorId,
-      undefined,
+      reason,
       this.buildAuditContext(req),
     );
   }

--- a/xconfess-backend/src/notifications/services/job-management.service.spec.ts
+++ b/xconfess-backend/src/notifications/services/job-management.service.spec.ts
@@ -13,8 +13,13 @@ import { AppLogger } from '../../logger/logger.service';
 
 type MockJob = {
   id: string;
+  name?: string;
   data: NotificationJobData;
   timestamp: number;
+  attemptsMade?: number;
+  failedReason?: string;
+  finishedOn?: number;
+  opts?: { attempts?: number };
   remove: jest.Mock<Promise<void>, []>;
   updateData: jest.Mock<Promise<void>, [NotificationJobData]>;
 };
@@ -114,6 +119,62 @@ describe('JobManagementService', () => {
     }).compile();
 
     service = module.get(JobManagementService);
+  });
+
+  it('lists DLQ jobs with UI-ready error details and pagination metadata', async () => {
+    const enqueuedAt = Date.parse('2026-04-24T09:55:00.000Z');
+    const dlqJob = {
+      ...buildJob('dlq-list', {
+        metadata: {
+          channel: 'email',
+          recipientEmail: 'operator@example.com',
+        },
+      }),
+      name: 'dead-letter',
+      timestamp: enqueuedAt,
+      opts: { attempts: 6 },
+    };
+
+    dlqQueue.getJobs.mockResolvedValue([dlqJob as any]);
+    dlqQueue.getJobCounts.mockResolvedValue({
+      failed: 1,
+      completed: 0,
+      waiting: 0,
+      active: 0,
+      delayed: 0,
+    } as any);
+
+    const result = await service.listDlqJobs(1, 20);
+
+    expect(dlqQueue.getJobs).toHaveBeenCalledWith(
+      ['failed', 'completed', 'waiting', 'active', 'delayed'],
+      0,
+      19,
+      true,
+    );
+    expect(result).toEqual({
+      jobs: [
+        expect.objectContaining({
+          id: 'dlq-list',
+          name: 'dead-letter',
+          attemptsMade: 5,
+          maxAttempts: 6,
+          failedReason: 'SMTP timeout',
+          failedAt: '2026-04-24T10:00:00.000Z',
+          createdAt: '2026-04-24T09:55:00.000Z',
+          channel: 'email',
+          recipientEmail: 'operator@example.com',
+          userId: 'user-dlq-list',
+          type: 'message_notification',
+          title: 'Job dlq-list',
+          lastError: 'SMTP timeout',
+          enqueuedAt,
+        }),
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
   });
 
   it('replays bulk DLQ jobs with replay-safe deduplication and audit context', async () => {

--- a/xconfess-backend/src/notifications/services/job-management.service.ts
+++ b/xconfess-backend/src/notifications/services/job-management.service.ts
@@ -42,6 +42,12 @@ function toAuditRecord(value: object): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
 @Injectable()
 export class JobManagementService {
   private readonly dlqStates: Array<
@@ -79,16 +85,7 @@ export class JobManagementService {
     }
 
     return {
-      jobs: filteredJobs.map((job) => ({
-        id: job.id,
-        userId: job.data.userId,
-        type: job.data.type,
-        title: job.data.title,
-        failedAt: job.data._meta?.failedAt,
-        attemptsMade: job.data._meta?.attemptsMade,
-        lastError: job.data._meta?.lastError,
-        enqueuedAt: job.timestamp,
-      })),
+      jobs: filteredJobs.map((job) => this.serializeDlqJob(job)),
       total: totalCount,
       page,
       limit,
@@ -312,6 +309,75 @@ export class JobManagementService {
   private async getFilteredDlqJobs(filter?: DlqJobFilter) {
     const jobs = await this.dlq.getJobs(this.dlqStates);
     return filter ? jobs.filter((job) => this.matchesDlqFilter(job, filter)) : jobs;
+  }
+
+  private serializeDlqJob(job: Job<NotificationJobData>) {
+    const metadata = toRecord(job.data.metadata);
+    const jobDetails = job as Job<NotificationJobData> & {
+      name?: string;
+      failedReason?: string;
+      finishedOn?: number;
+      opts?: { attempts?: number };
+    };
+    const attemptsMade = this.getDlqAttemptsMade(job);
+    const failedReason =
+      job.data._meta?.lastError || jobDetails.failedReason || null;
+    const failedAt =
+      job.data._meta?.failedAt ||
+      this.timestampToIsoString(jobDetails.finishedOn) ||
+      null;
+
+    return {
+      id: String(job.id),
+      name: jobDetails.name || job.data.type || 'dead-letter',
+      attemptsMade,
+      maxAttempts: this.getDlqMaxAttempts(job),
+      failedReason,
+      failedAt,
+      createdAt: this.timestampToIsoString(job.timestamp),
+      channel: this.getStringField(metadata, 'channel') || 'email',
+      recipientEmail:
+        this.getStringField(job.data as unknown as Record<string, unknown>, 'recipientEmail') ||
+        this.getStringField(metadata, 'recipientEmail'),
+      userId: job.data.userId,
+      type: job.data.type,
+      title: job.data.title,
+      lastError: failedReason,
+      enqueuedAt: job.timestamp,
+    };
+  }
+
+  private getDlqAttemptsMade(job: Job<NotificationJobData>): number {
+    const attemptsMade = job.data._meta?.attemptsMade;
+    if (typeof attemptsMade === 'number') {
+      return attemptsMade;
+    }
+
+    const jobAttempts = (job as Job<NotificationJobData> & {
+      attemptsMade?: number;
+    }).attemptsMade;
+    return typeof jobAttempts === 'number' ? jobAttempts : 0;
+  }
+
+  private getDlqMaxAttempts(job: Job<NotificationJobData>): number {
+    const attempts = (job as Job<NotificationJobData> & {
+      opts?: { attempts?: number };
+    }).opts?.attempts;
+    return typeof attempts === 'number' ? attempts : 1;
+  }
+
+  private timestampToIsoString(timestamp?: number): string | null {
+    return typeof timestamp === 'number'
+      ? new Date(timestamp).toISOString()
+      : null;
+  }
+
+  private getStringField(
+    record: Record<string, unknown>,
+    field: string,
+  ): string | undefined {
+    const value = record[field];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
   }
 
   private buildOperationId(action: string, actorId: string): string {

--- a/xconfess-frontend/app/lib/api/__tests__/admin-notifications.test.ts
+++ b/xconfess-frontend/app/lib/api/__tests__/admin-notifications.test.ts
@@ -34,7 +34,7 @@ describe('Admin API - Notification Jobs', () => {
 
       const result = await adminApi.getFailedNotificationJobs();
 
-      expect(apiClient.get).toHaveBeenCalledWith('/admin/notifications/dlq', {
+      expect(apiClient.get).toHaveBeenCalledWith('/api/admin/dlq', {
         params: {
           page: 1,
           limit: 20,
@@ -63,7 +63,7 @@ describe('Admin API - Notification Jobs', () => {
 
       await adminApi.getFailedNotificationJobs(filter);
 
-      expect(apiClient.get).toHaveBeenCalledWith('/admin/notifications/dlq', {
+      expect(apiClient.get).toHaveBeenCalledWith('/api/admin/dlq', {
         params: {
           page: 2,
           limit: 10,
@@ -100,16 +100,17 @@ describe('Admin API - Notification Jobs', () => {
   describe('replayFailedNotificationJob', () => {
     it('should replay a failed notification job', async () => {
       const mockResponse: ReplayJobResponse = {
-        success: true,
-        message: 'Job replayed successfully',
-        jobId: 'job-123',
+        id: 'job-123',
+        outcome: 'replayed',
+        replayJobId: 'dlq-replay:job-123',
+        newJobId: 'dlq-replay:job-123',
       };
 
       (apiClient.post as jest.Mock).mockResolvedValue({ data: mockResponse });
 
       const result = await adminApi.replayFailedNotificationJob('job-123');
 
-      expect(apiClient.post).toHaveBeenCalledWith('/admin/notifications/dlq/job-123/replay', {
+      expect(apiClient.post).toHaveBeenCalledWith('/api/admin/dlq/job-123/retry', {
         reason: undefined,
       });
       expect(result).toEqual(mockResponse);
@@ -117,9 +118,10 @@ describe('Admin API - Notification Jobs', () => {
 
     it('should replay a failed notification job with reason', async () => {
       const mockResponse: ReplayJobResponse = {
-        success: true,
-        message: 'Job replayed successfully',
-        jobId: 'job-123',
+        id: 'job-123',
+        outcome: 'replayed',
+        replayJobId: 'dlq-replay:job-123',
+        newJobId: 'dlq-replay:job-123',
       };
 
       (apiClient.post as jest.Mock).mockResolvedValue({ data: mockResponse });
@@ -127,7 +129,7 @@ describe('Admin API - Notification Jobs', () => {
       const reason = 'Manual retry after fixing SMTP configuration';
       await adminApi.replayFailedNotificationJob('job-123', reason);
 
-      expect(apiClient.post).toHaveBeenCalledWith('/admin/notifications/dlq/job-123/replay', {
+      expect(apiClient.post).toHaveBeenCalledWith('/api/admin/dlq/job-123/retry', {
         reason,
       });
     });
@@ -143,9 +145,10 @@ describe('Admin API - Notification Jobs', () => {
 
     it('should handle concurrent replay requests', async () => {
       const mockResponse: ReplayJobResponse = {
-        success: true,
-        message: 'Job replayed successfully',
-        jobId: 'job-123',
+        id: 'job-123',
+        outcome: 'replayed',
+        replayJobId: 'dlq-replay:job-123',
+        newJobId: 'dlq-replay:job-123',
       };
 
       (apiClient.post as jest.Mock).mockResolvedValue({ data: mockResponse });

--- a/xconfess-frontend/app/lib/api/admin.ts
+++ b/xconfess-frontend/app/lib/api/admin.ts
@@ -238,12 +238,12 @@ export const adminApi = {
       params.failedBefore = new Date(filter.endDate).toISOString();
     }
 
-    const response = await apiClient.get('/admin/notifications/dlq', { params });
+    const response = await apiClient.get('/api/admin/dlq', { params });
     return response.data;
   },
 
   replayFailedNotificationJob: async (jobId: string, reason?: string): Promise<ReplayJobResponse> => {
-    const response = await apiClient.post(`/admin/notifications/dlq/${jobId}/replay`, {
+    const response = await apiClient.post(`/api/admin/dlq/${jobId}/retry`, {
       reason,
     });
     return response.data;

--- a/xconfess-frontend/app/lib/types/notification-jobs.ts
+++ b/xconfess-frontend/app/lib/types/notification-jobs.ts
@@ -31,7 +31,8 @@ export interface FailedJobsFilter {
 }
 
 export interface ReplayJobResponse {
-  success: boolean;
-  message: string;
-  jobId: string;
+  id: string;
+  outcome: 'replayed' | 'deduplicated' | 'failed';
+  replayJobId: string;
+  newJobId: string | null;
 }


### PR DESCRIPTION
## Closes

Closes #1120

---

## What changed

Wires the existing admin notification DLQ page to the backend DLQ controller, returns UI-ready failed job details from `JobManagementService.listDlqJobs`, and passes single replay reasons through the controller into the audit-aware replay service.

## Why

The admin UI was calling stale `/admin/notifications/dlq` endpoints and could not reliably show DLQ error details or replay jobs through the existing audited backend flow.

## How to test

1. `cd xconfess-backend && npx --yes jest@30.0.5 --config jest.config.js src/notifications/dlq-admin.controller.spec.ts src/notifications/services/job-management.service.spec.ts --runInBand`
2. `cd xconfess-backend && npx eslint src/notifications/dlq-admin.controller.ts src/notifications/dlq-admin.controller.spec.ts src/notifications/services/job-management.service.ts src/notifications/services/job-management.service.spec.ts --quiet`
3. `cd xconfess-frontend && npm test -- app/lib/api/__tests__/admin-notifications.test.ts --runInBand`
4. `cd xconfess-frontend && npm test -- --runTestsByPath 'app/(dashboard)/admin/notifications/__tests__/page.test.tsx' --runInBand`
5. `cd xconfess-frontend && npx eslint app/lib/api/admin.ts app/lib/types/notification-jobs.ts app/lib/api/__tests__/admin-notifications.test.ts 'app/(dashboard)/admin/notifications/page.tsx' 'app/(dashboard)/admin/notifications/__tests__/page.test.tsx' --max-warnings=0`

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:
N/A

---

## Evidence

### Tests

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output:

```text
PASS src/notifications/dlq-admin.controller.spec.ts
PASS src/notifications/services/job-management.service.spec.ts
Test Suites: 2 passed, 2 total
Tests: 6 passed, 6 total

PASS app/lib/api/__tests__/admin-notifications.test.ts
Test Suites: 1 passed, 1 total
Tests: 10 passed, 10 total

PASS app/(dashboard)/admin/notifications/__tests__/page.test.tsx
Test Suites: 1 passed, 1 total
Tests: 24 passed, 24 total
```

Focused lint passed for the changed backend and frontend files.

Full build note: `npm run build` currently fails on existing unrelated `main` issues outside this PR scope:

- Backend: `src/admin/services/admin.service.ts`, `src/health/*`, and `src/tipping/chain-reconciliation.service.ts` TypeScript errors.
- Frontend: `app/(dashboard)/admin/diagnostics/page.tsx` JSX parse error and `app/components/comparison/ComparisonTool.tsx` importing non-existent `ArrowClockwise` from `lucide-react`.

### Screenshots (UI changes only)

N/A - no visual layout changes; this wires the existing DLQ UI to the existing backend route and response contract.

| | Before | After |
|---|---|---|
| Desktop (≥ 1280 px) | N/A | N/A |
| Mobile (≤ 390 px) | N/A | N/A |

---

## Checklist

- [x] Branch is up to date with `main`
- [ ] All CI checks pass
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)
