### PR TITLE
feat(frontend): onboarding tour covers Stellar wallet connect and anchor step

### DIFF
--- a/xconfess-frontend/app/components/confession/AnchorButton.tsx
+++ b/xconfess-frontend/app/components/confession/AnchorButton.tsx
@@ -131,7 +131,7 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
 
   if (anchored && txHash) {
     return (
-      <div className={cn("flex items-center gap-2", className)}>
+      <div className={cn("stellar-anchor-action flex items-center gap-2", className)}>
         <CheckCircle2 className="h-4 w-4 text-green-400" />
         <span className="text-xs text-zinc-400">Anchored</span>
         <a
@@ -148,7 +148,7 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
 
   if (walletCTA.status === "not-installed") {
     return (
-      <div className={cn("flex flex-col gap-1.5", className)}>
+      <div className={cn("stellar-wallet-cta stellar-anchor-action flex flex-col gap-1.5", className)}>
         <div className="flex items-center gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-1.5">
           <AlertCircle className="h-3.5 w-3.5 flex-shrink-0 text-yellow-500" />
           <span className="text-xs text-yellow-400">{walletCTA.guidance}</span>
@@ -158,7 +158,7 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
   }
 
   return (
-    <div className={cn("flex flex-col gap-1", className)}>
+    <div className={cn("stellar-anchor-action flex flex-col gap-1", className)}>
       <Button
         variant="outline"
         size="sm"
@@ -167,7 +167,7 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
         className={cn(
           "h-7 px-2 text-xs",
           walletCTA.status === "not-connected" &&
-            "border-blue-500/40 text-blue-400 hover:bg-blue-500/10 hover:text-blue-300",
+            "stellar-wallet-cta border-blue-500/40 text-blue-400 hover:bg-blue-500/10 hover:text-blue-300",
         )}
       >
         {isAnchoring || (isLoading && isConnected) ? (

--- a/xconfess-frontend/app/components/onboarding/FeatureTour.tsx
+++ b/xconfess-frontend/app/components/onboarding/FeatureTour.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { ONBOARDING_STEPS } from "@/app/lib/types/onboarding.types";
 import { useOnboardingStore } from "@/app/lib/store/onboardingStore";
+
+const FREIGHTER_INSTALL_URL =
+  "https://www.freighter.app/";
+
+const STELLAR_STEP_IDS = new Set(["stellar-wallet", "anchor-action"]);
+
+function isFreighterInstalled(): boolean {
+  if (typeof window === "undefined") return false;
+  return !!(window as Record<string, unknown>).freighter;
+}
 
 interface Props {
   run: boolean;
@@ -13,8 +23,25 @@ interface Props {
 export const FeatureTour = ({ run, onComplete, onSkip }: Props) => {
   const { setCurrentStep, completeStep } = useOnboardingStore();
   const [stepIndex, setStepIndex] = useState(0);
-  const step = ONBOARDING_STEPS[stepIndex];
-  const isLastStep = stepIndex === ONBOARDING_STEPS.length - 1;
+  const [walletAvailable, setWalletAvailable] = useState(false);
+
+  useEffect(() => {
+    setWalletAvailable(isFreighterInstalled());
+  }, []);
+
+  const visibleSteps = useMemo(
+    () =>
+      ONBOARDING_STEPS.filter((s) => {
+        if (!STELLAR_STEP_IDS.has(s.id)) return true;
+        const el = document.querySelector(s.target);
+        return !!el;
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [run],
+  );
+
+  const step = visibleSteps[stepIndex];
+  const isLastStep = stepIndex === visibleSteps.length - 1;
 
   useEffect(() => {
     if (!run || !step) return;
@@ -31,6 +58,8 @@ export const FeatureTour = ({ run, onComplete, onSkip }: Props) => {
   }, [run, step]);
 
   if (!run || !step) return null;
+
+  const isStellarStep = STELLAR_STEP_IDS.has(step.id);
 
   const handleNext = () => {
     completeStep(step.id);
@@ -59,10 +88,27 @@ export const FeatureTour = ({ run, onComplete, onSkip }: Props) => {
     <div className="fixed inset-0 z-[10000] bg-black/70 flex items-end md:items-center justify-center p-4">
       <div className="w-full max-w-md rounded-xl border border-zinc-700 bg-zinc-900 p-5 shadow-2xl">
         <p className="text-xs uppercase tracking-wide text-zinc-400 mb-2">
-          Step {stepIndex + 1} of {ONBOARDING_STEPS.length}
+          Step {stepIndex + 1} of {visibleSteps.length}
         </p>
         <h3 className="text-lg font-semibold text-white">{step.title}</h3>
         <p className="mt-2 text-sm text-zinc-300">{step.description}</p>
+
+        {isStellarStep && !walletAvailable && (
+          <div className="mt-3 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2">
+            <p className="text-xs text-yellow-400">
+              Freighter wallet extension not detected.{" "}
+              <a
+                href={FREIGHTER_INSTALL_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-yellow-300"
+              >
+                Install Freighter
+              </a>{" "}
+              to use Stellar features.
+            </p>
+          </div>
+        )}
 
         <div className="mt-5 flex items-center justify-between">
           <button

--- a/xconfess-frontend/app/components/onboarding/OnboardingFlow.tsx
+++ b/xconfess-frontend/app/components/onboarding/OnboardingFlow.tsx
@@ -32,20 +32,24 @@ export const OnboardingFlow = () => {
     markWelcomeSeen();
     setShowWelcome(false);
 
-    // Wait until the DOM has rendered the targets
+    const OPTIONAL_STEP_IDS = new Set(["stellar-wallet", "anchor-action"]);
+
     const startWhenReady = () => {
-      const allExist = ONBOARDING_STEPS.every((step) =>
+      const requiredSteps = ONBOARDING_STEPS.filter(
+        (step) => !OPTIONAL_STEP_IDS.has(step.id),
+      );
+      const requiredExist = requiredSteps.every((step) =>
         document.querySelector(step.target),
       );
 
-      if (allExist) {
-        setRunTour(true); // Start tour
+      if (requiredExist) {
+        setRunTour(true);
       } else {
-        setTimeout(startWhenReady, 100); // retry
+        setTimeout(startWhenReady, 100);
       }
     };
 
-    setTimeout(startWhenReady, 300); // small delay for modal to close
+    setTimeout(startWhenReady, 300);
   };
 
   const handleSkipWelcome = () => {

--- a/xconfess-frontend/app/lib/types/onboarding.types.ts
+++ b/xconfess-frontend/app/lib/types/onboarding.types.ts
@@ -31,7 +31,8 @@ export const ONBOARDING_STEPS: OnboardingStep[] = [
   { id: "confession-feed", title: "📝 Confession Feed", description: "Browse anonymous confessions", target: ".confession-feed", placement: "bottom" },
   { id: "create-confession", title: "✨ Share Your Thoughts", description: "Click here to post", target: ".create-confession-button", placement: "bottom", spotlightClicks: true },
   { id: "reactions", title: "❤️ React to Confessions", description: "Support with reactions", target: ".reaction-buttons", placement: "top" },
-  { id: "wallet-connect", title: "🌟 Stellar Integration (Optional)", description: "Connect wallet for blockchain storage", target: ".wallet-connect", placement: "left" },
+  { id: "stellar-wallet", title: "🔗 Connect Your Wallet (Optional)", description: "Install and connect the Freighter browser extension to unlock Stellar blockchain features like anchoring and tipping.", target: ".stellar-wallet-cta", placement: "left" },
+  { id: "anchor-action", title: "⚓ Anchor to Stellar (Optional)", description: "Anchor a confession to the Stellar blockchain for permanent, tamper-proof storage. Requires a connected Freighter wallet.", target: ".stellar-anchor-action", placement: "top" },
 ];
 
 export const TUTORIAL_STEPS: TutorialStep[] = [


### PR DESCRIPTION
## Summary
- Extends the FeatureTour onboarding to introduce Freighter wallet install, connect, and anchor action steps for new users
- Replaces the generic `wallet-connect` step with two specific Stellar steps: wallet setup (`stellar-wallet`) and anchor action (`anchor-action`)
- FeatureTour detects Freighter availability and shows an install link when the extension is missing; does not auto-trigger wallet install on unsupported browsers
- Tour completion is persisted via the existing zustand localStorage store (`xconfess-onboarding`)
- Stellar steps are optional: they only show if corresponding DOM targets exist, and the tour never blocks waiting for them

## Files changed
- `xconfess-frontend/app/lib/types/onboarding.types.ts` — new `stellar-wallet` and `anchor-action` steps
- `xconfess-frontend/app/components/onboarding/FeatureTour.tsx` — wallet detection, Freighter install link, dynamic step filtering
- `xconfess-frontend/app/components/onboarding/OnboardingFlow.tsx` — only wait for required step targets before starting tour
- `xconfess-frontend/app/components/confession/AnchorButton.tsx` — added `.stellar-wallet-cta` and `.stellar-anchor-action` CSS class targets

## Test plan
- [ ] Clear localStorage (`xconfess-onboarding` key), log in, and verify the tour appears once
- [ ] Walk through all steps — confirm wallet and anchor steps appear when confessions are in the feed
- [ ] On a browser without Freighter: verify the Freighter install link is shown on Stellar steps
- [ ] On a browser with Freighter: verify wallet steps highlight the connect/anchor buttons without the install warning
- [ ] Click "Skip tour" at any point — verify the tour dismisses and does not reappear
- [ ] Complete the full tour — verify it does not reappear on next visit
- [ ] Confirm the tour overlay does not block critical auth flows (login, signup)

Closes #1140