### PR TITLE
fix: audit comment admin moderation actions

### DIFF
--- a/xconfess-backend/src/comment/comment.module.ts
+++ b/xconfess-backend/src/comment/comment.module.ts
@@ -8,11 +8,13 @@ import { AnonymousContextMiddleware } from '../middleware/anonymous-context.midd
 import { ModerationComment } from './entities/moderation-comment.entity';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
 import { AnalyticsModule } from '../analytics/analytics.module';
+import { AuditLogModule } from '../audit-log/audit-log.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Comment, ModerationComment, OutboxEvent]),
     AnalyticsModule,
+    AuditLogModule,
   ],
   controllers: [CommentController, CommentAdminController],
   providers: [CommentService],

--- a/xconfess-backend/src/comment/comment.service.spec.ts
+++ b/xconfess-backend/src/comment/comment.service.spec.ts
@@ -3,6 +3,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, Repository, UpdateResult } from 'typeorm';
 import { AnalyticsService } from '../analytics/analytics.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
+import { AuditLogService } from '../audit-log/audit-log.service';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { CommentService } from './comment.service';
@@ -611,6 +613,72 @@ describe('CommentService – analytics cache invalidation', () => {
       await Promise.resolve();
       expect(analyticsService.invalidateTrendingCache).toHaveBeenCalledWith(
         `comment-moderated:${ModerationStatus.REJECTED}`,
+      );
+    });
+
+    it('writes an audit log with comment id and moderator after approval', async () => {
+      const modEntry = {
+        comment: { id: 12 },
+        status: ModerationStatus.PENDING,
+      } as any;
+      const modRepoValue = {
+        findOne: jest.fn().mockResolvedValue(modEntry),
+        save: jest.fn().mockResolvedValue({
+          ...modEntry,
+          status: ModerationStatus.APPROVED,
+        }),
+      };
+      const auditLogService = {
+        log: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          CommentService,
+          {
+            provide: getRepositoryToken(Comment),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(AnonymousConfession),
+            useValue: { findOne: jest.fn() },
+          },
+          {
+            provide: getRepositoryToken(ModerationComment),
+            useValue: modRepoValue,
+          },
+          {
+            provide: getRepositoryToken(OutboxEvent),
+            useValue: { create: jest.fn(), save: jest.fn() },
+          },
+          { provide: DataSource, useValue: { transaction: jest.fn() } },
+          { provide: AnalyticsService, useValue: analyticsService },
+          { provide: AuditLogService, useValue: auditLogService },
+        ],
+      }).compile();
+
+      service = module.get(CommentService);
+      await service.moderateComment(12, ModerationStatus.APPROVED, moderator);
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.MODERATION_OVERRIDE,
+          metadata: expect.objectContaining({
+            entityType: 'comment',
+            entityId: '12',
+            commentId: '12',
+            moderationStatus: ModerationStatus.APPROVED,
+            previousStatus: ModerationStatus.PENDING,
+          }),
+          context: expect.objectContaining({
+            userId: moderator.id,
+            actor: expect.objectContaining({
+              type: 'admin',
+              id: String(moderator.id),
+              userId: String(moderator.id),
+            }),
+          }),
+        }),
       );
     });
 

--- a/xconfess-backend/src/comment/comment.service.ts
+++ b/xconfess-backend/src/comment/comment.service.ts
@@ -3,10 +3,13 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  Optional,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { AnalyticsService } from '../analytics/analytics.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
+import { AuditLogService } from '../audit-log/audit-log.service';
 import {
   OutboxEvent,
   OutboxStatus,
@@ -50,6 +53,8 @@ export class CommentService {
     private outboxRepo: Repository<OutboxEvent>,
     private readonly dataSource: DataSource,
     private readonly analyticsService: AnalyticsService,
+    @Optional()
+    private readonly auditLogService?: AuditLogService,
   ) {}
 
   async create(
@@ -128,7 +133,7 @@ export class CommentService {
 
         return savedComment;
       })
-      .then(async (result) => {
+      .then((result) => {
         // Invalidate trending analytics after a new comment lands.
         // Fire-and-forget: cache failures must not roll back the comment write.
         this.analyticsService
@@ -386,6 +391,26 @@ export class CommentService {
     moderation.moderatedBy = moderator;
     moderation.moderatedById = moderator.id;
     await this.moderationCommentRepo.save(moderation);
+
+    await this.auditLogService?.log({
+      actionType: AuditActionType.MODERATION_OVERRIDE,
+      metadata: {
+        entityType: 'comment',
+        entityId: String(commentId),
+        commentId: String(commentId),
+        moderationStatus: status,
+        previousStatus: ModerationStatus.PENDING,
+      },
+      context: {
+        userId: moderator.id,
+        actor: {
+          type: 'admin',
+          id: String(moderator.id),
+          userId: String(moderator.id),
+          source: 'comment-admin-controller',
+        },
+      },
+    });
 
     // Moderation changes which comments are publicly visible, directly
     // affecting trending scores and platform stats.


### PR DESCRIPTION
Closes #1127.

This PR adds audit logging for successful comment admin moderation actions. The existing class-level `JwtAuthGuard` and `AdminGuard` contract remains intact, and the moderation service now writes an audit record containing the comment id, previous moderation status, new status, and moderator actor id after a successful state change.

## Validation

- `npx jest --config jest.config.js src/comment/comment.service.spec.ts --runInBand --testNamePattern "writes an audit log"`
- `npx jest --config jest.config.js src/comment/comment-admin.controller.spec.ts src/comment/comment.service.spec.ts --runInBand`
- `npx prettier --check src/comment/comment.service.ts src/comment/comment.service.spec.ts src/comment/comment.module.ts`
- `npx eslint src/comment/comment.service.ts src/comment/comment.service.spec.ts src/comment/comment.module.ts`

Full backend build is currently blocked by unrelated existing errors in admin, health, and tipping modules; no build failure was reported in the touched comment files.