### PR TITLE
Harden AnchorButton anchoring UX with distinct states and retry.

### DIFF
--- a/xconfess-frontend/app/components/confession/AnchorButton.tsx
+++ b/xconfess-frontend/app/components/confession/AnchorButton.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useState, type FC } from "react";
-import { Anchor, CheckCircle2, ExternalLink, Loader2, AlertCircle, Wallet } from "lucide-react";
+import { Anchor, CheckCircle2, ExternalLink, Loader2, AlertCircle, Wallet, RotateCcw } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import { Button } from "@/app/components/ui/button";
 import { cn } from "@/app/lib/utils/cn";
 import { useActivityStore } from "@/app/lib/store/activity.store";
 import { useStellarWallet } from "@/lib/hooks/useStellarWallet";
 import { getWalletCTAState } from "@/lib/hooks/useWalletCTAState";
-import { getStellarExplorerUrl } from "@/app/lib/utils/stellar";
+import { getStellarExplorerUrl, mapAnchorApiError } from "@/app/lib/utils/stellar";
+
+type AnchorStatus = "idle" | "pending" | "confirmed" | "failed";
 
 interface AnchorButtonProps {
   confessionId: string;
@@ -17,6 +19,10 @@ interface AnchorButtonProps {
   stellarTxHash?: string | null;
   onAnchorSuccess?: (txHash: string) => void;
   className?: string;
+}
+
+function shortHash(hash: string) {
+  return `${hash.slice(0, 6)}…${hash.slice(-6)}`;
 }
 
 export const AnchorButton: FC<AnchorButtonProps> = ({
@@ -47,25 +53,32 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
   const addActivity = useActivityStore((s) => s.addActivity);
   const updateActivity = useActivityStore((s) => s.updateActivity);
 
-  const [isAnchoring, setIsAnchoring] = useState(false);
+  const [status, setStatus] = useState<AnchorStatus>(
+    isAnchored && stellarTxHash ? "confirmed" : "idle",
+  );
   const [txHash, setTxHash] = useState<string | null>(stellarTxHash);
   const [error, setError] = useState<string | null>(null);
-  const [anchored, setAnchored] = useState(isAnchored);
+  const [liveMessage, setLiveMessage] = useState("");
+
+  const isPending = status === "pending";
 
   const handleAnchor = async () => {
-    if (isAnchoring || isLoading) return;
+    if (isPending || isLoading) return;
     setError(null);
+    setStatus("pending");
+    setLiveMessage("Anchoring confession on Stellar…");
 
     if (!isConnected) {
       try {
         await connect();
       } catch {
-        setError("Failed to connect wallet. Please ensure Freighter is unlocked.");
+        const msg = "Failed to connect wallet. Please ensure Freighter is unlocked.";
+        setError(msg);
+        setStatus("failed");
+        setLiveMessage(msg);
         return;
       }
     }
-
-    setIsAnchoring(true);
 
     const activityId = uuidv4();
     addActivity({
@@ -79,69 +92,78 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
     try {
       const result = await anchor(confessionContent);
 
-      if (result.success && result.txHash) {
-        updateActivity(activityId, {
-          status: "submitted",
-          txHash: result.txHash,
-        });
-
-        const response = await fetch(`/api/confessions/${confessionId}/anchor`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            stellarTxHash: result.txHash,
-          }),
-        });
-
-        if (!response.ok) {
-          throw new Error("Failed to save anchor");
-        }
-
-        updateActivity(activityId, {
-          status: "confirmed",
-          updatedAt: Date.now(),
-        });
-
-        setTxHash(result.txHash);
-        setAnchored(true);
-        onAnchorSuccess?.(result.txHash);
-      } else {
-        updateActivity(activityId, {
-          status: "failed",
-          updatedAt: Date.now(),
-        });
-
-        setError(result.error || "Failed to anchor confession");
+      if (!result.success || !result.txHash) {
+        updateActivity(activityId, { status: "failed", updatedAt: Date.now() });
+        const msg = result.error || "Failed to anchor confession";
+        setError(msg);
+        setStatus("failed");
+        setLiveMessage(msg);
+        return;
       }
+
+      updateActivity(activityId, {
+        status: "submitted",
+        txHash: result.txHash,
+      });
+
+      const response = await fetch(`/api/confessions/${confessionId}/anchor`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ stellarTxHash: result.txHash }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(
+          mapAnchorApiError(response.status, data?.message),
+        );
+      }
+
+      updateActivity(activityId, {
+        status: "confirmed",
+        updatedAt: Date.now(),
+      });
+
+      setTxHash(result.txHash);
+      setStatus("confirmed");
+      setLiveMessage("Confession anchored successfully.");
+      onAnchorSuccess?.(result.txHash);
     } catch (err) {
       updateActivity(activityId, {
         status: "failed",
         updatedAt: Date.now(),
       });
-
-      const message =
+      const msg =
         err instanceof Error ? err.message : "Failed to anchor confession";
-      setError(message);
-    } finally {
-      setIsAnchoring(false);
+      setError(msg);
+      setStatus("failed");
+      setLiveMessage(msg);
     }
   };
 
-  if (anchored && txHash) {
+  if (status === "confirmed" && txHash) {
+    const explorerUrl = getStellarExplorerUrl(txHash);
     return (
-      <div className={cn("stellar-anchor-action flex items-center gap-2", className)}>
-        <CheckCircle2 className="h-4 w-4 text-green-400" />
-        <span className="text-xs text-zinc-400">Anchored</span>
-        <a
-          href={getStellarExplorerUrl(txHash) ?? "#"}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
-        >
-          <ExternalLink className="h-3 w-3" />
-        </a>
+      <div
+        className={cn("stellar-anchor-action flex items-center gap-2", className)}
+        role="status"
+        aria-live="polite"
+      >
+        <CheckCircle2 className="h-4 w-4 text-green-400" aria-hidden="true" />
+        <span className="text-xs text-green-400">Anchored</span>
+        <span className="font-mono text-xs text-zinc-500">{shortHash(txHash)}</span>
+        {explorerUrl && (
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+          >
+            View on explorer
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </a>
+        )}
+        <span className="sr-only">{liveMessage || "Confession anchored successfully."}</span>
       </div>
     );
   }
@@ -158,43 +180,68 @@ export const AnchorButton: FC<AnchorButtonProps> = ({
   }
 
   return (
-    <div className={cn("stellar-anchor-action flex flex-col gap-1", className)}>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={walletCTA.status === "not-connected" ? handleAnchor : handleAnchor}
-        disabled={isAnchoring || walletCTA.disabled}
-        className={cn(
-          "h-7 px-2 text-xs",
-          walletCTA.status === "not-connected" &&
-            "stellar-wallet-cta border-blue-500/40 text-blue-400 hover:bg-blue-500/10 hover:text-blue-300",
-        )}
-      >
-        {isAnchoring || (isLoading && isConnected) ? (
-          <>
-            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-            Anchoring...
-          </>
-        ) : walletCTA.status === "not-connected" ? (
-          <>
-            <Wallet className="mr-1 h-3 w-3" />
-            Connect Wallet to Anchor
-          </>
-        ) : (
-          <>
-            <Anchor className="mr-1 h-3 w-3" />
-            Anchor
-          </>
-        )}
-      </Button>
+    <div className={cn("stellar-anchor-action flex flex-col gap-1.5", className)}>
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {liveMessage}
+      </span>
+
+      {status === "failed" && error ? (
+        <div
+          className="flex flex-col gap-1.5 rounded-md border border-red-500/30 bg-red-500/10 px-2.5 py-2"
+          role="alert"
+        >
+          <div className="flex items-start gap-2">
+            <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-red-400" aria-hidden="true" />
+            <p className="text-xs text-red-300">{error}</p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAnchor}
+            disabled={isPending || walletCTA.disabled}
+            className="h-7 w-fit px-2 text-xs border-red-500/40 text-red-300 hover:bg-red-500/10"
+          >
+            <RotateCcw className="mr-1 h-3 w-3" />
+            Retry
+          </Button>
+        </div>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleAnchor}
+          disabled={isPending || walletCTA.disabled}
+          aria-busy={isPending}
+          className={cn(
+            "h-7 px-2 text-xs",
+            walletCTA.status === "not-connected" &&
+              "stellar-wallet-cta border-blue-500/40 text-blue-400 hover:bg-blue-500/10 hover:text-blue-300",
+          )}
+        >
+          {isPending || (isLoading && isConnected) ? (
+            <>
+              <Loader2 className="mr-1 h-3 w-3 animate-spin" aria-hidden="true" />
+              Anchoring…
+            </>
+          ) : walletCTA.status === "not-connected" ? (
+            <>
+              <Wallet className="mr-1 h-3 w-3" aria-hidden="true" />
+              Connect Wallet to Anchor
+            </>
+          ) : (
+            <>
+              <Anchor className="mr-1 h-3 w-3" aria-hidden="true" />
+              Anchor
+            </>
+          )}
+        </Button>
+      )}
 
       {walletCTA.status === "not-connected" && walletCTA.guidance && (
         <p className="text-xs text-zinc-500">{walletCTA.guidance}</p>
       )}
 
-      {error && <div className="text-xs text-red-400">{error}</div>}
-
-      {walletCTA.status === "not-ready" && !error && (
+      {walletCTA.status === "not-ready" && status !== "failed" && (
         <div className="text-xs text-orange-400">{walletCTA.guidance}</div>
       )}
     </div>

--- a/xconfess-frontend/app/lib/utils/stellar.ts
+++ b/xconfess-frontend/app/lib/utils/stellar.ts
@@ -18,6 +18,36 @@ export function getStellarExplorerUrl(
   return `${STELLAR_EXPERT_BASE}/${segment}/tx/${txHash}`;
 }
 
+export function mapAnchorApiError(status: number, message?: string): string {
+  const lower = message?.toLowerCase() ?? "";
+  if (lower.includes("already anchored")) {
+    return "This confession is already anchored.";
+  }
+  if (lower.includes("invalid") && lower.includes("hash")) {
+    return "Invalid transaction hash. Try anchoring again.";
+  }
+  if (lower.includes("not found")) {
+    return "Confession not found.";
+  }
+
+  switch (status) {
+    case 400:
+      return message || "Invalid anchor request.";
+    case 401:
+      return "Sign in to save your anchor.";
+    case 403:
+      return "You cannot anchor this confession.";
+    case 404:
+      return "Confession not found.";
+    case 409:
+      return "This confession is already anchored.";
+    case 503:
+      return "Server unavailable. Check your wallet — the on-chain anchor may have succeeded.";
+    default:
+      return message || "Failed to save anchor. Try again.";
+  }
+}
+
 export function hashConfession(content: string, timestamp?: number): string {
   const ts = timestamp || Date.now();
   const payload = JSON.stringify({ content, timestamp: ts });

--- a/xconfess-frontend/lib/hooks/useStellarWallet.ts
+++ b/xconfess-frontend/lib/hooks/useStellarWallet.ts
@@ -54,17 +54,18 @@ export function useStellarWallet() {
 
         if (result.error) {
           const stellarError = handleStellarError(result.error);
-          setAnchorError(stellarError.actionable || stellarError.message);
-          return { success: false, error: stellarError.message };
-        } else {
-          setAnchorError(null);
+          const userError = stellarError.actionable || stellarError.message;
+          setAnchorError(userError);
+          return { success: false, error: userError };
         }
 
+        setAnchorError(null);
         return result;
       } catch (error: unknown) {
         const stellarError = handleStellarError(error);
-        setAnchorError(stellarError.actionable || stellarError.message);
-        return { success: false, error: stellarError.message };
+        const userError = stellarError.actionable || stellarError.message;
+        setAnchorError(userError);
+        return { success: false, error: userError };
       }
     },
     [wallet],

--- a/xconfess-frontend/tests/confessions/anchor-submission.spec.tsx
+++ b/xconfess-frontend/tests/confessions/anchor-submission.spec.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AnchorButton } from "@/app/components/confession/AnchorButton";
-import { useStellarWallet } from "@/app/lib/hooks/useStellarWallet";
-import { readyForAnchor, successfulAnchorResult } from "@/tests/mocks/anchor-fixtures";
+import { useStellarWallet } from "@/lib/hooks/useStellarWallet";
+import { readyForAnchor, successfulAnchorResult, getAnchorFetchMockResponse } from "@/tests/mocks/anchor-fixtures";
 
-jest.mock("@/app/lib/hooks/useStellarWallet", () => ({
+jest.mock("@/lib/hooks/useStellarWallet", () => ({
   useStellarWallet: jest.fn(),
 }));
 
@@ -17,6 +17,7 @@ describe("AnchorButton Duplicate Submission", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    global.fetch = jest.fn().mockImplementation(() => getAnchorFetchMockResponse("success"));
     mockUseStellarWallet.mockReturnValue({
       ...readyForAnchor(),
       anchor: mockAnchor,

--- a/xconfess-frontend/tests/wallet/wallet-readiness-parity.spec.tsx
+++ b/xconfess-frontend/tests/wallet/wallet-readiness-parity.spec.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { AnchorButton } from "@/app/components/confession/AnchorButton";
 import { TipButton } from "@/app/components/confession/TipButton";
 import { useWallet, type UseWalletReturn } from "@/lib/hooks/useWallet";
-import { useStellarWallet } from "@/app/lib/hooks/useStellarWallet";
+import { useStellarWallet } from "@/lib/hooks/useStellarWallet";
 import {
   walletNotInstalled,
   disconnectedWallet,
@@ -14,7 +14,7 @@ import {
 } from "@/tests/mocks/wallet-fixtures";
 
 jest.mock("@/lib/hooks/useWallet", () => ({ useWallet: jest.fn() }));
-jest.mock("@/app/lib/hooks/useStellarWallet", () => ({ useStellarWallet: jest.fn() }));
+jest.mock("@/lib/hooks/useStellarWallet", () => ({ useStellarWallet: jest.fn() }));
 jest.mock("@/lib/services/tipping.service", () => ({
   sendTip: jest.fn(),
   verifyTip: jest.fn(),


### PR DESCRIPTION
## Summary
- Add distinct anchor states: pending (spinner), confirmed (hash + explorer link), failed (message + retry)
- Disable double-submit while a transaction is in flight
- Map backend anchor API errors to readable copy via `mapAnchorApiError`
- Announce status changes with `aria-live` for screen readers
- Retry reuses existing wallet connection (no page reload)

## Test plan
- [ ] Set testnet in `.env.local`, connect Freighter, anchor a confession
- [ ] Confirm pending spinner, then confirmed state with explorer link
- [ ] Reject tx in Freighter → failed state with retry button
- [ ] Retry without reloading page
- [ ] `npm run test --workspace=xconfess-frontend` (anchor + wallet-readiness specs)

closes #1132