### PR TITLE
fix: validate search params and error envelope

### DIFF
--- a/xconfess-backend/src/common/errors/app-exception.spec.ts
+++ b/xconfess-backend/src/common/errors/app-exception.spec.ts
@@ -1,48 +1,26 @@
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { BadRequestException, HttpStatus } from '@nestjs/common';
 import { AppException } from './app-exception';
 import { ErrorCode } from './error-codes';
 
 describe('AppException', () => {
-  it('should create an instance with default values', () => {
-    const exception = new AppException('Test error');
-    const response: any = exception.getResponse();
-    expect(response.message).toBe('Test error');
-    expect(response.code).toBe(ErrorCode.INTERNAL_SERVER_ERROR);
-    expect(exception.getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
-  });
+  it('normalizes validation message arrays into a readable message with field details', () => {
+    const exception = new BadRequestException({
+      message: ['q should not be empty', 'limit must not be greater than 50'],
+    });
 
-  it('should create an instance with custom values', () => {
-    const exception = new AppException(
-      'Not found',
-      ErrorCode.NOT_FOUND,
-      HttpStatus.NOT_FOUND,
-      { id: 1 },
-    );
-    const response: any = exception.getResponse();
-    expect(response.message).toBe('Not found');
-    expect(response.code).toBe(ErrorCode.NOT_FOUND);
-    expect(response.details).toEqual({ id: 1 });
-    expect(exception.getStatus()).toBe(HttpStatus.NOT_FOUND);
-  });
+    const appException = AppException.fromHttpException(exception);
+    const response = appException.getResponse() as any;
 
-  it('should create from standard HttpException', () => {
-    const httpException = new HttpException('Bad request', HttpStatus.BAD_REQUEST);
-    const appException = AppException.fromHttpException(httpException);
-    const response: any = appException.getResponse();
-    expect(response.message).toBe('Bad request');
-    expect(response.code).toBe(ErrorCode.BAD_REQUEST);
     expect(appException.getStatus()).toBe(HttpStatus.BAD_REQUEST);
-  });
-
-  it('should create from HttpException with custom response', () => {
-    const httpException = new HttpException(
-      { message: 'Custom', code: 'CUSTOM_CODE', details: 'info' },
-      HttpStatus.BAD_REQUEST,
+    expect(response.code).toBe(ErrorCode.BAD_REQUEST);
+    expect(response.message).toBe(
+      'q should not be empty; limit must not be greater than 50',
     );
-    const appException = AppException.fromHttpException(httpException);
-    const response: any = appException.getResponse();
-    expect(response.message).toBe('Custom');
-    expect(response.code).toBe('CUSTOM_CODE');
-    expect(response.details).toBe('info');
+    expect(response.details).toEqual({
+      errors: [
+        { field: 'q', message: 'q should not be empty' },
+        { field: 'limit', message: 'limit must not be greater than 50' },
+      ],
+    });
   });
 });

--- a/xconfess-backend/src/common/errors/app-exception.ts
+++ b/xconfess-backend/src/common/errors/app-exception.ts
@@ -4,7 +4,13 @@ import { ErrorCode } from './error-codes';
 export interface AppExceptionResponse {
   message: string;
   code: ErrorCode;
-  details?: any;
+  details?: unknown;
+}
+
+interface HttpExceptionObjectResponse {
+  message?: string | string[];
+  code?: ErrorCode;
+  details?: unknown;
 }
 
 export class AppException extends HttpException {
@@ -12,23 +18,33 @@ export class AppException extends HttpException {
     message: string,
     code: ErrorCode = ErrorCode.INTERNAL_SERVER_ERROR,
     status: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
-    details?: any,
+    details?: unknown,
   ) {
     super({ message, code, details }, status);
   }
 
   static fromHttpException(exception: HttpException): AppException {
     const response = exception.getResponse();
-    const status = exception.getStatus();
+    const status = exception.getStatus() as HttpStatus;
     let message = exception.message;
     let code = ErrorCode.INTERNAL_SERVER_ERROR;
-    let details: any;
+    let details: unknown;
 
     if (typeof response === 'object' && response !== null) {
-      const res = response as any;
-      message = res.message || message;
+      const res = response as HttpExceptionObjectResponse;
+      const responseMessage = res.message;
+      if (Array.isArray(responseMessage)) {
+        const validationMessages = responseMessage.map((item: unknown) =>
+          String(item),
+        );
+        message = validationMessages.join('; ') || message;
+        details =
+          res.details || this.buildValidationDetails(validationMessages);
+      } else {
+        message = responseMessage || message;
+        details = res.details;
+      }
       code = res.code || this.mapStatusToCode(status);
-      details = res.details;
     } else {
       message = typeof response === 'string' ? response : message;
       code = this.mapStatusToCode(status);
@@ -37,7 +53,26 @@ export class AppException extends HttpException {
     return new AppException(message, code as ErrorCode, status, details);
   }
 
-  private static mapStatusToCode(status: number): ErrorCode {
+  private static buildValidationDetails(messages: string[]) {
+    return {
+      errors: messages.map((validationMessage) => ({
+        field: this.extractValidationField(validationMessage),
+        message: validationMessage,
+      })),
+    };
+  }
+
+  private static extractValidationField(message: string): string {
+    const eachValueMatch = message.match(/^each value in ([\w.-]+)\s/);
+    if (eachValueMatch?.[1]) {
+      return eachValueMatch[1];
+    }
+
+    const fieldMatch = message.match(/^([\w.-]+)\s/);
+    return fieldMatch?.[1] || 'request';
+  }
+
+  private static mapStatusToCode(status: HttpStatus): ErrorCode {
     switch (status) {
       case HttpStatus.BAD_REQUEST:
         return ErrorCode.BAD_REQUEST;

--- a/xconfess-backend/src/confession/dto/search-confession.dto.spec.ts
+++ b/xconfess-backend/src/confession/dto/search-confession.dto.spec.ts
@@ -1,0 +1,65 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { SearchConfessionDto } from './search-confession.dto';
+
+const validateQuery = (query: Record<string, unknown>) =>
+  validate(plainToInstance(SearchConfessionDto, query));
+
+const messagesFor = async (query: Record<string, unknown>) =>
+  (await validateQuery(query)).flatMap((error) =>
+    Object.values(error.constraints ?? {}),
+  );
+
+describe('SearchConfessionDto', () => {
+  it('rejects an empty search term after trimming whitespace', async () => {
+    const messages = await messagesFor({ q: '   ', page: '1', limit: '10' });
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('q should not be empty'),
+      ]),
+    );
+  });
+
+  it('rejects search terms over the documented maximum length', async () => {
+    const messages = await messagesFor({
+      q: 'a'.repeat(101),
+      page: '1',
+      limit: '10',
+    });
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'q must be shorter than or equal to 100 characters',
+        ),
+      ]),
+    );
+  });
+
+  it('rejects unsupported search characters before the repository layer', async () => {
+    const messages = await messagesFor({
+      q: '<script>alert(1)</script>',
+      page: '1',
+      limit: '10',
+    });
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'q can only contain letters, numbers, spaces, and common punctuation',
+        ),
+      ]),
+    );
+  });
+
+  it('rejects limits above the documented maximum', async () => {
+    const messages = await messagesFor({ q: 'stress', page: '1', limit: '51' });
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('limit must not be greater than 50'),
+      ]),
+    );
+  });
+});

--- a/xconfess-backend/src/confession/dto/search-confession.dto.ts
+++ b/xconfess-backend/src/confession/dto/search-confession.dto.ts
@@ -3,6 +3,8 @@ import {
   IsString,
   IsNotEmpty,
   MinLength,
+  MaxLength,
+  Matches,
   IsOptional,
   IsInt,
   Min,
@@ -24,15 +26,65 @@ export enum SortBy {
   RELEVANCE = 'relevance',
 }
 
+export const SEARCH_QUERY_MAX_LENGTH = 100;
+export const SEARCH_QUERY_PATTERN = /^[\p{L}\p{N}\s.,!?'"#@&()_:-]+$/u;
+
+type TransformValue = { value: unknown };
+
+const trimString = ({ value }: TransformValue): unknown =>
+  typeof value === 'string' ? value.trim() : value;
+
+const toInteger = ({ value }: TransformValue): unknown => {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return parseInt(value, 10);
+  }
+
+  return value;
+};
+
+const toStringArray = ({ value }: TransformValue): string[] => {
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter((tag): tag is string => typeof tag === 'string');
+  }
+
+  return [];
+};
+
+const toBoolean = ({ value }: TransformValue): boolean => {
+  if (typeof value === 'string') {
+    return value === 'true';
+  }
+
+  return value === true;
+};
+
 export class SearchConfessionDto {
   @ApiProperty({
     description: 'Search query string',
     example: 'work stress',
     minLength: 1,
+    maxLength: SEARCH_QUERY_MAX_LENGTH,
   })
+  @Transform(trimString)
   @IsString()
   @IsNotEmpty()
   @MinLength(1)
+  @MaxLength(SEARCH_QUERY_MAX_LENGTH)
+  @Matches(SEARCH_QUERY_PATTERN, {
+    message:
+      'q can only contain letters, numbers, spaces, and common punctuation',
+  })
   q: string;
 
   @ApiPropertyOptional({
@@ -42,7 +94,7 @@ export class SearchConfessionDto {
     default: 1,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toInteger)
   @IsInt()
   @Min(1)
   page?: number = 1;
@@ -55,7 +107,7 @@ export class SearchConfessionDto {
     default: 10,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toInteger)
   @IsInt()
   @Min(1)
   @Max(50)
@@ -88,7 +140,9 @@ export class SearchConfessionDto {
   @IsOptional()
   @Type(() => Date)
   @IsDate()
-  @ValidateIf((o) => o.startDate !== undefined)
+  @ValidateIf(
+    (o: Pick<SearchConfessionDto, 'startDate'>) => o.startDate !== undefined,
+  )
   endDate?: Date;
 
   @ApiPropertyOptional({
@@ -97,7 +151,7 @@ export class SearchConfessionDto {
     minimum: 0,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toInteger)
   @IsNumber()
   @Min(0)
   minReactions?: number;
@@ -108,10 +162,13 @@ export class SearchConfessionDto {
     minimum: 0,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toInteger)
   @IsNumber()
   @Min(0)
-  @ValidateIf((o) => o.minReactions !== undefined)
+  @ValidateIf(
+    (o: Pick<SearchConfessionDto, 'minReactions'>) =>
+      o.minReactions !== undefined,
+  )
   maxReactions?: number;
 
   @ApiPropertyOptional({
@@ -120,7 +177,7 @@ export class SearchConfessionDto {
     minimum: 0,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toInteger)
   @IsNumber()
   @Min(0)
   minViews?: number;
@@ -131,10 +188,12 @@ export class SearchConfessionDto {
     minimum: 0,
   })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toInteger)
   @IsNumber()
   @Min(0)
-  @ValidateIf((o) => o.minViews !== undefined)
+  @ValidateIf(
+    (o: Pick<SearchConfessionDto, 'minViews'>) => o.minViews !== undefined,
+  )
   maxViews?: number;
 
   @ApiPropertyOptional({
@@ -145,15 +204,7 @@ export class SearchConfessionDto {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      return value
-        .split(',')
-        .map((tag) => tag.trim())
-        .filter((tag) => tag.length > 0);
-    }
-    return Array.isArray(value) ? value : [];
-  })
+  @Transform(toStringArray)
   tags?: string[];
 
   @ApiPropertyOptional({
@@ -162,12 +213,7 @@ export class SearchConfessionDto {
     default: false,
   })
   @IsOptional()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      return value === 'true';
-    }
-    return value === true;
-  })
+  @Transform(toBoolean)
   @IsBoolean()
   anonymousOnly?: boolean;
 
@@ -187,12 +233,7 @@ export class SearchConfessionDto {
     default: false,
   })
   @IsOptional()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      return value === 'true';
-    }
-    return value === true;
-  })
+  @Transform(toBoolean)
   @IsBoolean()
   requiresReview?: boolean;
 

--- a/xconfess-backend/test/api-error-contract.e2e-spec.ts
+++ b/xconfess-backend/test/api-error-contract.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from './../src/app.module';
 import { HttpExceptionFilter } from './../src/common/filters/http-exception.filter';
 import { ThrottlerExceptionFilter } from './../src/common/filters/throttler-exception.filter';
@@ -62,6 +62,23 @@ describe('API Error Contract (e2e)', () => {
 
       expectErrorEnvelope(response, 400);
       expect(response.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('should return field-level search validation errors in the standard envelope', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: '   ', limit: 51 });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+      expect(response.body.details).toEqual(
+        expect.objectContaining({
+          errors: expect.arrayContaining([
+            expect.objectContaining({ field: 'q' }),
+            expect.objectContaining({ field: 'limit' }),
+          ]),
+        }),
+      );
     });
   });
 
@@ -136,7 +153,11 @@ describe('API Error Contract (e2e)', () => {
       // This verifies the structure of rate limit error responses
       const response = await request(app.getHttpServer())
         .post('/reactions')
-        .send({ confessionId: 'test-id', anonymousUserId: 'test-user', emoji: 'like' });
+        .send({
+          confessionId: 'test-id',
+          anonymousUserId: 'test-user',
+          emoji: 'like',
+        });
       // The endpoint may return 404 (route exists but validation fails) or other status
       // Key point: any 429 response should have the predictable envelope
       expect(response.body).toHaveProperty('status');


### PR DESCRIPTION
Closes #1128.

This PR validates search query parameters before reaching the repository layer and keeps validation failures in the API error envelope. It trims `q`, rejects whitespace-only queries, enforces a 100-character max, rejects unsupported characters, and preserves the existing `limit <= 50` behavior. Validation error arrays are normalized into a readable `message` plus `details.errors` entries keyed by field.

## Validation

- `npx jest --config jest.config.js src/confession/dto/search-confession.dto.spec.ts src/common/errors/app-exception.spec.ts --runInBand`
- `npx prettier --check src/confession/dto/search-confession.dto.ts src/confession/dto/search-confession.dto.spec.ts src/common/errors/app-exception.ts src/common/errors/app-exception.spec.ts test/api-error-contract.e2e-spec.ts`
- `npx eslint src/confession/dto/search-confession.dto.ts src/confession/dto/search-confession.dto.spec.ts src/common/errors/app-exception.ts src/common/errors/app-exception.spec.ts test/api-error-contract.e2e-spec.ts`

Full build/e2e are currently blocked by existing unrelated repository errors in admin, health, and tipping modules.