### PR TITLE
[codex] Improve admin table mobile responsiveness

### DIFF
--- a/xconfess-frontend/app/(dashboard)/admin/audit-logs/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/audit-logs/page.tsx
@@ -4,7 +4,7 @@ import AuditLogList from '@/app/components/admin/AuditLogList';
 
 export default function AuditLogsPage() {
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <div>
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Audit Logs</h2>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">

--- a/xconfess-frontend/app/(dashboard)/admin/reports/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/reports/page.tsx
@@ -4,7 +4,7 @@ import ReportList from '@/app/components/admin/ReportList';
 
 export default function ReportsPage() {
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <div>
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Reports</h2>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">

--- a/xconfess-frontend/app/(dashboard)/admin/users/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/users/page.tsx
@@ -4,7 +4,7 @@ import UserManagement from '@/app/components/admin/UserManagement';
 
 export default function UsersPage() {
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <div>
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">User Management</h2>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">

--- a/xconfess-frontend/app/components/admin/AuditLogList.tsx
+++ b/xconfess-frontend/app/components/admin/AuditLogList.tsx
@@ -72,9 +72,9 @@ export default function AuditLogList() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="min-w-0 space-y-4">
       {/* Filters */}
-      <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4">
+      <div className="min-w-0 bg-white dark:bg-gray-800 shadow rounded-lg p-4">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -180,14 +180,14 @@ export default function AuditLogList() {
                 `audit-logs-${new Date().toISOString().split("T")[0]}.csv`,
               );
             }}
-            className="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 text-sm"
+            className="min-h-[44px] rounded-md bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-700"
           >
             Export CSV
           </button>
           {hasActiveFilters && (
             <button
               onClick={clearFilters}
-              className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 underline"
+              className="min-h-[44px] rounded-md px-3 text-sm text-gray-500 underline hover:text-gray-700 dark:hover:text-gray-300"
             >
               Clear all filters
             </button>
@@ -196,9 +196,9 @@ export default function AuditLogList() {
       </div>
 
       {/* Audit Logs Table */}
-      <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <div className="min-w-0 max-w-full overflow-hidden rounded-lg bg-white shadow dark:bg-gray-800">
+        <div className="max-w-full overflow-x-auto overscroll-x-contain">
+          <table className="min-w-[56rem] divide-y divide-gray-200 dark:divide-gray-700 md:min-w-full">
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Admin</th>
@@ -250,22 +250,22 @@ export default function AuditLogList() {
 
       {/* Pagination */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="text-sm text-gray-700 dark:text-gray-300">
             Showing {(page - 1) * limit + 1} to {Math.min(page * limit, total)} of {total} results
           </div>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="px-4 py-2 border rounded-md disabled:opacity-50 text-sm"
+              className="min-h-[44px] rounded-md border px-4 py-2 text-sm disabled:opacity-50"
             >
               Previous
             </button>
             <button
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={page === totalPages}
-              className="px-4 py-2 border rounded-md disabled:opacity-50 text-sm"
+              className="min-h-[44px] rounded-md border px-4 py-2 text-sm disabled:opacity-50"
             >
               Next
             </button>

--- a/xconfess-frontend/app/components/admin/ReportList.tsx
+++ b/xconfess-frontend/app/components/admin/ReportList.tsx
@@ -145,11 +145,11 @@ export default function ReportList() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="min-w-0 space-y-4">
       {confirmDialog}
 
       {/* Filters */}
-      <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4">
+      <div className="min-w-0 bg-white dark:bg-gray-800 shadow rounded-lg p-4">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-5">
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -221,7 +221,7 @@ export default function ReportList() {
               className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
             />
           </div>
-          <div className="flex items-end gap-2">
+          <div className="flex flex-wrap items-end gap-2">
             <ExportCsvButton
               onClick={() => {
                 const exportData: Record<string, unknown>[] = reports.map((r: Report) => ({
@@ -242,6 +242,7 @@ export default function ReportList() {
               }}
               isExporting={isExportingCsv}
               label="Export Reports CSV"
+              className="min-h-[44px]"
             />
             {selectedIds.size > 0 && (
               <Button
@@ -249,7 +250,7 @@ export default function ReportList() {
                 size="sm"
                 onClick={handleBulkResolve}
                 aria-label={`Resolve ${selectedIds.size} selected reports`}
-                className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 text-sm"
+                className="min-h-[44px] rounded-md bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-700"
               >
                 Resolve Selected ({selectedIds.size})
               </Button>
@@ -281,9 +282,9 @@ export default function ReportList() {
           </div>
         </div>
       ) : (
-        <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <div className="min-w-0 max-w-full overflow-hidden rounded-lg bg-white shadow dark:bg-gray-800">
+          <div className="max-w-full overflow-x-auto overscroll-x-contain">
+            <table className="min-w-[48rem] divide-y divide-gray-200 dark:divide-gray-700 md:min-w-full">
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
@@ -329,7 +330,7 @@ export default function ReportList() {
                       aria-label={`Select report ${report.id}`}
                       checked={selectedIds.has(report.id)}
                       onChange={() => toggleSelect(report.id)}
-                      className="rounded border-gray-300"
+                      className="min-h-[44px] min-w-[44px] rounded border-gray-300"
                     />
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
@@ -352,7 +353,7 @@ export default function ReportList() {
                       size="sm"
                       onClick={() => setSelectedReport(report.id)}
                       aria-label={`View report ${report.id}`}
-                      className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 p-0"
+                      className="min-h-[44px] min-w-[44px] rounded-md px-3 text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300"
                     >
                       View
                     </Button>
@@ -367,12 +368,12 @@ export default function ReportList() {
 
       {/* Pagination */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="text-sm text-gray-700 dark:text-gray-300">
             Showing {(page - 1) * limit + 1} to {Math.min(page * limit, total)}{" "}
             of {total} results
           </div>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <Button
               type="button"
               onClick={() => setPage((p) => Math.max(1, p - 1))}

--- a/xconfess-frontend/app/components/admin/UserManagement.tsx
+++ b/xconfess-frontend/app/components/admin/UserManagement.tsx
@@ -79,12 +79,12 @@ export default function UserManagement() {
   const totalPages = Math.ceil(total / limit);
 
   return (
-    <div className="space-y-4">
+    <div className="min-w-0 space-y-4">
       {confirmDialog}
 
       {/* Search */}
-      <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4">
-        <div className="flex gap-4">
+      <div className="min-w-0 bg-white dark:bg-gray-800 shadow rounded-lg p-4">
+        <div className="flex min-w-0 gap-4">
           <input
             type="text"
             value={searchQuery}
@@ -93,22 +93,22 @@ export default function UserManagement() {
               setPage(1);
             }}
             placeholder="Search by username..."
-            className="flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
+            className="min-h-[44px] min-w-0 flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
           />
         </div>
       </div>
 
       {/* Users Table */}
       {searchQuery.length > 0 && (
-        <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+        <div className="min-w-0 max-w-full overflow-hidden rounded-lg bg-white shadow dark:bg-gray-800">
           {isLoading ? (
             <div className="text-center py-8 text-gray-500">Loading users...</div>
           ) : users.length === 0 ? (
             <div className="text-center py-8 text-gray-500">No users found</div>
           ) : (
             <>
-              <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <div className="max-w-full overflow-x-auto overscroll-x-contain">
+                <table className="min-w-[44rem] divide-y divide-gray-200 dark:divide-gray-700 md:min-w-full">
                   <thead className="bg-gray-50 dark:bg-gray-700">
                     <tr>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
@@ -159,7 +159,7 @@ export default function UserManagement() {
                                 size="sm"
                                 onClick={() => handleBan(user)}
                                 aria-label={`Ban ${user.username}`}
-                                className="text-red-600 hover:text-red-900 dark:text-red-400 p-0"
+                                className="min-h-[44px] min-w-[44px] rounded-md px-3 text-red-600 hover:text-red-900 dark:text-red-400"
                               >
                                 Ban
                               </Button>
@@ -169,7 +169,7 @@ export default function UserManagement() {
                                 size="sm"
                                 onClick={() => handleUnban(user)}
                                 aria-label={`Unban ${user.username}`}
-                                className="text-green-600 hover:text-green-900 dark:text-green-400 p-0"
+                                className="min-h-[44px] min-w-[44px] rounded-md px-3 text-green-600 hover:text-green-900 dark:text-green-400"
                               >
                                 Unban
                               </Button>
@@ -179,7 +179,7 @@ export default function UserManagement() {
                               size="sm"
                               onClick={() => setSelectedUser(user)}
                               aria-label={`View history for ${user.username}`}
-                              className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 p-0"
+                              className="min-h-[44px] min-w-[64px] rounded-md px-3 text-indigo-600 hover:text-indigo-900 dark:text-indigo-400"
                             >
                               History
                             </Button>
@@ -193,12 +193,12 @@ export default function UserManagement() {
 
               {/* Pagination */}
               {totalPages > 1 && (
-                <div className="px-6 py-4 flex items-center justify-between border-t border-gray-200 dark:border-gray-700">
+                <div className="flex flex-col gap-3 border-t border-gray-200 px-4 py-4 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between sm:px-6">
                   <div className="text-sm text-gray-700 dark:text-gray-300">
                     Showing {(page - 1) * limit + 1} to {Math.min(page * limit, total)} of {total}{' '}
                     results
                   </div>
-                  <div className="flex gap-2">
+                  <div className="flex flex-wrap gap-2">
                     <Button
                       type="button"
                       onClick={() => setPage((p) => Math.max(1, p - 1))}


### PR DESCRIPTION
## Summary
- keep admin users, reports, and audit log tables contained on narrow screens with internal horizontal scrolling
- add shrink-safe wrappers around admin table routes and cards
- restore 44px minimum touch targets for primary table actions and mobile pagination controls

## Why
Admin tables could force horizontal page overflow during tablet/mobile demos, and some inline action buttons were visually small because table code overrode shared button padding.

Closes #1139

## Validation
- `npx eslint 'app/components/admin/UserManagement.tsx' 'app/components/admin/ReportList.tsx' 'app/components/admin/AuditLogList.tsx' 'app/(dashboard)/admin/users/page.tsx' 'app/(dashboard)/admin/reports/page.tsx' 'app/(dashboard)/admin/audit-logs/page.tsx'`
- `git diff --check`

## Notes
- Initial `npm ci` failed because npm auto-detected the monorepo root and hit `Invalid Version:`. `npm ci --workspaces=false` succeeded using the frontend lockfile directly.
Closes #1139
