### PR TITLE
test(contracts): cover confession anchor pause flow

### DIFF
--- a/docs/contract-abi-reference.md
+++ b/docs/contract-abi-reference.md
@@ -304,21 +304,30 @@ Check if upgrade from a specific version is compatible.
 
 #### `pause(env, caller, reason) -> Result<(), Error>`
 
-Pause the contract (owner/admin only). Blocks `anchor_confession` writes.
+Pause the contract (owner/admin only). Blocks `anchor_confession` writes while preserving read-only verification and count queries.
 
 **Parameters:**
 - `caller: Address` - Must be owner or admin
 - `reason: String` - Reason for pausing
 
+**Errors:**
+- `NotAuthorized` (code 2) when `caller` is not owner/admin
+- `AlreadyPaused` (code 9) when the contract is already paused
+- `ContractPaused` (code 12) is emitted by blocked write paths such as `anchor_confession` while paused
+
 ---
 
 #### `unpause(env, caller, reason) -> Result<(), Error>`
 
-Unpause the contract (owner/admin only).
+Unpause the contract (owner/admin only). After a successful unpause, `anchor_confession` writes are accepted again.
 
 **Parameters:**
 - `caller: Address` - Must be owner or admin
 - `reason: String` - Reason for unpausing
+
+**Errors:**
+- `NotAuthorized` (code 2) when `caller` is not owner/admin
+- `NotPaused` (code 10) when the contract is not currently paused
 
 ---
 

--- a/xconfess-contracts/contracts/confession-anchor/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-anchor/src/lib.rs
@@ -1286,6 +1286,39 @@ mod test {
     }
 
     #[test]
+    fn pause_blocks_anchor_and_unpause_restores_writes() {
+        let (env, client) = new_client();
+        let owner = Address::generate(&env);
+        let reason = SorobanString::from_str(&env, "incident");
+        let blocked_hash = sample_hash(&env, 91);
+        let restored_hash = sample_hash(&env, 92);
+
+        client.initialize(&owner);
+        client.pause(&owner, &reason);
+        assert!(client.is_paused());
+
+        let paused_anchor = client.try_anchor_confession(&blocked_hash, &1_700_000_000_001);
+        assert!(
+            paused_anchor.is_err(),
+            "anchoring should fail while paused: {paused_anchor:?}"
+        );
+        assert_eq!(client.verify_confession(&blocked_hash), None);
+        assert_eq!(client.get_confession_count(), 0);
+
+        client.unpause(&owner, &reason);
+        assert!(!client.is_paused());
+        assert_eq!(
+            client.anchor_confession(&restored_hash, &1_700_000_000_002),
+            symbol_short!("anchored")
+        );
+        assert_eq!(
+            client.verify_confession(&restored_hash),
+            Some(1_700_000_000_002)
+        );
+        assert_eq!(client.get_confession_count(), 1);
+    }
+
+    #[test]
     fn pause_reason_exact_limit_succeeds() {
         let (env, client) = new_client();
         let owner = Address::generate(&env);


### PR DESCRIPTION
## Summary
- adds confession-anchor coverage for pause -> blocked anchor -> unpause -> successful anchor
- asserts the blocked write does not store the hash or increment count
- documents pause/unpause error codes and post-unpause write behavior in the ABI reference

Closes #1125

## Testing
- `cargo fmt --all --check` (from `xconfess-contracts/`)
- `cargo test -p confession-anchor --lib`
- `npm run contract:test`

Note: `npm install --no-audit --no-fund` was attempted first but npm reported `Invalid Version:` in this checkout; the workspace already had enough dependencies available for `npm run contract:test`, which passed.