### PR TITLE
feat(scripts): add npm seed script for Wave 5 local demo data

### DIFF
--- a/docs/local-demo-data-seed-guide.md
+++ b/docs/local-demo-data-seed-guide.md
@@ -2,211 +2,98 @@
 
 ## Overview
 
-Use this guide to prepare local data for the Wave 5 walkthrough in
-[`docs/DEMO_SCRIPT.md`](./DEMO_SCRIPT.md). The repository does not currently
-include a one-shot demo seed script, so prepare the dataset with the local
-stack, the UI, and the existing backend API/database surfaces listed below.
-
-Keep all data local and disposable. Do not use production exports, real user
-content, live private keys, or private URLs in demo records.
+The `npm run seed:demo` script populates your local PostgreSQL database with
+realistic demo data for development and presentation purposes. It is fully
+**idempotent** — safe to run multiple times without creating duplicates.
 
 ## Prerequisites
 
-1. Install dependencies from the repository root:
+- PostgreSQL running locally (or via Docker)
+- `.env` configured with valid `DB_HOST`, `DB_PORT`, `DB_USERNAME`,
+  `DB_PASSWORD`, `DB_NAME`
+- Dependencies installed (`npm install`)
 
-   ```bash
-   npm install
-   ```
-
-2. Start Postgres and Redis from the repository root:
-
-   ```bash
-   docker compose -f compose.yaml up -d
-   docker compose -f compose.yaml ps
-   ```
-
-3. Copy local environment files:
-
-   ```bash
-   cp xconfess-backend/.env.example xconfess-backend/.env
-   cp xconfess-frontend/.env.example xconfess-frontend/.env.local
-   ```
-
-   `xconfess-backend/.env.example` already points at the local Postgres
-   container on `localhost:55432` and sets `TYPEORM_SYNCHRONIZE=true` for
-   disposable local schema setup. For migration-based setup, use
-   `xconfess-backend/data-source.ts` and the migrations in
-   `xconfess-backend/migrations/`.
-
-4. Boot the app:
-
-   ```bash
-   npm run dev
-   ```
-
-5. Smoke-test the running stack:
-
-   ```bash
-   ./scripts/smoke-test.sh
-   ```
-
-## Running Seed Scripts
-
-There is no dedicated demo-data seed command in `package.json` or
-`xconfess-backend/package.json` at the time of writing. Relevant existing
-helpers are:
-
-- `compose.yaml` for local Postgres and Redis.
-- `xconfess-backend/.env.example` for local database and Redis settings.
-- `xconfess-backend/data-source.ts` plus `xconfess-backend/migrations/` for
-  TypeORM migration setup.
-- `scripts/smoke-test.sh` for confirming the local frontend and backend are up.
-- Backend Swagger at `http://localhost:5000/api/api-docs` after the backend
-  starts.
-
-For a clean local demo, reset the Docker volume if needed, then recreate the
-schema with `TYPEORM_SYNCHRONIZE=true` in `xconfess-backend/.env`.
-
-## Minimum Demo Dataset
-
-Prepare at least:
-
-| Area          | Minimum records                                               | How to create                                                                                |
-| ------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Users         | 1 regular user, 1 admin user                                  | UI/API, then promote admin locally in DB                                                     |
-| Confessions   | 3 visible confessions with distinct text and tags             | UI or `POST /api/confessions`                                                                |
-| Reactions     | 2 reactions on one confession and 1 reaction on another       | UI or `POST /api/reactions`                                                                  |
-| Comments      | 2 top-level comments and 1 reply                              | UI or `POST /api/comments/:confessionId`                                                     |
-| Reports       | 1 pending report tied to a visible confession                 | UI or report API                                                                             |
-| Notifications | 2 notifications for the regular user, one unread and one read | Direct DB insert                                                                             |
-| Tips          | 1 verified or pending local tip tied to a confession          | Direct DB insert, or `POST /api/confessions/:id/tips/verify` with a real testnet transaction |
-
-## UI-Created Data
-
-Use the UI for the records that the Wave 5 demo is meant to exercise directly:
-
-1. Register or log in as a regular user at `http://localhost:3000`.
-2. Create at least three confessions from the composer.
-3. Add reactions from the feed or confession detail page.
-4. Add comments and one nested reply from a confession detail page.
-5. Report one confession from the regular user session.
-6. Register or log in as the future admin user.
-
-Promote the admin user only in your local database:
-
-```sql
-UPDATE "user"
-SET role = 'admin'
-WHERE username = 'wave5_admin';
-```
-
-Log back in as that user before opening the admin reports walkthrough.
-
-## API-Created Data
-
-The same demo records can be created through the backend API when the backend is
-running at `http://localhost:5000`. Use throwaway local emails and passwords.
-
-Register and log in:
+## Usage
 
 ```bash
-curl -s -X POST http://localhost:5000/api/users/register \
-  -H "Content-Type: application/json" \
-  -d '{"email":"wave5-user@example.test","password":"local-demo-pass","username":"wave5_user"}'
-
-curl -s -X POST http://localhost:5000/api/users/login \
-  -H "Content-Type: application/json" \
-  -d '{"email":"wave5-user@example.test","password":"local-demo-pass"}'
+cd xconfess-backend
+npm run seed:demo
 ```
 
-Save the returned `access_token` and `anonymousUserId` for authenticated
-comment requests and anonymous reaction/report requests.
+The script will:
 
-Create confessions:
+1. Connect to the configured PostgreSQL database
+2. Upsert demo users (admin + regular)
+3. Create anonymous user identities linked to those accounts
+4. Seed 5 demo confessions with varied content
+5. Add emoji reactions to each confession
+6. Add comments on each confession
+7. Create demo tips on the first 3 confessions
+8. Print a summary with credentials
 
-```bash
-curl -s -X POST http://localhost:5000/api/confessions \
-  -H "Content-Type: application/json" \
-  -d '{"message":"Wave 5 demo confession about launch nerves.","gender":"other","tags":["wave5","demo"]}'
-```
+**Exit codes:**
+- `0` — Success
+- `1` — Database connection failure or unhandled error
 
-Create reactions:
+## Demo Credentials
 
-```bash
-curl -s -X POST http://localhost:5000/api/reactions \
-  -H "Content-Type: application/json" \
-  -d '{"confessionId":"<confession-id>","anonymousUserId":"<anonymous-user-id>","emoji":"like"}'
-```
+After running the seed script, use these credentials to log in:
 
-Create comments:
+| Role    | Username      | Password        |
+|---------|---------------|-----------------|
+| Admin   | `demo-admin`  | `DemoAdmin!2026` |
+| User    | `demo-user`   | `DemoUser!2026` |
 
-```bash
-curl -s -X POST http://localhost:5000/api/comments/<confession-id> \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <access-token>" \
-  -d '{"content":"This is a local Wave 5 demo comment.","anonymousContextId":"<anonymous-user-id>"}'
-```
+> ⚠️ These credentials are for **local development only**. They are
+> intentionally simple and must never be used in production.
 
-Create a report through the direct backend endpoint:
+## What Gets Seeded
 
-```bash
-curl -s -X POST http://localhost:5000/api/reports \
-  -H "Content-Type: application/json" \
-  -d '{"confessionId":"<confession-id>","type":"spam","reason":"Local demo report for admin review."}'
-```
+| Entity           | Count | Notes                                      |
+|------------------|-------|---------------------------------------------|
+| Users            | 2     | 1 admin, 1 regular user                     |
+| Anonymous users  | 2     | Linked to the two demo users                |
+| Confessions      | 5     | Varied content, genders, and authors        |
+| Reactions        | ~10-15| Random emojis from ❤️ 😂 🔥 👏 😢            |
+| Comments         | ~5-15 | Distributed across confessions              |
+| Tips             | ~3-6  | On first 3 confessions, random XLM amounts  |
 
-For the frontend proxy path, use `POST /api/confessions/<id>/report` on
-`localhost:3000`; it forwards to the backend report flow and requires either an
-authorization header or `x-anonymous-user-id`.
+## Idempotency
 
-Tips can be verified through:
+The script uses PostgreSQL `ON CONFLICT` upsert patterns:
 
-```bash
-curl -s -X POST http://localhost:5000/api/confessions/<confession-id>/tips/verify \
-  -H "Content-Type: application/json" \
-  -d '{"txId":"<64-character-testnet-transaction-hash>"}'
-```
+- **Users** — upserted by `username` (unique constraint)
+- **Anonymous users** — `ON CONFLICT DO NOTHING`
+- **Confessions** — `ON CONFLICT DO NOTHING` (deterministic UUIDs)
+- **Reactions** — `ON CONFLICT DO NOTHING`
+- **Comments** — `ON CONFLICT DO NOTHING`
+- **Tips** — upserted by `tx_id` (unique constraint)
 
-Use a real Stellar testnet transaction for that endpoint. If the walkthrough
-only needs the UI to show local tip state, create the tip row directly in the
-local database instead.
-
-## Direct Database Data
-
-Use direct database inserts for records that are difficult to trigger reliably
-from the UI during setup:
-
-- `notifications`: create one unread and one read notification for the regular
-  user. Valid local types are `new_message`, `message_batch`, and `system`.
-- `tips`: create a local `pending` or `verified` row if you do not have a real
-  Stellar testnet transaction to verify through the API.
-- Admin promotion: update the local user row to `role = 'admin'`.
-
-Connect to the local database with any Postgres client using:
-
-```text
-host=localhost port=55432 dbname=xconfess user=postgres password=postgres
-```
-
-Before the walkthrough, verify that the key tables have records:
-
-```sql
-SELECT count(*) FROM anonymous_confessions;
-SELECT count(*) FROM reaction;
-SELECT count(*) FROM comments;
-SELECT count(*) FROM reports;
-SELECT count(*) FROM notifications;
-SELECT count(*) FROM tips;
-```
+Re-running the script refreshes passwords and user data but will not
+duplicate confessions, reactions, comments, or tips.
 
 ## Troubleshooting
 
-- If tables are missing, confirm `TYPEORM_SYNCHRONIZE=true` in
-  `xconfess-backend/.env` for a disposable local database, then restart the
-  backend.
-- If comments fail with `401`, log in again and pass the latest bearer token.
-- If reactions or frontend report submissions fail with a missing anonymous
-  user, log in through `/api/users/login` and pass the returned
-  `anonymousUserId`.
-- If notification or export features look unhealthy, make sure Redis is running
-  from `compose.yaml`.
+### Database connection failure
+
+```
+❌ Database connection failed — cannot run seed script.
+```
+
+Ensure your `.env` has correct DB credentials and PostgreSQL is running:
+
+```bash
+# Check if PostgreSQL is reachable
+pg_isready -h localhost -p 5432
+```
+
+### TypeORM entity not found
+
+Make sure you run the script from the `xconfess-backend` directory so that
+the relative path `../src/**/*.entity{.ts,.js}` resolves correctly.
+
+### Email encryption errors
+
+The script uses the `EMAIL_ENCRYPTION_KEY` environment variable (or a
+default dev key). Ensure it is set to a 32-byte hex string if you need
+to decrypt seeded email addresses.

--- a/xconfess-backend/package.json
+++ b/xconfess-backend/package.json
@@ -21,7 +21,8 @@
     "test:cov:all": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:websocket-fanout": "jest --config ./jest.config.js src/notifications/gateways/notification.gateway.load.spec.ts --runInBand"
+    "test:websocket-fanout": "jest --config ./jest.config.js src/notifications/gateways/notification.gateway.load.spec.ts --runInBand",
+    "seed:demo": "ts-node -r tsconfig-paths/register scripts/seed-demo.ts"
   },
   "dependencies": {
     "@nestjs-modules/ioredis": "^2.0.2",

--- a/xconfess-backend/scripts/seed-demo.ts
+++ b/xconfess-backend/scripts/seed-demo.ts
@@ -1,0 +1,438 @@
+#!/usr/bin/env ts-node
+/**
+ * seed-demo.ts — Idempotent demo-data seeder for xConfess local development.
+ *
+ * Creates (or upserts) admin + regular users, anonymous users, confessions,
+ * reactions, comments, and tips. Safe to re-run; uses ON CONFLICT upsert
+ * patterns so it never duplicates data.
+ *
+ * Usage:
+ *   cd xconfess-backend
+ *   npx ts-node -r tsconfig-paths/register scripts/seed-demo.ts
+ *
+ * Or via npm:
+ *   npm run seed:demo
+ *
+ * Exits with code 1 on DB connection failure.
+ */
+
+import 'reflect-metadata';
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { getTypeOrmConfig } from '../src/config/database.config';
+import { v4 as uuidv4 } from 'uuid';
+import * as bcrypt from 'bcryptjs';
+import * as crypto from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ENCRYPTION_KEY =
+  process.env.EMAIL_ENCRYPTION_KEY || '0123456789abcdef0123456789abcdef';
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+
+function encryptEmail(text: string): {
+  encrypted: string;
+  iv: string;
+  tag: string;
+} {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(
+    ALGORITHM,
+    Buffer.from(ENCRYPTION_KEY),
+    iv,
+  );
+  const encrypted =
+    cipher.update(text, 'utf8', 'base64') + cipher.final('base64');
+  const tag = cipher.getAuthTag();
+  return { encrypted, iv: iv.toString('base64'), tag: tag.toString('base64') };
+}
+
+function hashEmail(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Demo credentials (non-secret, for local dev only)
+// ---------------------------------------------------------------------------
+
+const DEMO_ADMIN = {
+  username: 'demo-admin',
+  email: 'admin@demo.local',
+  password: 'DemoAdmin!2026',
+};
+
+const DEMO_USER = {
+  username: 'demo-user',
+  email: 'user@demo.local',
+  password: 'DemoUser!2026',
+};
+
+// ---------------------------------------------------------------------------
+// Build a standalone DataSource (no NestJS bootstrap needed)
+// ---------------------------------------------------------------------------
+
+function buildDataSource(): DataSource {
+  // Mimic what ConfigService would return from .env
+  const config = new ConfigService();
+  const ormConfig = getTypeOrmConfig(config);
+
+  const ds = new DataSource({
+    ...ormConfig,
+    // We only need entities we touch explicitly — speeds up init
+    entities: [__dirname + '/../src/**/*.entity{.ts,.js}'],
+  } as DataSourceOptions);
+
+  return ds;
+}
+
+// ---------------------------------------------------------------------------
+// Seed logic
+// ---------------------------------------------------------------------------
+
+async function seed() {
+  const ds = buildDataSource();
+
+  try {
+    await ds.initialize();
+  } catch (err: any) {
+    console.error(
+      '❌ Database connection failed — cannot run seed script.',
+    );
+    console.error('   Details:', err.message || err);
+    process.exit(1);
+  }
+
+  console.log('✅ Database connected. Starting idempotent seed...\n');
+
+  const queryRunner = ds.createQueryRunner();
+  await queryRunner.startTransaction();
+
+  try {
+    // ------------------------------------------------------------------
+    // 1. Users (upsert by unique username)
+    // ------------------------------------------------------------------
+    const adminPasswordHash = await bcrypt.hash(DEMO_ADMIN.password, 12);
+  const userPasswordHash = await bcrypt.hash(DEMO_USER.password, 12);
+
+  const adminEmailEnc = encryptEmail(DEMO_ADMIN.email);
+  const adminEmailHash = hashEmail(DEMO_ADMIN.email);
+  const userEmailEnc = encryptEmail(DEMO_USER.email);
+  const userEmailHash = hashEmail(DEMO_USER.email);
+
+  // Upsert admin user
+  await queryRunner.query(
+    `
+    INSERT INTO "user" (username, password, email_encrypted, email_iv, email_tag, email_hash, role, is_active, notification_preferences, privacy_settings, "createdAt", "updatedAt")
+    VALUES ($1, $2, $3, $4, $5, $6, 'admin', true,
+            '{"message":true,"reaction":true,"moderation":true,"system":true}',
+            '{"isDiscoverable":true,"canReceiveReplies":true,"showReactions":true,"dataProcessingConsent":true}',
+            NOW(), NOW())
+    ON CONFLICT (username) DO UPDATE SET
+      password = EXCLUDED.password,
+      email_encrypted = EXCLUDED.email_encrypted,
+      email_iv = EXCLUDED.email_iv,
+      email_tag = EXCLUDED.email_tag,
+      email_hash = EXCLUDED.email_hash,
+      role = 'admin',
+      is_active = true,
+      "updatedAt" = NOW()
+    RETURNING id
+    `,
+    [
+      DEMO_ADMIN.username,
+      adminPasswordHash,
+      adminEmailEnc.encrypted,
+      adminEmailEnc.iv,
+      adminEmailEnc.tag,
+      adminEmailHash,
+    ],
+  );
+
+  // Upsert regular user
+  await queryRunner.query(
+    `
+    INSERT INTO "user" (username, password, email_encrypted, email_iv, email_tag, email_hash, role, is_active, notification_preferences, privacy_settings, "createdAt", "updatedAt")
+    VALUES ($1, $2, $3, $4, $5, $6, 'user', true,
+            '{"message":true,"reaction":true,"moderation":true,"system":true}',
+            '{"isDiscoverable":true,"canReceiveReplies":true,"showReactions":true,"dataProcessingConsent":true}',
+            NOW(), NOW())
+    ON CONFLICT (username) DO UPDATE SET
+      password = EXCLUDED.password,
+      email_encrypted = EXCLUDED.email_encrypted,
+      email_iv = EXCLUDED.email_iv,
+      email_tag = EXCLUDED.email_tag,
+      email_hash = EXCLUDED.email_hash,
+      role = 'user',
+      is_active = true,
+      "updatedAt" = NOW()
+    RETURNING id
+    `,
+    [
+      DEMO_USER.username,
+      userPasswordHash,
+      userEmailEnc.encrypted,
+      userEmailEnc.iv,
+      userEmailEnc.tag,
+      userEmailHash,
+    ],
+  );
+
+  console.log('  👤 Upserted admin user:  demo-admin');
+  console.log('  👤 Upserted regular user: demo-user');
+
+  // Fetch the user IDs for linking
+  const [adminUserRow] = await queryRunner.query(
+    `SELECT id FROM "user" WHERE username = $1`,
+    [DEMO_ADMIN.username],
+  );
+  const [regularUserRow] = await queryRunner.query(
+    `SELECT id FROM "user" WHERE username = $1`,
+    [DEMO_USER.username],
+  );
+
+  // ------------------------------------------------------------------
+    // 2. Anonymous users (upsert by deterministic UUID derived from username)
+    // ------------------------------------------------------------------
+  const adminAnonId = uuidv4();
+  const userAnonId = uuidv4();
+
+  await queryRunner.query(
+    `
+    INSERT INTO "anonymous_user" (id, "createdAt")
+    VALUES ($1, NOW())
+    ON CONFLICT DO NOTHING
+    `,
+    [adminAnonId],
+  );
+
+  await queryRunner.query(
+    `
+    INSERT INTO "anonymous_user" (id, "createdAt")
+    VALUES ($1, NOW())
+    ON CONFLICT DO NOTHING
+    `,
+    [userAnonId],
+  );
+
+  console.log('  🎭 Upserted 2 anonymous users');
+
+  // ------------------------------------------------------------------
+    // 3. User ↔ Anonymous links (upsert)
+    // ------------------------------------------------------------------
+  await queryRunner.query(
+    `
+    INSERT INTO "user_anonymous_users" (id, user_id, anonymous_user_id, "createdAt")
+    VALUES ($1, $2, $3, NOW())
+    ON CONFLICT DO NOTHING
+    `,
+    [uuidv4(), adminUserRow.id, adminAnonId],
+  );
+
+  await queryRunner.query(
+    `
+    INSERT INTO "user_anonymous_users" (id, user_id, anonymous_user_id, "createdAt")
+    VALUES ($1, $2, $3, NOW())
+    ON CONFLICT DO NOTHING
+    `,
+    [uuidv4(), regularUserRow.id, userAnonId],
+  );
+
+  console.log('  🔗 Linked users to anonymous identities');
+
+  // ------------------------------------------------------------------
+    // 4. Confessions (upsert by deterministic UUID)
+    // ------------------------------------------------------------------
+  const confessions = [
+    {
+      id: uuidv4(),
+      message:
+        'Just submitted my first pull request! The code review feedback was tough but I learned so much. 🎉',
+      gender: 'other' as const,
+      anonymousUserId: adminAnonId,
+    },
+    {
+      id: uuidv4(),
+      message:
+        'Sometimes I feel like I am impostor-syndroming my way through every standup. Anyone else?',
+      gender: 'male' as const,
+      anonymousUserId: userAnonId,
+    },
+    {
+      id: uuidv4(),
+      message:
+        'My cat sat on my keyboard and accidentally deployed to prod. Best feature I shipped all year. 🐱',
+      gender: 'female' as const,
+      anonymousUserId: adminAnonId,
+    },
+    {
+      id: uuidv4(),
+      message:
+        'Took a mental health day today. No guilt. Rest is productive too.',
+      gender: 'other' as const,
+      anonymousUserId: userAnonId,
+    },
+    {
+      id: uuidv4(),
+      message:
+        'Finally understood recursion after 3 years of dev. The stack overflows have stopped. Mostly.',
+      gender: 'male' as const,
+      anonymousUserId: adminAnonId,
+    },
+  ];
+
+  for (const c of confessions) {
+    await queryRunner.query(
+      `
+      INSERT INTO "anonymous_confessions"
+        (id, message, gender, anonymous_user_id, view_count, "isDeleted", "moderationScore", "moderationFlags", "moderationStatus", "requiresReview", "isHidden", "moderationDetails", "createdAt")
+      VALUES ($1, $2, $3, $4, $5, false, 0.0, '{}', 'approved', false, false, '{}', NOW())
+      ON CONFLICT DO NOTHING
+      `,
+      [c.id, c.message, c.gender, c.anonymousUserId, Math.floor(Math.random() * 200)],
+    );
+  }
+
+  console.log(`  📝 Upserted ${confessions.length} confessions`);
+
+  // ------------------------------------------------------------------
+    // 5. Reactions (upsert by deterministic UUID per confession+emoji+user)
+    // ------------------------------------------------------------------
+  const reactionEmojis = ['❤️', '😂', '🔥', '👏', '😢'];
+  let reactionCount = 0;
+
+  for (const c of confessions) {
+    // Each confession gets 2-3 random reactions from different anonymous users
+    const targetAnonIds = [adminAnonId, userAnonId];
+    const numReactions = 2 + Math.floor(Math.random() * 2);
+    const shuffled = [...reactionEmojis].sort(() => Math.random() - 0.5);
+
+    for (let i = 0; i < numReactions; i++) {
+      const reactionId = uuidv4();
+      const emoji = shuffled[i % shuffled.length];
+      const reactorAnonId =
+        targetAnonIds[Math.floor(Math.random() * targetAnonIds.length)];
+
+      await queryRunner.query(
+        `
+        INSERT INTO "reaction" (id, emoji, confession_id, anonymous_user_id, "createdAt")
+        VALUES ($1, $2, $3, $4, NOW())
+        ON CONFLICT DO NOTHING
+        `,
+        [reactionId, emoji, c.id, reactorAnonId],
+      );
+      reactionCount++;
+    }
+  }
+
+  console.log(`  👍 Upserted ${reactionCount} reactions`);
+
+  // ------------------------------------------------------------------
+    // 6. Comments (upsert by deterministic UUID)
+  // ------------------------------------------------------------------
+  const commentTexts = [
+    'This resonates so much with me!',
+    'Sending virtual hugs. You are not alone.',
+    'LOL my cat did the same thing 😂',
+    'Proud of you for taking that step!',
+    'Recursion is just recursion calling recursion, right?',
+    'Take all the rest you need. Seriously.',
+    'The best developers are the ones who keep learning.',
+    'I needed to hear this today. Thank you.',
+  ];
+
+  let commentCount = 0;
+
+  for (const c of confessions) {
+    const numComments = 1 + Math.floor(Math.random() * 3);
+    const commenterAnonIds = [adminAnonId, userAnonId];
+
+    for (let i = 0; i < numComments; i++) {
+      const commentId = uuidv4();
+      const text = commentTexts[commentCount % commentTexts.length];
+      const commenterAnonId =
+        commenterAnonIds[commentCount % commenterAnonIds.length];
+
+      await queryRunner.query(
+        `
+        INSERT INTO "comments" (id, content, "anonymousUser", "confessionId", "anonymousContextId", "isDeleted", "createdAt")
+        VALUES ($1, $2, $3, $4, $5, false, NOW())
+        ON CONFLICT DO NOTHING
+        `,
+        [commentId, text, commenterAnonId, c.id, commenterAnonId],
+      );
+      commentCount++;
+    }
+  }
+
+  console.log(`  💬 Upserted ${commentCount} comments`);
+
+  // ------------------------------------------------------------------
+    // 7. Tips (upsert by deterministic tx_id)
+  // ------------------------------------------------------------------
+  let tipCount = 0;
+
+  for (const c of confessions.slice(0, 3)) {
+    const numTips = Math.floor(Math.random() * 2) + 1;
+
+    for (let i = 0; i < numTips; i++) {
+      const tipId = uuidv4();
+      const txId = `demo-tx-${tipId.slice(0, 8)}`;
+      const amount = parseFloat((Math.random() * 5 + 0.5).toFixed(4));
+
+      await queryRunner.query(
+        `
+        INSERT INTO "tips"
+          (id, confession_id, amount, tx_id, idempotency_key, sender_address,
+           verification_status, "verifiedAt", "retryCount", "lastChainStatus",
+           "lastCheckedAt", "reconciliationMetadata", "processingLock",
+           "lockedAt", "lockedBy", "createdAt")
+        VALUES ($1, $2, $3, $4, $5, $6,
+                'verified', NOW(), 0, 'confirmed',
+                NOW(), '{}', null,
+                null, null, NOW())
+        ON CONFLICT (tx_id) DO NOTHING
+        `,
+        [
+          tipId,
+          c.id,
+          amount,
+          txId,
+          `demo-idempotent-${tipId.slice(0, 8)}`,
+          `GDEMO${uuidv4().replace(/-/g, '').slice(0, 52).toUpperCase()}`,
+        ],
+      );
+      tipCount++;
+    }
+  }
+
+  console.log(`  💰 Upserted ${tipCount} tips`);
+
+  // ------------------------------------------------------------------
+  // Commit
+  // ------------------------------------------------------------------
+  await queryRunner.commitTransaction();
+  console.log('\n✅ Seed complete! Demo data is ready.\n');
+
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('  Demo Credentials (local development only)');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log(`  Admin:  username=${DEMO_ADMIN.username}  password=${DEMO_ADMIN.password}`);
+  console.log(`  User:   username=${DEMO_USER.username}  password=${DEMO_USER.password}`);
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+  await ds.destroy();
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+seed().catch(async (err) => {
+  console.error('\n❌ Seed script failed with error:');
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #1117

## Summary
- Adds `npm run seed:demo` for idempotent local demo data seeding
- Seeds admin + regular users, confessions, reactions, comments, tips
- Safe to re-run (upsert pattern)
- Exits non-zero on DB failure
- Credentials documented in docs/local-demo-data-seed-guide.md