### PR TITLE
fix(backend): register confession draft module

### DIFF
--- a/xconfess-backend/src/app.module.ts
+++ b/xconfess-backend/src/app.module.ts
@@ -28,6 +28,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { EncryptionModule } from './encryption/encryption.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { DatabaseModule } from './database/database.module';
+import { ConfessionDraftModule } from './confession-draft/confession-draft.module';
 // ✅ Canonical queue stack: @nestjs/bullmq (BullMQ v4 + ioredis)
 // The legacy @nestjs/bull import has been removed. All queues use BullMQ.
 import { BullModule } from '@nestjs/bullmq';
@@ -109,6 +110,7 @@ import { BullModule } from '@nestjs/bullmq';
     UserModule,
     AuthModule,
     ConfessionModule,
+    ConfessionDraftModule,
     SearchDiscoveryModule,
     ReactionModule,
     MessagesModule,

--- a/xconfess-backend/src/confession-draft/confession-draft.module.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.module.spec.ts
@@ -1,0 +1,99 @@
+import { getQueueToken } from '@nestjs/bullmq';
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { AppModule } from '../app.module';
+import { ConfessionService } from '../confession/confession.service';
+import { ConfessionDraftQueue } from './confession-draft.queue';
+import { ConfessionDraftModule } from './confession-draft.module';
+import { ConfessionDraftService } from './confession-draft.service';
+import { ConfessionDraft } from './entities/confession-draft.entity';
+
+describe('ConfessionDraftModule registration', () => {
+  const mockRepository = () => ({
+    count: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+  });
+
+  const mockQueue = {
+    add: jest.fn(),
+    close: jest.fn(),
+  };
+
+  let moduleRef: TestingModule;
+
+  beforeEach(async () => {
+    moduleRef = await Test.createTestingModule({
+      providers: [
+        ConfessionDraftService,
+        ConfessionDraftQueue,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, fallback?: unknown) => {
+              if (key === 'ENABLE_BACKGROUND_JOBS') return 'false';
+              if (key === 'app.confessionAesKey') {
+                return '12345678901234567890123456789012';
+              }
+              return fallback ?? null;
+            }),
+          },
+        },
+        {
+          provide: getRepositoryToken(ConfessionDraft),
+          useFactory: mockRepository,
+        },
+        { provide: ConfessionService, useValue: { create: jest.fn() } },
+        {
+          provide: DataSource,
+          useValue: {
+            transaction: jest.fn(async (cb: any) =>
+              cb({ getRepository: mockRepository }),
+            ),
+          },
+        },
+        {
+          provide: getQueueToken('confession-draft-publisher'),
+          useValue: mockQueue,
+        },
+      ],
+    }).compile();
+  });
+
+  afterEach(async () => {
+    await moduleRef?.close();
+    jest.clearAllMocks();
+  });
+
+  it('is imported by AppModule so draft routes are active at boot', () => {
+    const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, AppModule) ?? [];
+
+    expect(imports).toContain(ConfessionDraftModule);
+  });
+
+  it('registers the publisher queue on the feature module', () => {
+    const imports =
+      Reflect.getMetadata(MODULE_METADATA.IMPORTS, ConfessionDraftModule) ?? [];
+
+    const hasPublisherQueueRegistration = imports.some((importedModule: any) =>
+      importedModule?.providers?.some?.(
+        (provider: any) =>
+          provider?.provide === getQueueToken('confession-draft-publisher'),
+      ),
+    );
+
+    expect(hasPublisherQueueRegistration).toBe(true);
+  });
+
+  it('resolves the draft service and queue without starting jobs when disabled', () => {
+    expect(moduleRef.get(ConfessionDraftService)).toBeDefined();
+    expect(moduleRef.get(ConfessionDraftQueue)).toBeDefined();
+    expect(mockQueue.add).not.toHaveBeenCalled();
+  });
+});

--- a/xconfess-backend/src/confession-draft/confession-draft.queue.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.queue.ts
@@ -1,12 +1,12 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
-import { BullModule, InjectQueue } from '@nestjs/bullmq';
+import { InjectQueue } from '@nestjs/bullmq';
 import { Queue, Worker, Job } from 'bullmq';
 import { ConfigService } from '@nestjs/config';
 import { ConfessionDraftService } from './confession-draft.service';
 
 @Injectable()
 export class ConfessionDraftQueue implements OnModuleDestroy {
-  private readonly worker: Worker;
+  private readonly worker?: Worker;
   private readonly logger = new Logger(ConfessionDraftQueue.name);
 
   constructor(
@@ -15,6 +15,13 @@ export class ConfessionDraftQueue implements OnModuleDestroy {
     @InjectQueue('confession-draft-publisher')
     private readonly queue: Queue,
   ) {
+    if (this.configService.get<string>('ENABLE_BACKGROUND_JOBS') !== 'true') {
+      this.logger.log(
+        'Confession draft publisher disabled because ENABLE_BACKGROUND_JOBS is not true',
+      );
+      return;
+    }
+
     const redisConfig = {
       host: this.configService.get('REDIS_HOST', 'localhost'),
       port: this.configService.get('REDIS_PORT', 6379),
@@ -87,7 +94,7 @@ export class ConfessionDraftQueue implements OnModuleDestroy {
   }
 
   async onModuleDestroy() {
-    await this.worker.close();
+    await this.worker?.close();
     await this.queue.close();
   }
 }


### PR DESCRIPTION
## Closes

Closes #1114

---

## What changed

Registers `ConfessionDraftModule` in `AppModule` so the existing draft controller, service, repository, and publisher queue become part of the backend application.

Also gates the draft publisher worker startup behind `ENABLE_BACKGROUND_JOBS=true`, so importing the module does not start the recurring Redis-backed publisher in local/API-only runs.

Adds module registration coverage for:

- `AppModule` importing `ConfessionDraftModule`
- `ConfessionDraftModule` registering the `confession-draft-publisher` queue
- the draft service and queue resolving without scheduling jobs when background jobs are disabled

## Why

The draft feature files already existed, but the module was not wired into the application entrypoint, leaving draft routes and scheduled publishing inactive at runtime.

## How to test

1. Run `npm run test --workspace=xconfess-backend -- src/confession-draft/confession-draft.module.spec.ts src/confession-draft/confession-draft.service.spec.ts --runInBand`.
2. Start the backend and confirm authenticated `/api/confessions/drafts` routes are available.
3. With `ENABLE_BACKGROUND_JOBS=true` and Redis configured, confirm the `confession-draft-publisher` recurring job is scheduled.
4. With `ENABLE_BACKGROUND_JOBS=false`, confirm importing the draft module does not schedule publisher jobs.

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines <= 400 and files touched <= 8 (excluding lockfiles and generated files)

---

## Evidence

### Tests

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output:

```
Not run in this browser-only environment because Node/npm are not available on PATH.
Targeted test command is listed above for reviewer verification.
```

### Screenshots (UI changes only)

N/A — backend-only change.

---

## Checklist

- [x] Branch is up to date with `main`
- [ ] All CI checks pass
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)