### PR TITLE
feat(backend): search API input validation and structured error responses

### DIFF
--- a/xconfess-backend/src/confession/dto/search-confession.dto.ts
+++ b/xconfess-backend/src/confession/dto/search-confession.dto.ts
@@ -3,6 +3,7 @@ import {
   IsString,
   IsNotEmpty,
   MinLength,
+  MaxLength,
   IsOptional,
   IsInt,
   Min,
@@ -13,6 +14,7 @@ import {
   IsEnum,
   IsArray,
   ValidateIf,
+  Matches,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -29,10 +31,16 @@ export class SearchConfessionDto {
     description: 'Search query string',
     example: 'work stress',
     minLength: 1,
+    maxLength: 200,
   })
   @IsString()
   @IsNotEmpty()
   @MinLength(1)
+  @MaxLength(200)
+  @Matches(/^[\p{L}\p{N}\s\-_'".,!?&]+$/u, {
+    message:
+      'Query contains invalid characters. Only letters, numbers, spaces, and basic punctuation are allowed.',
+  })
   q: string;
 
   @ApiPropertyOptional({

--- a/xconfess-backend/test/api-error-contract.e2e-spec.ts
+++ b/xconfess-backend/test/api-error-contract.e2e-spec.ts
@@ -144,4 +144,61 @@ describe('API Error Contract (e2e)', () => {
       expect(response.body).toHaveProperty('message');
     });
   });
+
+  describe('400 Search Validation', () => {
+    it('should return 400 with structured error when search query is empty', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: '' });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('should return 400 with structured error when search query exceeds max length', async () => {
+      const longQuery = 'a'.repeat(201);
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: longQuery });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('should return 400 with structured error when search query has invalid characters', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: '<script>alert(1)</script>' });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('should return 400 with structured error when limit exceeds maximum', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: 'test', limit: 100 });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('should return 400 with structured error when page is less than 1', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: 'test', page: 0 });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('should return 400 with structured error when sortBy is invalid', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: 'test', sortBy: 'invalid_sort' });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+    });
+  });
 });


### PR DESCRIPTION
Closes #1128

## Summary

Implements search query input validation and extends the API error contract e2e spec with search boundary tests.

### Changes

**DTO validation enhancements** (`xconfess-backend/src/confession/dto/search-confession.dto.ts`):
- Added `@MaxLength(200)` on the `q` field to cap query length
- Added `@Matches` decorator with a unicode-safe regex to restrict query charset to letters, numbers, spaces, and basic punctuation (prevents XSS/special char injection)
- Updated Swagger `@ApiProperty` docs to reflect `maxLength: 200`

**E2E test coverage** (`xconfess-backend/test/api-error-contract.e2e-spec.ts`):
- Added `400 Search Validation` describe block with 6 test cases:
  1. Empty query → 400 BAD_REQUEST
  2. Query > 200 chars → 400 BAD_REQUEST
  3. Query with invalid characters (e.g. `<script>`) → 400 BAD_REQUEST
  4. Limit > 50 (max) → 400 BAD_REQUEST
  5. Page < 1 → 400 BAD_REQUEST
  6. Invalid sortBy enum → 400 BAD_REQUEST

All validation errors return the structured error envelope per the existing api-error-contract pattern.