### PR TITLE
feat: draft-backend-wiring

### DIFF
--- a/xconfess-backend/src/app.module.ts
+++ b/xconfess-backend/src/app.module.ts
@@ -9,6 +9,7 @@ import appConfig from './config/app.config';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfessionModule } from './confession/confession.module';
+import { ConfessionDraftModule } from './confession-draft/confession-draft.module';
 import { SearchDiscoveryModule } from './search-discovery/search-discovery.module';
 import { ReactionModule } from './reaction/reaction.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
@@ -109,6 +110,7 @@ import { BullModule } from '@nestjs/bullmq';
     UserModule,
     AuthModule,
     ConfessionModule,
+    ConfessionDraftModule,
     SearchDiscoveryModule,
     ReactionModule,
     MessagesModule,

--- a/xconfess-backend/src/confession-draft/confession-draft.controller.integration.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.controller.integration.spec.ts
@@ -1,0 +1,160 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import request from 'supertest';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ConfessionService } from '../confession/confession.service';
+import { ConfessionDraftController } from './confession-draft.controller';
+import { ConfessionDraftService } from './confession-draft.service';
+import {
+  ConfessionDraft,
+  ConfessionDraftStatus,
+} from './entities/confession-draft.entity';
+
+const AES_KEY = '12345678901234567890123456789012';
+const USER_ID = 42;
+
+describe('ConfessionDraftController (integration)', () => {
+  let app: INestApplication;
+  let repo: jest.Mocked<Repository<ConfessionDraft>>;
+  const confessionService = {
+    create: jest.fn(),
+  };
+  let drafts: ConfessionDraft[];
+  let nextId: number;
+
+  beforeAll(async () => {
+    repo = {
+      count: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      remove: jest.fn(),
+    } as unknown as jest.Mocked<Repository<ConfessionDraft>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConfessionDraftController],
+      providers: [
+        ConfessionDraftService,
+        { provide: getRepositoryToken(ConfessionDraft), useValue: repo },
+        { provide: ConfessionService, useValue: confessionService },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              key === 'app.confessionAesKey' ? AES_KEY : undefined,
+          },
+        },
+        {
+          provide: DataSource,
+          useValue: {
+            transaction: (callback: (manager: any) => unknown) =>
+              callback({ getRepository: () => repo }),
+          },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context: any) => {
+          context.switchToHttp().getRequest().user = { id: USER_ID };
+          return true;
+        },
+      })
+      .compile();
+
+    app = module.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  beforeEach(() => {
+    drafts = [];
+    nextId = 1;
+    jest.clearAllMocks();
+
+    repo.count.mockImplementation(async ({ where }: any) =>
+      drafts.filter((draft) => draft.userId === where.userId).length,
+    );
+    repo.create.mockImplementation((draft: any) => draft);
+    repo.save.mockImplementation(async (draft: any) => {
+      const existing = drafts.find((stored) => stored.id === draft.id);
+      const now = new Date();
+      const saved = {
+        ...draft,
+        id: draft.id ?? `draft-${nextId++}`,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+        version: existing ? existing.version + 1 : 1,
+        revisions: draft.revisions ?? [],
+        publishAttempts: draft.publishAttempts ?? 0,
+        lastPublishError: draft.lastPublishError ?? null,
+      } as ConfessionDraft;
+
+      drafts = existing
+        ? drafts.map((stored) => (stored.id === saved.id ? saved : stored))
+        : [...drafts, saved];
+      return saved;
+    });
+    repo.find.mockImplementation(async ({ where }: any) =>
+      drafts
+        .filter((draft) => draft.userId === where.userId)
+        .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()),
+    );
+    repo.findOne.mockImplementation(async ({ where }: any) =>
+      drafts.find((draft) => draft.id === where.id) ?? null,
+    );
+    confessionService.create.mockResolvedValue({ id: 'confession-1' });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('creates, lists, and publishes an authenticated user draft', async () => {
+    const createResponse = await request(app.getHttpServer())
+      .post('/api/confessions/drafts')
+      .set('Authorization', 'Bearer test-token')
+      .send({ content: 'A private draft' })
+      .expect(201);
+
+    expect(createResponse.body).toEqual(
+      expect.objectContaining({
+        id: 'draft-1',
+        content: 'A private draft',
+        status: ConfessionDraftStatus.DRAFT,
+      }),
+    );
+    expect(repo.count).toHaveBeenCalledWith({ where: { userId: USER_ID } });
+
+    const listResponse = await request(app.getHttpServer())
+      .get('/api/confessions/drafts')
+      .set('Authorization', 'Bearer test-token')
+      .expect(200);
+
+    expect(listResponse.body).toEqual([
+      expect.objectContaining({ id: 'draft-1', content: 'A private draft' }),
+    ]);
+
+    const publishResponse = await request(app.getHttpServer())
+      .post('/api/confessions/drafts/draft-1/publish')
+      .set('Authorization', 'Bearer test-token')
+      .expect(201);
+
+    expect(confessionService.create).toHaveBeenCalledWith(
+      { message: 'A private draft' },
+      expect.anything(),
+    );
+    expect(publishResponse.body.draft).toEqual(
+      expect.objectContaining({
+        id: 'draft-1',
+        content: 'A private draft',
+        status: ConfessionDraftStatus.POSTED,
+      }),
+    );
+  });
+});

--- a/xconfess-backend/src/confession-draft/confession-draft.queue.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.queue.ts
@@ -1,12 +1,12 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
-import { BullModule, InjectQueue } from '@nestjs/bullmq';
+import { InjectQueue } from '@nestjs/bullmq';
 import { Queue, Worker, Job } from 'bullmq';
 import { ConfigService } from '@nestjs/config';
 import { ConfessionDraftService } from './confession-draft.service';
 
 @Injectable()
 export class ConfessionDraftQueue implements OnModuleDestroy {
-  private readonly worker: Worker;
+  private readonly worker?: Worker;
   private readonly logger = new Logger(ConfessionDraftQueue.name);
 
   constructor(
@@ -15,6 +15,13 @@ export class ConfessionDraftQueue implements OnModuleDestroy {
     @InjectQueue('confession-draft-publisher')
     private readonly queue: Queue,
   ) {
+    if (this.configService.get<string>('ENABLE_BACKGROUND_JOBS') !== 'true') {
+      this.logger.log(
+        'Confession draft publisher is disabled; set ENABLE_BACKGROUND_JOBS=true to enable it.',
+      );
+      return;
+    }
+
     const redisConfig = {
       host: this.configService.get('REDIS_HOST', 'localhost'),
       port: this.configService.get('REDIS_PORT', 6379),
@@ -87,7 +94,7 @@ export class ConfessionDraftQueue implements OnModuleDestroy {
   }
 
   async onModuleDestroy() {
-    await this.worker.close();
+    await this.worker?.close();
     await this.queue.close();
   }
 }


### PR DESCRIPTION
## Closes #1114 

---

## What changed

Registers `ConfessionDraftModule` in `AppModule`, gates the draft publisher worker and recurring job behind `ENABLE_BACKGROUND_JOBS=true`, and adds an authenticated integration test covering draft creation, listing, and immediate publishing.

## Why

This activates the existing draft API routes and scheduled publisher that were unavailable because the module was not wired into the application.

## How to test

1. From a fresh checkout, install backend dependencies and configure the required database and JWT environment variables.
2. Start PostgreSQL and Redis, then set `ENABLE_BACKGROUND_JOBS=true`, `REDIS_HOST`, and `REDIS_PORT`.
3. Start the backend with `npm run dev:backend`.
4. Authenticate, then `POST /api/confessions/drafts`, `GET /api/confessions/drafts`, and `POST /api/confessions/drafts/:id/publish`; each request should return 2xx.
5. To verify scheduled publishing, create or schedule a draft for a future time and confirm the `confession-draft-publisher` worker processes it once due.
6. Run the focused test: `npm --prefix xconfess-backend test -- --runInBand src/confession-draft/confession-draft.service.spec.ts src/confession-draft/confession-draft.controller.integration.spec.ts`.

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

N/A

---

## Evidence

### Tests


- [x] Added or updated integration / e2e tests

Closes #1114 