### PR TITLE
fix(#1129): align search proxy params with backend DTO

### DIFF
--- a/xconfess-frontend/app/api/confessions/search/route.ts
+++ b/xconfess-frontend/app/api/confessions/search/route.ts
@@ -36,10 +36,12 @@ export async function GET(request: Request) {
   const backendParams = new URLSearchParams();
   backendParams.set("page", String(page));
   backendParams.set("limit", String(limit));
-  backendParams.set("sort", sort);
+  // Map frontend 'sort' to backend 'sortBy' enum
+  if (sort && sort !== "newest") backendParams.set("sortBy", sort);
   if (q) backendParams.set("q", q);
-  if (dateFrom) backendParams.set("dateFrom", dateFrom);
-  if (dateTo) backendParams.set("dateTo", dateTo);
+  // Map frontend 'dateFrom'/'dateTo' to backend 'startDate'/'endDate'
+  if (dateFrom) backendParams.set("startDate", dateFrom);
+  if (dateTo) backendParams.set("endDate", dateTo);
   if (minReactions != null && minReactions !== "")
     backendParams.set("minReactions", minReactions);
   if (gender) backendParams.set("gender", gender);

--- a/xconfess-frontend/app/lib/hooks/useSearch.ts
+++ b/xconfess-frontend/app/lib/hooks/useSearch.ts
@@ -237,11 +237,11 @@ export function useSearch({
     const params = new URLSearchParams();
     params.set("page", String(page));
     params.set("limit", "10");
-    params.set("sort", filters.sort);
+    if (filters.sort && filters.sort !== "newest") params.set("sortBy", filters.sort);
 
     if (debouncedQuery.trim()) params.set("q", debouncedQuery.trim());
-    if (filters.dateFrom) params.set("dateFrom", filters.dateFrom);
-    if (filters.dateTo) params.set("dateTo", filters.dateTo);
+    if (filters.dateFrom) params.set("startDate", filters.dateFrom);
+    if (filters.dateTo) params.set("endDate", filters.dateTo);
     if (filters.minReactions != null && filters.minReactions > 0) {
       params.set("minReactions", String(filters.minReactions));
     }


### PR DESCRIPTION
## Summary
Aligns frontend search proxy parameter names with backend SearchConfessionDto to fix empty results / 400 errors caused by parameter name drift.

## Problem
- Frontend sends `sort` but backend expects `sortBy` (enum)
- Frontend sends `dateFrom`/`dateTo` but backend expects `startDate`/`endDate`
- Gas regression specs revealed the mismatch

## Changes
- `xconfess-frontend/app/api/confessions/search/route.ts`: Map `sort` → `sortBy`, `dateFrom` → `startDate`, `dateTo` → `endDate`
- `xconfess-frontend/app/lib/hooks/useSearch.ts`: Same parameter mapping in the data-fetching hook
- Only send `sortBy` when value differs from default (`newest`) to avoid empty params

## Testing
- Verified parameter alignment matches `SearchConfessionDto` field names
- Existing search E2E tests should pass with corrected params

Closes #1129