### PR TITLE
feat: add correlation ids to tip and anchor verify logs

### DIFF
--- a/docs/stellar-anchor-and-tipping-runbook.md
+++ b/docs/stellar-anchor-and-tipping-runbook.md
@@ -214,6 +214,55 @@ When fixture version changes, backend must implement migration logic to handle b
 - `maintainer/issues/170-fix-backend-tip-verification-idempotency-replay.md`
 - `maintainer/issues/173-feat-backend-chain-reconciliation-worker.md`
 
+## Correlation Log Fields
+
+Every verify call emits structured log lines with the following correlation fields so a single attempt can be traced end-to-end:
+
+| Field | Type | Present in |
+| :--- | :--- | :--- |
+| `requestId` | string (UUID) | All tip and anchor verify log lines |
+| `confessionId` | string (UUID) | Tip verify log lines |
+| `txHash` | string (64-char hex) | Tip and stellar verify log lines |
+| `confessionHash` | string (64-char hex) | Anchor verify log lines |
+| `tipId` | string | Success and idempotent-replay log lines |
+| `amount` | number | Tip verify success log line |
+
+### Log lifecycle events (tip verify)
+
+| Event | Level | Key fields |
+| :--- | :--- | :--- |
+| Verify request received | `LOG` | `requestId`, `confessionId`, `txHash` |
+| Idempotent replay detected | `DEBUG` | `requestId`, `confessionId`, `txHash`, `tipId` |
+| Conflict (txId reuse) | `WARN` | `requestId`, `confessionId`, `txHash`, `originalConfessionId` |
+| Confession not found | `WARN` | `requestId`, `confessionId`, `txHash` |
+| Transaction not found on-chain | `WARN` | `requestId`, `confessionId`, `txHash` |
+| Verify succeeded | `LOG` | `requestId`, `confessionId`, `txHash`, `tipId`, `amount` |
+| Horizon fetch error | `ERROR` | `requestId`, `txHash` |
+
+### Log lifecycle events (anchor verify)
+
+| Event | Level | Key fields |
+| :--- | :--- | :--- |
+| Verify request received | `LOG` | `requestId`, `confessionHash` |
+| Verify completed | `LOG` | `requestId`, `confessionHash`, `isAnchored` |
+
+### Grep recipes
+
+```bash
+# Trace a single verify attempt end-to-end
+grep '"requestId":"<value>"' app.log
+
+# Find all log lines for a specific txHash
+grep '"txHash":"<value>"' app.log
+
+# Confirm requestId and txHash appear on the same line
+grep '"requestId":"<value>"' app.log | grep '"txHash":"<value>"'
+```
+
+### Security invariant
+
+`requestId` is echoed from the incoming `x-request-id` header (or auto-generated). No secrets, private keys, or seed phrases are ever written to logs. Sender addresses are omitted when the tip is marked anonymous.
+
 ## Metrics & Observability (Reconciliation Lag)
 
 As per Issue #783, the backend emits bounded metrics to track the age of pending records. This allows operators to differentiate between "normal network delay" and "stuck records."

--- a/xconfess-backend/src/stellar/stellar.controller.ts
+++ b/xconfess-backend/src/stellar/stellar.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   Controller,
   Get,
+  Logger,
   Param,
   Post,
   Req,
@@ -30,6 +31,8 @@ import {
 @ApiTags('Stellar')
 @Controller('stellar')
 export class StellarController {
+  private readonly logger = new Logger(StellarController.name);
+
   constructor(
     private stellarService: StellarService,
     private contractService: ContractService,
@@ -69,12 +72,25 @@ export class StellarController {
       },
     },
   })
-  async verifyAnchor(@Param('confessionHash') confessionHash: string) {
+  async verifyAnchor(@Param('confessionHash') confessionHash: string, @Req() req: any) {
+    const requestId = req.requestId as string | undefined;
+    this.logger.log({
+      message: 'Anchor verify started',
+      requestId,
+      confessionHash,
+    });
+
     if (!/^[0-9a-fA-F]{64}$/.test(confessionHash)) {
       throw new BadRequestException('Invalid confession hash format. Expected 32-byte hex.');
     }
 
     const timestamp = await this.contractService.verifyConfession(confessionHash);
+    this.logger.log({
+      message: 'Anchor verify completed',
+      requestId,
+      confessionHash,
+      isAnchored: timestamp !== null,
+    });
     return {
       isAnchored: timestamp !== null,
       timestamp,
@@ -91,8 +107,10 @@ export class StellarController {
   @Post('verify')
   @ApiOperation({ summary: 'Verify transaction on-chain' })
   @ApiResponse({ status: 200, description: 'Transaction verification result' })
-  async verifyTransaction(@Body() dto: VerifyTransactionDto) {
-    return this.stellarService.verifyTransaction(dto.txHash);
+  async verifyTransaction(@Body() dto: VerifyTransactionDto, @Req() req: any) {
+    const requestId = req.requestId as string | undefined;
+    this.logger.log({ message: 'Stellar tx verify started', requestId, txHash: dto.txHash });
+    return this.stellarService.verifyTransaction(dto.txHash, requestId);
   }
 
   @Get('account-exists/:address')

--- a/xconfess-backend/src/stellar/stellar.service.ts
+++ b/xconfess-backend/src/stellar/stellar.service.ts
@@ -216,7 +216,7 @@ export class StellarService {
   /**
    * Verify a transaction exists on the Stellar network
    */
-  async verifyTransaction(txHash: string): Promise<boolean> {
+  async verifyTransaction(txHash: string, requestId?: string): Promise<boolean> {
     if (!this.isValidTxHash(txHash)) {
       return false;
     }
@@ -231,7 +231,11 @@ export class StellarService {
       return data.successful === true;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(`Error verifying Stellar transaction: ${message}`);
+      this.logger.error({
+        message: `Error verifying Stellar transaction: ${message}`,
+        requestId,
+        txHash,
+      });
       return false;
     }
   }

--- a/xconfess-backend/src/tipping/tipping.controller.ts
+++ b/xconfess-backend/src/tipping/tipping.controller.ts
@@ -4,9 +4,11 @@ import {
   Post,
   Body,
   Param,
+  Req,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { Throttle } from '@nestjs/throttler';
 import {
   ApiTags,
@@ -97,7 +99,9 @@ export class TippingController {
   async verifyTip(
     @Param('id') confessionId: string,
     @Body() dto: VerifyTipDto,
+    @Req() req: Request,
   ): Promise<TipVerificationResult> {
-    return this.tippingService.verifyAndRecordTip(confessionId, dto);
+    const requestId = (req as any).requestId as string | undefined;
+    return this.tippingService.verifyAndRecordTip(confessionId, dto, requestId);
   }
 }

--- a/xconfess-backend/src/tipping/tipping.service.spec.ts
+++ b/xconfess-backend/src/tipping/tipping.service.spec.ts
@@ -194,6 +194,82 @@ describe('TippingService', () => {
     });
   });
 
+  describe('correlation log fields', () => {
+    const mockDto = { txId: 'abc123tx' };
+    const confessionId = 'conf-456';
+    const requestId = 'req-uuid-789';
+
+    beforeEach(() => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            _embedded: {
+              operations: [
+                {
+                  type: 'payment',
+                  asset_type: 'native',
+                  amount: '5.0',
+                  from: 'GABC123',
+                },
+              ],
+            },
+          }),
+      });
+    });
+
+    it('emits a start log containing requestId, confessionId, and txHash', async () => {
+      mockConfessionRepo.findOne.mockResolvedValue({ id: confessionId });
+      mockTipRepo.findOne.mockResolvedValue(null);
+      mockStellarService.verifyTransaction.mockResolvedValue(true);
+
+      const logSpy = jest.spyOn((service as any).logger, 'log');
+
+      await service.verifyAndRecordTip(confessionId, mockDto, requestId);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId,
+          confessionId,
+          txHash: mockDto.txId,
+        }),
+      );
+    });
+
+    it('emits a success log containing requestId, confessionId, txHash, and tipId', async () => {
+      mockConfessionRepo.findOne.mockResolvedValue({ id: confessionId });
+      mockTipRepo.findOne.mockResolvedValue(null);
+      mockStellarService.verifyTransaction.mockResolvedValue(true);
+
+      const logSpy = jest.spyOn((service as any).logger, 'log');
+
+      const result = await service.verifyAndRecordTip(confessionId, mockDto, requestId);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Tip verify succeeded',
+          requestId,
+          confessionId,
+          txHash: mockDto.txId,
+          tipId: result.tip.id,
+        }),
+      );
+    });
+
+    it('passes requestId to stellarService.verifyTransaction', async () => {
+      mockConfessionRepo.findOne.mockResolvedValue({ id: confessionId });
+      mockTipRepo.findOne.mockResolvedValue(null);
+      mockStellarService.verifyTransaction.mockResolvedValue(true);
+
+      await service.verifyAndRecordTip(confessionId, mockDto, requestId);
+
+      expect(mockStellarService.verifyTransaction).toHaveBeenCalledWith(
+        mockDto.txId,
+        requestId,
+      );
+    });
+  });
+
   describe('getTipStats', () => {
     it('should calculate correct stats', async () => {
       const tips = [

--- a/xconfess-backend/src/tipping/tipping.service.ts
+++ b/xconfess-backend/src/tipping/tipping.service.ts
@@ -280,13 +280,27 @@ export class TippingService {
   async verifyAndRecordTip(
     confessionId: string,
     dto: VerifyTipDto,
+    requestId?: string,
   ): Promise<TipVerificationResult> {
+    this.logger.log({
+      message: 'Tip verify started',
+      requestId,
+      confessionId,
+      txHash: dto.txId,
+    });
+
     // Check if confession exists
     const confession = await this.confessionRepository.findOne({
       where: { id: confessionId },
     });
 
     if (!confession) {
+      this.logger.warn({
+        message: 'Confession not found',
+        requestId,
+        confessionId,
+        txHash: dto.txId,
+      });
       throw new NotFoundException(
         `Confession with ID ${confessionId} not found`,
       );
@@ -301,10 +315,13 @@ export class TippingService {
     );
 
     if (existingIdempotentTip) {
-      // This exact request already completed - return canonical response
-      this.logger.debug(
-        `Idempotent replay detected for tip ${dto.txId} on confession ${confessionId}`,
-      );
+      this.logger.debug({
+        message: 'Idempotent replay detected',
+        requestId,
+        confessionId,
+        txHash: dto.txId,
+        tipId: existingIdempotentTip.id,
+      });
 
       return {
         tip: existingIdempotentTip,
@@ -319,10 +336,13 @@ export class TippingService {
     });
 
     if (tipByTxId && tipByTxId.confessionId !== confessionId) {
-      // Conflict: txId already used for a different confession
-      this.logger.warn(
-        `Conflict: txId ${dto.txId} attempted for confession ${confessionId} but already used for ${tipByTxId.confessionId}`,
-      );
+      this.logger.warn({
+        message: 'Conflict: txId already used for a different confession',
+        requestId,
+        confessionId,
+        txHash: dto.txId,
+        originalConfessionId: tipByTxId.confessionId,
+      });
 
       throw new ConflictException({
         message: `Transaction ${dto.txId} was already used for a different confession`,
@@ -355,9 +375,15 @@ export class TippingService {
 
     try {
       // Verify transaction on-chain
-      const isValid = await this.stellarService.verifyTransaction(dto.txId);
+      const isValid = await this.stellarService.verifyTransaction(dto.txId, requestId);
 
       if (!isValid) {
+        this.logger.warn({
+          message: 'Transaction not found or invalid on Stellar network',
+          requestId,
+          confessionId,
+          txHash: dto.txId,
+        });
         await this.updateRetryMetadata(dto.txId, 'not_found', {
           error: 'Transaction not found on chain',
           attemptedAt: new Date().toISOString(),
@@ -433,6 +459,16 @@ export class TippingService {
 
       // Release lock after successful processing
       await this.releaseProcessingLock(dto.txId);
+
+      this.logger.log({
+        message: 'Tip verify succeeded',
+        requestId,
+        confessionId,
+        txHash: dto.txId,
+        tipId: savedTip.id,
+        amount: processedData.amount,
+        isNew: !existingTip,
+      });
 
       return {
         tip: savedTip,


### PR DESCRIPTION
Propagates requestId from the request-id middleware into all tip and anchor verification log calls. Every verify attempt now emits structured log objects containing requestId, confessionId, and txHash on the same line, making individual attempts traceable through logs via a single grep.

- TippingController extracts req.requestId and forwards to service
- TippingService logs { requestId, confessionId, txHash } at five lifecycle points: start, not-found, conflict, idempotent replay, success
- StellarService.verifyTransaction accepts and logs requestId on error
- StellarController logs requestId for both verifyTransaction and verifyAnchor endpoints
- Runbook updated with Correlation Log Fields section, lifecycle event tables, and grep recipes
- Tests added for log shape (start log, success log, requestId forwarding)


Closes #1130 