### PR TITLE
docs: clean up README merge artifact and document GrantFox labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,27 +199,11 @@ When your PR is ready for review, use the [Ready for Review comment template](do
 
 When reporting bugs, see [Attaching Logs to Issues and PRs](docs/LOG_ATTACHING_GUIDE.md) for redaction guidelines.
 
+## GrantFox Campaign
+
+xConfess participates in the GrantFox Official Campaign. All related pull requests must include the labels `GrantFox OSS`, `Official Campaign`, and `Maybe Rewarded`. Ensure you link your PR to its corresponding issue using `Closes #ISSUE_NUMBER`. For more details, refer to the contributor guide gf-09 (link to be added once published).
+
 ## Package Docs
 - `xconfess-backend/README.md`
 - `xconfess-frontend/README.md`
 - `xconfess-contracts/README.md`
-# README.md — contributing section patch
-
-Find the **Contributing** section in `README.md` and insert the two lines marked `+` below.
-The surrounding lines are shown for context; do not duplicate them.
-
-```diff
- ## Contributing
-
- xConfess participates in Stellar Wave. Check the open issues for work tagged
- Stellar Wave, then coordinate before opening a PR.
-+
-+Before opening a PR, read the [small PR policy](docs/SMALL_PR_POLICY.md).
-+Keep each PR focused on one issue, include tests for code changes, and
-+screenshots for UI changes.
-
- When your PR is ready for review, use the Ready for Review comment template
- to signal maintainers.
-```
-
-That is the only change to `README.md`.


### PR DESCRIPTION
Removes a corrupted merge-artifact block at the end of `README.md` (leftover patch-style instructions that shouldn't be in the rendered doc) and adds a short GrantFox Campaign section. 

This new section documents:
* Required PR labels (`GrantFox OSS`, `Official Campaign`, `Maybe Rewarded`)
* The `Closes #ISSUE_NUMBER` linking requirement
* A placeholder link for the `gf-09` contributor guide

No other sections were modified. 

Closes #1137.
