### PR TITLE
feat(scripts): add Wave 5 local demo seed command

### DIFF
--- a/docs/local-demo-data-seed-guide.md
+++ b/docs/local-demo-data-seed-guide.md
@@ -3,9 +3,9 @@
 ## Overview
 
 Use this guide to prepare local data for the Wave 5 walkthrough in
-[`docs/DEMO_SCRIPT.md`](./DEMO_SCRIPT.md). The repository does not currently
-include a one-shot demo seed script, so prepare the dataset with the local
-stack, the UI, and the existing backend API/database surfaces listed below.
+[`docs/DEMO_SCRIPT.md`](./DEMO_SCRIPT.md). The backend includes a one-shot demo seed script for the local stack. Use it
+after the database schema exists to create the standard users, feed content,
+comments, reactions, and sample tip rows used by the walkthrough.
 
 Keep all data local and disposable. Do not use production exports, real user
 content, live private keys, or private URLs in demo records.
@@ -50,49 +50,54 @@ content, live private keys, or private URLs in demo records.
    ./scripts/smoke-test.sh
    ```
 
-## Running Seed Scripts
+## Running the Demo Seed
 
-There is no dedicated demo-data seed command in `package.json` or
-`xconfess-backend/package.json` at the time of writing. Relevant existing
-helpers are:
+Run the seed after the database schema exists. With the default local env copied
+from `xconfess-backend/.env.example`, the command is:
 
-- `compose.yaml` for local Postgres and Redis.
-- `xconfess-backend/.env.example` for local database and Redis settings.
-- `xconfess-backend/data-source.ts` plus `xconfess-backend/migrations/` for
-  TypeORM migration setup.
-- `scripts/smoke-test.sh` for confirming the local frontend and backend are up.
-- Backend Swagger at `http://localhost:5000/api/api-docs` after the backend
-  starts.
+```bash
+npm run seed:demo --workspace=xconfess-backend
+```
 
-For a clean local demo, reset the Docker volume if needed, then recreate the
-schema with `TYPEORM_SYNCHRONIZE=true` in `xconfess-backend/.env`.
+The command is safe to re-run. Existing demo users and confessions are updated,
+and reaction/comment rows that already exist are skipped. If the database cannot
+be reached or the local confession AES key is not exactly 32 characters, the
+command exits non-zero.
+
+## Demo Credentials
+
+All seeded accounts use the local-only password `Wave5DemoPass!2026`.
+
+| Role         | Username       | Email                       |
+| ------------ | -------------- | --------------------------- |
+| Regular user | `wave5_user`   | `wave5-user@example.test`   |
+| Regular user | `wave5_friend` | `wave5-friend@example.test` |
+| Admin        | `wave5_admin`  | `wave5-admin@example.test`  |
 
 ## Minimum Demo Dataset
 
 Prepare at least:
 
-| Area          | Minimum records                                               | How to create                                                                                |
-| ------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Users         | 1 regular user, 1 admin user                                  | UI/API, then promote admin locally in DB                                                     |
-| Confessions   | 3 visible confessions with distinct text and tags             | UI or `POST /api/confessions`                                                                |
-| Reactions     | 2 reactions on one confession and 1 reaction on another       | UI or `POST /api/reactions`                                                                  |
-| Comments      | 2 top-level comments and 1 reply                              | UI or `POST /api/comments/:confessionId`                                                     |
-| Reports       | 1 pending report tied to a visible confession                 | UI or report API                                                                             |
-| Notifications | 2 notifications for the regular user, one unread and one read | Direct DB insert                                                                             |
-| Tips          | 1 verified or pending local tip tied to a confession          | Direct DB insert, or `POST /api/confessions/:id/tips/verify` with a real testnet transaction |
+| Area        | Minimum records                                         | How to create                                    |
+| ----------- | ------------------------------------------------------- | ------------------------------------------------ |
+| Users       | 2 regular users, 1 admin user                           | `npm run seed:demo --workspace=xconfess-backend` |
+| Confessions | 3 visible confessions with distinct demo text           | `npm run seed:demo --workspace=xconfess-backend` |
+| Reactions   | 2 reactions on one confession and 1 reaction on another | `npm run seed:demo --workspace=xconfess-backend` |
+| Comments    | 2 top-level comments and 1 nested reply                 | `npm run seed:demo --workspace=xconfess-backend` |
+| Tips        | 1 verified sample tip and 1 pending sample tip          | `npm run seed:demo --workspace=xconfess-backend` |
 
 ## UI-Created Data
 
-Use the UI for the records that the Wave 5 demo is meant to exercise directly:
+Use the UI for extra records that the Wave 5 demo is meant to exercise beyond the seeded baseline:
 
 1. Register or log in as a regular user at `http://localhost:3000`.
 2. Create at least three confessions from the composer.
 3. Add reactions from the feed or confession detail page.
 4. Add comments and one nested reply from a confession detail page.
 5. Report one confession from the regular user session.
-6. Register or log in as the future admin user.
+6. Log in as the seeded admin user if you need the admin review walkthrough.
 
-Promote the admin user only in your local database:
+If you created an extra admin account manually, promote it only in your local database:
 
 ```sql
 UPDATE "user"

--- a/xconfess-backend/.env.example
+++ b/xconfess-backend/.env.example
@@ -27,8 +27,9 @@ APP_SECRET=change-me-to-a-long-local-app-secret
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
-# Confession encryption key: 64-character hex string
+# Confession encryption keys
 CONFESSION_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
+CONFESSION_AES_KEY=local-demo-confession-aes-key-32
 
 # Stellar
 # Set to true in environments that require on-chain anchoring/tipping (all contract IDs below become required).

--- a/xconfess-backend/package.json
+++ b/xconfess-backend/package.json
@@ -13,6 +13,7 @@
     "start:dev": "ts-node -r tsconfig-paths/register src/main.ts",
     "start:debug": "node --inspect -r ts-node/register -r tsconfig-paths/register src/main.ts",
     "start:prod": "node dist/main",
+    "seed:demo": "ts-node -r tsconfig-paths/register scripts/seed-demo.ts",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings=0",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest --config jest.config.js",

--- a/xconfess-backend/scripts/seed-demo.ts
+++ b/xconfess-backend/scripts/seed-demo.ts
@@ -1,0 +1,444 @@
+import 'reflect-metadata';
+
+import { createHash } from 'crypto';
+import * as bcrypt from 'bcryptjs';
+import { DataSource } from 'typeorm';
+import dataSource from '../data-source';
+import { Comment } from '../src/comment/entities/comment.entity';
+import { CryptoUtil } from '../src/common/crypto.util';
+import { AnonymousConfession } from '../src/confession/entities/confession.entity';
+import { Gender } from '../src/confession/dto/get-confessions.dto';
+import { Reaction } from '../src/reaction/entities/reaction.entity';
+import { Tip, TipVerificationStatus } from '../src/tipping/entities/tip.entity';
+import { AnonymousUser } from '../src/user/entities/anonymous-user.entity';
+import { UserAnonymousUser } from '../src/user/entities/user-anonymous-link.entity';
+import { User, UserRole } from '../src/user/entities/user.entity';
+import { encryptConfession } from '../src/utils/confession-encryption';
+
+const DEMO_PASSWORD = 'Wave5DemoPass!2026';
+const LOCAL_CONFESSION_AES_KEY = 'local-demo-confession-aes-key-32';
+const BUCKETS = [
+  'users',
+  'anonymousUsers',
+  'confessions',
+  'reactions',
+  'comments',
+  'tips',
+] as const;
+
+type Bucket = (typeof BUCKETS)[number];
+type Action = 'created' | 'updated' | 'skipped';
+type SeedReport = Record<Bucket, Record<Action, number>>;
+
+const USERS = [
+  {
+    key: 'regular',
+    username: 'wave5_user',
+    email: 'wave5-user@example.test',
+    role: UserRole.USER,
+  },
+  {
+    key: 'friend',
+    username: 'wave5_friend',
+    email: 'wave5-friend@example.test',
+    role: UserRole.USER,
+  },
+  {
+    key: 'admin',
+    username: 'wave5_admin',
+    email: 'wave5-admin@example.test',
+    role: UserRole.ADMIN,
+  },
+] as const;
+
+const CONFESSIONS = [
+  {
+    key: 'launch-checkin',
+    ownerKey: 'regular',
+    message: 'Wave 5 demo: shipping a calmer launch after a long week.',
+    gender: Gender.OTHER,
+  },
+  {
+    key: 'team-support',
+    ownerKey: 'friend',
+    message: 'Wave 5 demo: a teammate helped turn a rough day around.',
+    gender: Gender.FEMALE,
+  },
+  {
+    key: 'tip-readiness',
+    ownerKey: 'regular',
+    message: 'Wave 5 demo: validating anonymous tips before the walkthrough.',
+    gender: Gender.MALE,
+  },
+] as const;
+
+const REACTIONS = [
+  { actorKey: 'friend', confessionKey: 'launch-checkin', emoji: 'like' },
+  { actorKey: 'admin', confessionKey: 'launch-checkin', emoji: 'heart' },
+  { actorKey: 'regular', confessionKey: 'team-support', emoji: 'support' },
+] as const;
+
+const COMMENTS = [
+  {
+    key: 'launch-support',
+    actorKey: 'friend',
+    confessionKey: 'launch-checkin',
+    content: 'Rooting for this launch. The checklist looks solid.',
+  },
+  {
+    key: 'team-thanks',
+    actorKey: 'regular',
+    confessionKey: 'team-support',
+    content: 'This is exactly the kind of support worth calling out.',
+  },
+  {
+    key: 'launch-admin-reply',
+    actorKey: 'admin',
+    confessionKey: 'launch-checkin',
+    content: 'Admin demo reply for nested comment moderation checks.',
+    parentKey: 'launch-support',
+  },
+] as const;
+
+const TIPS = [
+  {
+    key: 'tip-1',
+    confessionKey: 'launch-checkin',
+    amount: 1.25,
+    status: TipVerificationStatus.VERIFIED,
+  },
+  {
+    key: 'tip-2',
+    confessionKey: 'tip-readiness',
+    amount: 2.5,
+    status: TipVerificationStatus.PENDING,
+  },
+] as const;
+
+function stableHex(seed: string): string {
+  return createHash('sha256').update(seed).digest('hex');
+}
+
+function stableUuid(seed: string): string {
+  const hex = stableHex(seed);
+  const variant = ((parseInt(hex[16], 16) & 0x3) | 0x8).toString(16);
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    '4' + hex.slice(13, 16),
+    variant + hex.slice(17, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+function createReport(): SeedReport {
+  return Object.fromEntries(
+    BUCKETS.map((bucket) => [bucket, { created: 0, updated: 0, skipped: 0 }]),
+  ) as SeedReport;
+}
+
+function mark(report: SeedReport, bucket: Bucket, action: Action): void {
+  report[bucket][action] += 1;
+}
+
+function getConfessionAesKey(): string {
+  const key = process.env.CONFESSION_AES_KEY || LOCAL_CONFESSION_AES_KEY;
+  if (key.length !== 32) {
+    throw new Error('CONFESSION_AES_KEY must be exactly 32 characters.');
+  }
+  return key;
+}
+
+async function seedUsers(
+  source: DataSource,
+  report: SeedReport,
+): Promise<Map<string, User>> {
+  const userRepo = source.getRepository(User);
+  const users = new Map<string, User>();
+
+  for (const seed of USERS) {
+    const email = seed.email.toLowerCase();
+    const emailHash = CryptoUtil.hash(email);
+    const usernameOwner = await userRepo.findOne({
+      where: { username: seed.username },
+    });
+
+    if (usernameOwner && usernameOwner.emailHash !== emailHash) {
+      throw new Error('Demo username already belongs to another local account: ' + seed.username);
+    }
+
+    const encryptedEmail = CryptoUtil.encrypt(email);
+    const existing = await userRepo.findOne({ where: { emailHash } });
+    const user = existing ?? userRepo.create();
+    user.username = seed.username;
+    user.password = await bcrypt.hash(DEMO_PASSWORD, 10);
+    user.emailEncrypted = encryptedEmail.encrypted;
+    user.emailIv = encryptedEmail.iv;
+    user.emailTag = encryptedEmail.tag;
+    user.emailHash = emailHash;
+    user.role = seed.role;
+    user.is_active = true;
+    user.notificationPreferences = {};
+    user.privacySettings = {
+      isDiscoverable: true,
+      canReceiveReplies: true,
+      showReactions: true,
+      dataProcessingConsent: true,
+    };
+
+    users.set(seed.key, await userRepo.save(user));
+    mark(report, 'users', existing ? 'updated' : 'created');
+  }
+
+  return users;
+}
+
+async function seedAnonymousUsers(
+  source: DataSource,
+  users: Map<string, User>,
+  report: SeedReport,
+): Promise<Map<string, AnonymousUser>> {
+  const anonymousRepo = source.getRepository(AnonymousUser);
+  const linkRepo = source.getRepository(UserAnonymousUser);
+  const anonymousUsers = new Map<string, AnonymousUser>();
+
+  for (const seed of USERS) {
+    const id = stableUuid('wave5-anonymous-user:' + seed.key);
+    const existing = await anonymousRepo.findOne({ where: { id } });
+    const anonymousUser = existing ?? anonymousRepo.create({ id });
+    const savedAnonymousUser = await anonymousRepo.save(anonymousUser);
+    const user = users.get(seed.key);
+
+    if (!user) throw new Error('Missing seeded user for ' + seed.key);
+
+    const existingLink = await linkRepo.findOne({
+      where: { userId: user.id, anonymousUserId: savedAnonymousUser.id },
+    });
+
+    if (!existingLink) {
+      await linkRepo.save(
+        linkRepo.create({
+          id: stableUuid('wave5-user-link:' + seed.key),
+          userId: user.id,
+          anonymousUserId: savedAnonymousUser.id,
+        }),
+      );
+    }
+
+    anonymousUsers.set(seed.key, savedAnonymousUser);
+    mark(report, 'anonymousUsers', existing ? 'skipped' : 'created');
+  }
+
+  return anonymousUsers;
+}
+
+async function seedConfessions(
+  source: DataSource,
+  anonymousUsers: Map<string, AnonymousUser>,
+  report: SeedReport,
+): Promise<Map<string, AnonymousConfession>> {
+  const confessionRepo = source.getRepository(AnonymousConfession);
+  const confessions = new Map<string, AnonymousConfession>();
+  const aesKey = getConfessionAesKey();
+
+  for (const seed of CONFESSIONS) {
+    const anonymousUser = anonymousUsers.get(seed.ownerKey);
+    if (!anonymousUser) throw new Error('Missing anonymous user for ' + seed.ownerKey);
+
+    const idempotencyKey = 'wave5-demo-confession-' + seed.key;
+    const existing = await confessionRepo.findOne({ where: { idempotencyKey } });
+    const confession =
+      existing ??
+      confessionRepo.create({
+        id: stableUuid('wave5-confession:' + seed.key),
+        idempotencyKey,
+      });
+
+    confession.message = encryptConfession(seed.message, aesKey);
+    confession.gender = seed.gender;
+    confession.anonymousUser = anonymousUser;
+    confession.anonymousUserId = anonymousUser.id;
+    confession.view_count = 0;
+    confession.isDeleted = false;
+    confession.deletedAt = null;
+    confession.deletedBy = null;
+    confession.moderationScore = 0;
+    confession.moderationFlags = [];
+    confession.moderationStatus = 'approved';
+    confession.requiresReview = false;
+    confession.isHidden = false;
+    confession.moderationDetails = {};
+
+    confessions.set(seed.key, await confessionRepo.save(confession));
+    mark(report, 'confessions', existing ? 'updated' : 'created');
+  }
+
+  return confessions;
+}
+
+async function seedReactions(
+  source: DataSource,
+  anonymousUsers: Map<string, AnonymousUser>,
+  confessions: Map<string, AnonymousConfession>,
+  report: SeedReport,
+): Promise<void> {
+  const reactionRepo = source.getRepository(Reaction);
+
+  for (const seed of REACTIONS) {
+    const id = stableUuid(
+      'wave5-reaction:' + seed.actorKey + ':' + seed.confessionKey + ':' + seed.emoji,
+    );
+    const existing = await reactionRepo.findOne({ where: { id } });
+
+    if (existing) {
+      mark(report, 'reactions', 'skipped');
+      continue;
+    }
+
+    const anonymousUser = anonymousUsers.get(seed.actorKey);
+    const confession = confessions.get(seed.confessionKey);
+    if (!anonymousUser || !confession) throw new Error('Missing reaction relation for ' + id);
+
+    await reactionRepo.save(
+      reactionRepo.create({ id, emoji: seed.emoji, anonymousUser, confession }),
+    );
+    mark(report, 'reactions', 'created');
+  }
+}
+
+async function seedComments(
+  source: DataSource,
+  anonymousUsers: Map<string, AnonymousUser>,
+  confessions: Map<string, AnonymousConfession>,
+  report: SeedReport,
+): Promise<void> {
+  const commentRepo = source.getRepository(Comment);
+  const comments = new Map<string, Comment>();
+
+  for (const seed of COMMENTS) {
+    const anonymousUser = anonymousUsers.get(seed.actorKey);
+    const confession = confessions.get(seed.confessionKey);
+    const parent = 'parentKey' in seed && seed.parentKey ? comments.get(seed.parentKey) : undefined;
+    if (!anonymousUser || !confession) throw new Error('Missing comment relation for ' + seed.key);
+    if ('parentKey' in seed && seed.parentKey && !parent) throw new Error('Missing parent comment for ' + seed.key);
+
+    let query = commentRepo
+      .createQueryBuilder('comment')
+      .leftJoin('comment.confession', 'confession')
+      .leftJoin('comment.anonymousUser', 'anonymousUser')
+      .where('comment.content = :content', { content: seed.content })
+      .andWhere('confession.id = :confessionId', { confessionId: confession.id })
+      .andWhere('anonymousUser.id = :anonymousUserId', {
+        anonymousUserId: anonymousUser.id,
+      });
+
+    query = parent
+      ? query.andWhere('comment.parent_id = :parentId', { parentId: parent.id })
+      : query.andWhere('comment.parent_id IS NULL');
+
+    const existing = await query.getOne();
+    if (existing) {
+      comments.set(seed.key, existing);
+      mark(report, 'comments', 'skipped');
+      continue;
+    }
+
+    const comment = commentRepo.create({
+      content: seed.content,
+      anonymousUser,
+      confession,
+      anonymousContextId: anonymousUser.id,
+      parent,
+      isDeleted: false,
+    });
+
+    comments.set(seed.key, await commentRepo.save(comment));
+    mark(report, 'comments', 'created');
+  }
+}
+
+async function seedTips(
+  source: DataSource,
+  confessions: Map<string, AnonymousConfession>,
+  report: SeedReport,
+): Promise<void> {
+  const tipRepo = source.getRepository(Tip);
+
+  for (const seed of TIPS) {
+    const confession = confessions.get(seed.confessionKey);
+    if (!confession) throw new Error('Missing confession for tip ' + seed.key);
+
+    const txId = stableHex('wave5-demo-tip:' + seed.key);
+    const existing = await tipRepo.findOne({ where: { txId } });
+    const tip = existing ?? tipRepo.create({ id: stableUuid('wave5-tip:' + seed.key) });
+
+    tip.confession = confession;
+    tip.confessionId = confession.id;
+    tip.amount = seed.amount;
+    tip.txId = txId;
+    tip.idempotencyKey = 'wave5-demo-tip-' + seed.key;
+    tip.senderAddress = null;
+    tip.verificationStatus = seed.status;
+    tip.verifiedAt = seed.status === TipVerificationStatus.VERIFIED ? new Date() : null;
+    tip.rejectionReason = null;
+    tip.retryCount = 0;
+    tip.lastChainStatus = seed.status;
+    tip.lastCheckedAt = tip.verifiedAt;
+    tip.reconciliationMetadata = { source: 'local-demo-seed' };
+
+    await tipRepo.save(tip);
+    mark(report, 'tips', existing ? 'updated' : 'created');
+  }
+}
+
+export async function seedDemoRecords(source: DataSource): Promise<SeedReport> {
+  const report = createReport();
+  const users = await seedUsers(source, report);
+  const anonymousUsers = await seedAnonymousUsers(source, users, report);
+  const confessions = await seedConfessions(source, anonymousUsers, report);
+
+  await seedReactions(source, anonymousUsers, confessions, report);
+  await seedComments(source, anonymousUsers, confessions, report);
+  await seedTips(source, confessions, report);
+
+  return report;
+}
+
+function printReport(report: SeedReport): void {
+  console.log('Seeded Wave 5 local demo data.');
+  for (const bucket of BUCKETS) {
+    const value = report[bucket];
+    console.log(
+      '- ' +
+        bucket +
+        ': created ' +
+        value.created +
+        ', updated ' +
+        value.updated +
+        ', skipped ' +
+        value.skipped,
+    );
+  }
+  console.log('');
+  console.log('Demo credentials:');
+  console.log('- wave5_user / ' + DEMO_PASSWORD);
+  console.log('- wave5_friend / ' + DEMO_PASSWORD);
+  console.log('- wave5_admin / ' + DEMO_PASSWORD);
+}
+
+async function main(): Promise<void> {
+  try {
+    await dataSource.initialize();
+    printReport(await seedDemoRecords(dataSource));
+  } finally {
+    if (dataSource.isInitialized) await dataSource.destroy();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed to seed Wave 5 demo data: ' + message);
+    process.exitCode = 1;
+  });
+}

--- a/xconfess-backend/src/config/app.config.ts
+++ b/xconfess-backend/src/config/app.config.ts
@@ -12,6 +12,7 @@ export default registerAs('app', () => ({
   backendUrl: process.env.BACKEND_URL ?? '',
   appSecret: process.env.APP_SECRET ?? '',
   confessionEncryptionKey: process.env.CONFESSION_ENCRYPTION_KEY ?? '',
+  confessionAesKey: process.env.CONFESSION_AES_KEY ?? '',
 
   /**
    * Search observability settings.


### PR DESCRIPTION
## Summary

Adds a local Wave 5 demo seed command that prepares a repeatable contributor walkthrough dataset:

- Adds `npm run seed:demo --workspace=xconfess-backend`.
- Seeds local-only demo users, confessions, reactions, comments, and sample tips.
- Keeps the command safe to re-run by updating stable demo users/confessions and skipping existing reaction/comment rows.
- Documents local demo credentials and the seed flow in `docs/local-demo-data-seed-guide.md`.
- Exposes the local confession AES key used by the existing confession read/write path.

## Verification

Static preparation only in this environment; the full compose-backed DB/browser smoke test was not run here.

Expected manual checks for reviewers:

1. Copy `xconfess-backend/.env.example` to `xconfess-backend/.env`.
2. Start the local stack and ensure the database schema exists.
3. Run `npm run seed:demo --workspace=xconfess-backend`.
4. Re-run the command and confirm it does not create duplicate-key failures.
5. Open the local feed and confirm seeded confessions are visible.

Closes #1117