### PR TITLE
fix: align search proxy params with backend dto

### DIFF
--- a/xconfess-frontend/app/api/confessions/search/route.ts
+++ b/xconfess-frontend/app/api/confessions/search/route.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from "@/app/lib/config";
+import { buildBackendSearchParams } from "@/app/lib/search/searchParams";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 
 const BASE_API_URL = getApiBaseUrl();
@@ -24,31 +25,17 @@ function parseBoolean(value: unknown, fallback = false): boolean {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const q = searchParams.get("q") ?? "";
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10) || 1);
-  const limit = Math.max(1, Math.min(50, parseInt(searchParams.get("limit") ?? "10", 10) || 10));
-  const sort = searchParams.get("sort") ?? "newest";
-  const dateFrom = searchParams.get("dateFrom") ?? undefined;
-  const dateTo = searchParams.get("dateTo") ?? undefined;
-  const minReactions = searchParams.get("minReactions") ?? undefined;
-  const gender = searchParams.get("gender") ?? undefined;
-
-  const backendParams = new URLSearchParams();
-  backendParams.set("page", String(page));
-  backendParams.set("limit", String(limit));
-  backendParams.set("sort", sort);
-  if (q) backendParams.set("q", q);
-  if (dateFrom) backendParams.set("dateFrom", dateFrom);
-  if (dateTo) backendParams.set("dateTo", dateTo);
-  if (minReactions != null && minReactions !== "")
-    backendParams.set("minReactions", minReactions);
-  if (gender) backendParams.set("gender", gender);
+  const backendParams = buildBackendSearchParams(searchParams);
+  const page = parseNumber(backendParams.get("page"), 1);
+  const limit = parseNumber(backendParams.get("limit"), 10);
 
   const searchUrl = `${BASE_API_URL}/confessions/search?${backendParams}`;
 
   try {
     const authHeader = request.headers.get("Authorization");
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
     if (authHeader) {
       headers["Authorization"] = authHeader;
     }
@@ -64,7 +51,7 @@ export async function GET(request: Request) {
       return createApiErrorResponse(errData, {
         status: res.status,
         fallbackMessage: `Search failed: ${res.statusText}`,
-        route: "GET /api/confessions/search"
+        route: "GET /api/confessions/search",
       });
     }
 
@@ -114,11 +101,11 @@ export async function GET(request: Request) {
 
     const partial = parseBoolean(
       data.partial ?? data.meta?.partial ?? inferredPartialFromSearchType,
-      false
+      false,
     );
     const degraded = parseBoolean(
       data.degraded ?? data.meta?.degraded,
-      warnings.length > 0
+      warnings.length > 0,
     );
 
     return Response.json({
@@ -144,7 +131,7 @@ export async function GET(request: Request) {
     return createApiErrorResponse(err, {
       status: 503,
       fallbackMessage: "Search service unavailable",
-      route: "GET /api/confessions/search"
+      route: "GET /api/confessions/search",
     });
   }
 }

--- a/xconfess-frontend/app/lib/hooks/useSearch.ts
+++ b/xconfess-frontend/app/lib/hooks/useSearch.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { buildSearchProxyParams } from "@/app/lib/search/searchParams";
 import type { SearchConfession, SearchFilters } from "@/app/lib/types/search";
 import { logError } from "@/app/lib/utils/errorHandler";
 
@@ -107,7 +108,7 @@ function userMessageForSearchFailure(status: number | null): string {
 async function fetchSearchWithRetry(
   url: string,
   signal: AbortSignal,
-  onRetrying: (retrying: boolean) => void
+  onRetrying: (retrying: boolean) => void,
 ): Promise<Record<string, unknown>> {
   for (let attempt = 0; attempt < SEARCH_MAX_RETRIES; attempt++) {
     if (signal.aborted) {
@@ -133,7 +134,7 @@ async function fetchSearchWithRetry(
           {
             url: "/api/confessions/search",
             attempt: attempt + 1,
-          }
+          },
         );
       } else {
         logError(fetchErr, "useSearch", {
@@ -161,7 +162,7 @@ async function fetchSearchWithRetry(
           url: "/api/confessions/search",
           httpStatus: res.status,
           attempt: attempt + 1,
-        }
+        },
       );
     } else {
       logError(new Error(`search_upstream_${res.status}`), "useSearch", {
@@ -197,9 +198,8 @@ export function useSearch({
   const [isLoading, setIsLoading] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [statusMeta, setStatusMeta] = useState<UseSearchResult["statusMeta"]>(
-    null
-  );
+  const [statusMeta, setStatusMeta] =
+    useState<UseSearchResult["statusMeta"]>(null);
   const [retryTick, setRetryTick] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
   const accumulatedRef = useRef<SearchConfession[]>([]);
@@ -234,18 +234,12 @@ export function useSearch({
     const { signal } = abortRef.current;
 
     const append = page > 1;
-    const params = new URLSearchParams();
-    params.set("page", String(page));
-    params.set("limit", "10");
-    params.set("sort", filters.sort);
-
-    if (debouncedQuery.trim()) params.set("q", debouncedQuery.trim());
-    if (filters.dateFrom) params.set("dateFrom", filters.dateFrom);
-    if (filters.dateTo) params.set("dateTo", filters.dateTo);
-    if (filters.minReactions != null && filters.minReactions > 0) {
-      params.set("minReactions", String(filters.minReactions));
-    }
-    if (filters.gender) params.set("gender", filters.gender);
+    const params = buildSearchProxyParams({
+      query: debouncedQuery,
+      filters,
+      page,
+      limit: 10,
+    });
 
     if (page === 1) accumulatedRef.current = [];
     setIsLoading(true);
@@ -260,7 +254,7 @@ export function useSearch({
           signal,
           (retrying) => {
             if (!cancelled) setIsRetrying(retrying);
-          }
+          },
         );
 
         if (cancelled) return;
@@ -271,7 +265,7 @@ export function useSearch({
         const warnings = Array.isArray(data.warnings)
           ? data.warnings.filter(
               (entry: unknown) =>
-                typeof entry === "string" && entry.trim().length > 0
+                typeof entry === "string" && entry.trim().length > 0,
             )
           : [];
         const partial = Boolean(data.partial);
@@ -309,7 +303,7 @@ export function useSearch({
                 warnings,
                 searchType,
               }
-            : null
+            : null,
         );
       } catch (e: unknown) {
         if (e instanceof DOMException && e.name === "AbortError") return;
@@ -328,7 +322,7 @@ export function useSearch({
                 warnings: [],
                 searchType: "error",
               }
-            : null
+            : null,
         );
 
         if (page === 1) {

--- a/xconfess-frontend/app/lib/search/__tests__/searchParams.test.ts
+++ b/xconfess-frontend/app/lib/search/__tests__/searchParams.test.ts
@@ -1,0 +1,56 @@
+import {
+  buildBackendSearchParams,
+  buildSearchProxyParams,
+} from "@/app/lib/search/searchParams";
+import type { SearchFilters } from "@/app/lib/types/search";
+
+describe("search parameter serialization", () => {
+  it("serializes frontend filters for the local search proxy", () => {
+    const filters: SearchFilters = {
+      sort: "reactions",
+      dateFrom: "2026-06-01",
+      dateTo: "2026-06-20",
+      minReactions: 5,
+      gender: "other",
+    };
+
+    const params = buildSearchProxyParams({
+      query: "  work stress  ",
+      filters,
+      page: 2,
+      limit: 10,
+    });
+
+    expect(params.toString()).toBe(
+      "page=2&limit=10&sort=reactions&q=work+stress&dateFrom=2026-06-01&dateTo=2026-06-20&minReactions=5&gender=other",
+    );
+  });
+
+  it("maps proxy params to backend SearchConfessionDto field names", () => {
+    const incoming = new URLSearchParams({
+      query: "legacy term",
+      page: "0",
+      limit: "100",
+      sort: "newest",
+      dateFrom: "2026-06-01",
+      dateTo: "2026-06-20",
+      minReactions: "5",
+      gender: "female",
+    });
+
+    const params = buildBackendSearchParams(incoming);
+
+    expect(params.get("q")).toBe("legacy term");
+    expect(params.get("page")).toBe("1");
+    expect(params.get("limit")).toBe("50");
+    expect(params.get("sortBy")).toBe("date");
+    expect(params.get("startDate")).toBe("2026-06-01");
+    expect(params.get("endDate")).toBe("2026-06-20");
+    expect(params.get("minReactions")).toBe("5");
+    expect(params.get("gender")).toBe("female");
+    expect(params.has("query")).toBe(false);
+    expect(params.has("sort")).toBe(false);
+    expect(params.has("dateFrom")).toBe(false);
+    expect(params.has("dateTo")).toBe(false);
+  });
+});

--- a/xconfess-frontend/app/lib/search/searchParams.ts
+++ b/xconfess-frontend/app/lib/search/searchParams.ts
@@ -1,0 +1,85 @@
+import type { SearchFilters } from "@/app/lib/types/search";
+
+type SearchSortBy = "relevance" | "reactions" | "date" | "views";
+
+interface SearchProxyParamOptions {
+  query: string;
+  filters: SearchFilters;
+  page: number;
+  limit: number;
+}
+
+function clampInteger(
+  value: string | number | null,
+  fallback: number,
+  max?: number,
+) {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : Number.parseInt(value ?? String(fallback), 10);
+  const safeValue = Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  return max ? Math.min(safeValue, max) : safeValue;
+}
+
+function frontendSortToBackendSortBy(
+  sort: SearchFilters["sort"],
+): SearchSortBy {
+  if (sort === "reactions") return "reactions";
+  if (sort === "newest" || sort === "oldest") return "date";
+  return "relevance";
+}
+
+function setIfPresent(
+  params: URLSearchParams,
+  key: string,
+  value?: string | null,
+) {
+  if (value != null && value !== "") {
+    params.set(key, value);
+  }
+}
+
+export function buildSearchProxyParams({
+  query,
+  filters,
+  page,
+  limit,
+}: SearchProxyParamOptions): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("page", String(clampInteger(page, 1)));
+  params.set("limit", String(clampInteger(limit, 10, 50)));
+  params.set("sort", filters.sort);
+
+  const trimmedQuery = query.trim();
+  if (trimmedQuery) params.set("q", trimmedQuery);
+  setIfPresent(params, "dateFrom", filters.dateFrom);
+  setIfPresent(params, "dateTo", filters.dateTo);
+  if (filters.minReactions != null && filters.minReactions > 0) {
+    params.set("minReactions", String(filters.minReactions));
+  }
+  setIfPresent(params, "gender", filters.gender);
+
+  return params;
+}
+
+export function buildBackendSearchParams(
+  searchParams: URLSearchParams,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("page", String(clampInteger(searchParams.get("page"), 1)));
+  params.set("limit", String(clampInteger(searchParams.get("limit"), 10, 50)));
+
+  const q = searchParams.get("q") ?? searchParams.get("query") ?? "";
+  setIfPresent(params, "q", q.trim());
+
+  const sort = (searchParams.get("sort") ?? "newest") as SearchFilters["sort"];
+  params.set("sortBy", frontendSortToBackendSortBy(sort));
+
+  setIfPresent(params, "startDate", searchParams.get("dateFrom"));
+  setIfPresent(params, "endDate", searchParams.get("dateTo"));
+  setIfPresent(params, "minReactions", searchParams.get("minReactions"));
+  setIfPresent(params, "gender", searchParams.get("gender"));
+
+  return params;
+}


### PR DESCRIPTION
Closes #1129.

This PR aligns frontend search serialization with the backend search DTO. The search hook now uses a shared proxy parameter builder, and the API route converts proxy params to backend DTO fields before calling `/confessions/search`. This keeps `q`, pagination, date filters, reactions filter, gender, and sort mapping consistent and supports legacy `query` by forwarding it as backend `q`.

## Validation

- `npx jest --config jest.config.ts app/lib/search/__tests__/searchParams.test.ts --runInBand`
- `npx prettier --check app/lib/search/searchParams.ts app/lib/search/__tests__/searchParams.test.ts app/api/confessions/search/route.ts app/lib/hooks/useSearch.ts app/lib/types/search.ts`
- `npx eslint app/lib/search/searchParams.ts app/lib/search/__tests__/searchParams.test.ts app/api/confessions/search/route.ts app/lib/hooks/useSearch.ts app/lib/types/search.ts`

Full frontend build is currently blocked by unrelated existing errors in admin diagnostics and comparison tool files.