### PR TITLE
fix(#1127): add audit logging to comment admin moderation routes

### DIFF
--- a/xconfess-backend/src/audit-log/audit-log.entity.ts
+++ b/xconfess-backend/src/audit-log/audit-log.entity.ts
@@ -34,6 +34,8 @@ export enum AuditActionType {
   // Moderation
   MODERATION_ESCALATION = 'moderation_escalation',
   MODERATION_OVERRIDE = 'moderation_override',
+  COMMENT_APPROVED = 'comment_approved',
+  COMMENT_REJECTED = 'comment_rejected',
   BULK_ACTION = 'bulk_action',
 
   // User actions

--- a/xconfess-backend/src/comment/comment-admin.controller.spec.ts
+++ b/xconfess-backend/src/comment/comment-admin.controller.spec.ts
@@ -4,9 +4,15 @@ import { CommentService } from './comment.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
 import { ModerationStatus } from './entities/moderation-comment.entity';
+import { AuditLogService } from '../audit-log/audit-log.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
 
 const mockCommentService = {
   moderateComment: jest.fn(),
+};
+
+const mockAuditLogService = {
+  log: jest.fn().mockResolvedValue(undefined),
 };
 
 /**

--- a/xconfess-backend/src/comment/comment.module.ts
+++ b/xconfess-backend/src/comment/comment.module.ts
@@ -8,11 +8,13 @@ import { AnonymousContextMiddleware } from '../middleware/anonymous-context.midd
 import { ModerationComment } from './entities/moderation-comment.entity';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
 import { AnalyticsModule } from '../analytics/analytics.module';
+import { AuditLogModule } from '../audit-log/audit-log.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Comment, ModerationComment, OutboxEvent]),
     AnalyticsModule,
+    AuditLogModule,
   ],
   controllers: [CommentController, CommentAdminController],
   providers: [CommentService],

--- a/xconfess-backend/src/comment/comment.service.audit.spec.ts
+++ b/xconfess-backend/src/comment/comment.service.audit.spec.ts
@@ -1,0 +1,185 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentService } from '../comment.service';
+import { AuditLogService } from '../../audit-log/audit-log.service';
+import { AuditActionType } from '../../audit-log/audit-log.entity';
+import { ModerationStatus } from '../entities/moderation-comment.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Comment } from '../entities/comment.entity';
+import { AnonymousConfession } from '../../confession/entities/confession.entity';
+import { ModerationComment } from '../entities/moderation-comment.entity';
+import { OutboxEvent } from '../../common/entities/outbox-event.entity';
+import { AnalyticsService } from '../../analytics/analytics.service';
+import { User } from '../../user/entities/user.entity';
+
+describe('CommentService — audit logging', () => {
+  let service: CommentService;
+  let auditLogService: jest.Mocked<AuditLogService>;
+  let moderationCommentRepo: jest.Mocked<Repository<ModerationComment>>;
+
+  const mockModeration = {
+    id: 1,
+    comment: { id: 42, content: 'test comment' },
+    status: ModerationStatus.PENDING,
+    moderatedAt: null,
+    moderatedBy: null,
+    moderatedById: null,
+  };
+
+  const mockModerator = {
+    id: 1,
+    username: 'admin_user',
+    role: 'admin',
+  } as User;
+
+  beforeEach(async () => {
+    auditLogService = {
+      log: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    moderationCommentRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentService,
+        {
+          provide: getRepositoryToken(Comment),
+          useValue: {} as Repository<Comment>,
+        },
+        {
+          provide: getRepositoryToken(AnonymousConfession),
+          useValue: {} as Repository<AnonymousConfession>,
+        },
+        {
+          provide: getRepositoryToken(ModerationComment),
+          useValue: moderationCommentRepo,
+        },
+        {
+          provide: getRepositoryToken(OutboxEvent),
+          useValue: {} as Repository<OutboxEvent>,
+        },
+        {
+          provide: DataSource,
+          useValue: {} as DataSource,
+        },
+        {
+          provide: AnalyticsService,
+          useValue: {
+            invalidateTrendingCache: jest.fn().mockResolvedValue(undefined),
+            invalidateStatsCache: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: auditLogService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CommentService>(CommentService);
+  });
+
+  describe('moderateComment() — audit log on approve', () => {
+    it('writes COMMENT_APPROVED audit log when comment is approved', async () => {
+      moderationCommentRepo.findOne.mockResolvedValue(mockModeration as any);
+      moderationCommentRepo.save.mockResolvedValue({
+        ...mockModeration,
+        status: ModerationStatus.APPROVED,
+        moderatedAt: new Date(),
+        moderatedBy: mockModerator,
+        moderatedById: mockModerator.id,
+      } as any);
+
+      await service.moderateComment(42, ModerationStatus.APPROVED, mockModerator);
+
+      expect(auditLogService.log).toHaveBeenCalledTimes(1);
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.COMMENT_APPROVED,
+          metadata: expect.objectContaining({
+            entityType: 'comment',
+            entityId: '42',
+            commentId: '42',
+            previousStatus: ModerationStatus.PENDING,
+            newStatus: ModerationStatus.APPROVED,
+          }),
+          context: expect.objectContaining({
+            userId: mockModerator.id,
+            actor: expect.objectContaining({
+              type: 'admin',
+              id: String(mockModerator.id),
+              label: mockModerator.username,
+              source: 'comment-admin-controller',
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('writes COMMENT_REJECTED audit log when comment is rejected', async () => {
+      moderationCommentRepo.findOne.mockResolvedValue(mockModeration as any);
+      moderationCommentRepo.save.mockResolvedValue({
+        ...mockModeration,
+        status: ModerationStatus.REJECTED,
+        moderatedAt: new Date(),
+        moderatedBy: mockModerator,
+        moderatedById: mockModerator.id,
+      } as any);
+
+      await service.moderateComment(42, ModerationStatus.REJECTED, mockModerator);
+
+      expect(auditLogService.log).toHaveBeenCalledTimes(1);
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.COMMENT_REJECTED,
+          metadata: expect.objectContaining({
+            entityType: 'comment',
+            entityId: '42',
+            newStatus: ModerationStatus.REJECTED,
+          }),
+        }),
+      );
+    });
+
+    it('includes moderatedAt timestamp in audit metadata', async () => {
+      const beforeModeration = new Date();
+      moderationCommentRepo.findOne.mockResolvedValue(mockModeration as any);
+      moderationCommentRepo.save.mockResolvedValue({
+        ...mockModeration,
+        status: ModerationStatus.APPROVED,
+        moderatedAt: new Date(),
+        moderatedBy: mockModerator,
+        moderatedById: mockModerator.id,
+      } as any);
+
+      await service.moderateComment(42, ModerationStatus.APPROVED, mockModerator);
+
+      const logCall = (auditLogService.log as jest.Mock).mock.calls[0][0];
+      expect(logCall.metadata.moderatedAt).toBeDefined();
+      expect(new Date(logCall.metadata.moderatedAt).getTime()).toBeGreaterThanOrEqual(
+        beforeModeration.getTime(),
+      );
+    });
+
+    it('does not throw when audit log write fails', async () => {
+      moderationCommentRepo.findOne.mockResolvedValue(mockModeration as any);
+      moderationCommentRepo.save.mockResolvedValue({
+        ...mockModeration,
+        status: ModerationStatus.APPROVED,
+        moderatedAt: new Date(),
+        moderatedBy: mockModerator,
+        moderatedById: mockModerator.id,
+      } as any);
+
+      auditLogService.log.mockRejectedValueOnce(new Error('DB write failed'));
+
+      // Should not throw — audit log failure must not break moderation
+      await expect(
+        service.moderateComment(42, ModerationStatus.APPROVED, mockModerator),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/xconfess-backend/src/comment/comment.service.ts
+++ b/xconfess-backend/src/comment/comment.service.ts
@@ -7,6 +7,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { AnalyticsService } from '../analytics/analytics.service';
+import { AuditLogService, AuditActionType } from '../audit-log/audit-log.service';
 import {
   OutboxEvent,
   OutboxStatus,
@@ -50,6 +51,7 @@ export class CommentService {
     private outboxRepo: Repository<OutboxEvent>,
     private readonly dataSource: DataSource,
     private readonly analyticsService: AnalyticsService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   async create(
@@ -386,6 +388,36 @@ export class CommentService {
     moderation.moderatedBy = moderator;
     moderation.moderatedById = moderator.id;
     await this.moderationCommentRepo.save(moderation);
+
+    // Write audit log entry for the moderation action
+    const actionType = status === ModerationStatus.APPROVED
+      ? AuditActionType.COMMENT_APPROVED
+      : AuditActionType.COMMENT_REJECTED;
+    this.auditLogService.log({
+      actionType,
+      metadata: {
+        entityType: 'comment',
+        entityId: String(commentId),
+        commentId: String(commentId),
+        previousStatus: ModerationStatus.PENDING,
+        newStatus: status,
+        moderatedAt: moderation.moderatedAt.toISOString(),
+      },
+      context: {
+        userId: moderator.id,
+        actor: {
+          type: 'admin',
+          id: String(moderator.id),
+          userId: String(moderator.id),
+          label: moderator.username || `admin-${moderator.id}`,
+          source: 'comment-admin-controller',
+        },
+      },
+    }).catch((err: Error) => {
+      this.logger.error(
+        `Failed to write audit log for comment ${status} on comment ${commentId}: ${err.message}`,
+      );
+    });
 
     // Moderation changes which comments are publicly visible, directly
     // affecting trending scores and platform stats.


### PR DESCRIPTION
## Summary
Ensures CommentAdminController enforces admin roles and writes audit log entries for all comment moderation actions (approve/reject).

## Problem
Comment moderation routes had RBAC guards but no audit trail, which is required for operator compliance.

## Changes
- `audit-log.entity.ts`: Add `COMMENT_APPROVED` and `COMMENT_REJECTED` to `AuditActionType` enum
- `comment.module.ts`: Import `AuditLogModule`
- `comment.service.ts`:
  - Inject `AuditLogService`
  - Write audit log entry on every moderation action with:
    - entityType: 'comment', entityId, commentId
    - previousStatus (PENDING), newStatus (APPROVED/REJECTED)
    - moderatedAt timestamp
    - actor info (admin id, username, source)
  - Audit log failures are caught and logged (non-blocking)
- `comment.service.audit.spec.ts`: New unit tests:
  - COMMENT_APPROVED audit on approve
  - COMMENT_REJECTED audit on reject
  - moderatedAt timestamp in metadata
  - Non-throwing on audit log failure

## Guards
Existing `@UseGuards(JwtAuthGuard, AdminGuard)` at class level ensures all admin routes require authentication + admin role.

Closes #1127