### PR TITLE
Ensure CommentAdminController

### DIFF
--- a/xconfess-backend/migrations/20260623000001-add-comment-moderation-audit-actions.ts
+++ b/xconfess-backend/migrations/20260623000001-add-comment-moderation-audit-actions.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCommentModerationAuditActions20260623000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM pg_type t
+          WHERE t.typname = 'audit_logs_action_enum'
+        ) THEN
+          ALTER TYPE "audit_logs_action_enum" ADD VALUE IF NOT EXISTS 'comment_approved';
+          ALTER TYPE "audit_logs_action_enum" ADD VALUE IF NOT EXISTS 'comment_rejected';
+        END IF;
+      END
+      $$;
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // Postgres enum values are not removed safely in a reversible way.
+  }
+}

--- a/xconfess-backend/src/audit-log/audit-log.entity.ts
+++ b/xconfess-backend/src/audit-log/audit-log.entity.ts
@@ -17,6 +17,8 @@ export enum AuditActionType {
   COMMENT_DELETED = 'comment_deleted',
   CONFESSION_HIDDEN = 'confession_hidden',
   CONFESSION_UNHIDDEN = 'confession_unhidden',
+  COMMENT_APPROVED = 'comment_approved',
+  COMMENT_REJECTED = 'comment_rejected',
 
   // Report actions
   REPORT_CREATED = 'report_created',

--- a/xconfess-backend/src/comment/comment-admin.controller.spec.ts
+++ b/xconfess-backend/src/comment/comment-admin.controller.spec.ts
@@ -4,9 +4,15 @@ import { CommentService } from './comment.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
 import { ModerationStatus } from './entities/moderation-comment.entity';
+import { AuditLogService } from '../audit-log/audit-log.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
 
 const mockCommentService = {
   moderateComment: jest.fn(),
+};
+
+const mockAuditLogService = {
+  log: jest.fn().mockResolvedValue(undefined),
 };
 
 /**
@@ -20,6 +26,7 @@ async function buildModule() {
     controllers: [CommentAdminController],
     providers: [
       { provide: CommentService, useValue: mockCommentService },
+      { provide: AuditLogService, useValue: mockAuditLogService },
     ],
   })
     .overrideGuard(JwtAuthGuard)
@@ -72,6 +79,34 @@ describe('CommentAdminController', () => {
       expect(typeof calledId).toBe('number');
       expect(calledId).toBe(7);
     });
+
+    it('creates an audit log row on successful approve', async () => {
+      const req = { user: { id: 1, role: 'admin' } } as any;
+      mockCommentService.moderateComment.mockResolvedValue({ success: true, message: '' });
+
+      await controller.approveComment('42', req);
+
+      expect(mockAuditLogService.log).toHaveBeenCalledTimes(1);
+      expect(mockAuditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.COMMENT_APPROVED,
+          metadata: expect.objectContaining({
+            commentId: '42',
+            entityType: 'comment',
+            entityId: '42',
+            status: ModerationStatus.APPROVED,
+          }),
+          context: expect.objectContaining({
+            userId: '1',
+            actor: expect.objectContaining({
+              type: 'admin',
+              id: '1',
+              userId: '1',
+            }),
+          }),
+        }),
+      );
+    });
   });
 
   describe('rejectComment() — POST /api/admin/comments/:id/reject', () => {
@@ -91,6 +126,34 @@ describe('CommentAdminController', () => {
         req.user,
       );
       expect(result.success).toBe(true);
+    });
+
+    it('creates an audit log row on successful reject', async () => {
+      const req = { user: { id: 2, role: 'admin' } } as any;
+      mockCommentService.moderateComment.mockResolvedValue({ success: true, message: '' });
+
+      await controller.rejectComment('15', req);
+
+      expect(mockAuditLogService.log).toHaveBeenCalledTimes(1);
+      expect(mockAuditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.COMMENT_REJECTED,
+          metadata: expect.objectContaining({
+            commentId: '15',
+            entityType: 'comment',
+            entityId: '15',
+            status: ModerationStatus.REJECTED,
+          }),
+          context: expect.objectContaining({
+            userId: '2',
+            actor: expect.objectContaining({
+              type: 'admin',
+              id: '2',
+              userId: '2',
+            }),
+          }),
+        }),
+      );
     });
   });
 

--- a/xconfess-backend/src/comment/comment-admin.controller.ts
+++ b/xconfess-backend/src/comment/comment-admin.controller.ts
@@ -18,6 +18,8 @@ import { AdminGuard } from '../auth/admin.guard';
 import { Request as ExpressRequest } from 'express';
 import { ModerationStatus } from './entities/moderation-comment.entity';
 import { User } from '../user/entities/user.entity';
+import { AuditLogService } from '../audit-log/audit-log.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
 
 interface RequestWithUser extends ExpressRequest {
   user?: any;
@@ -38,7 +40,7 @@ interface RequestWithUser extends ExpressRequest {
 @UseGuards(JwtAuthGuard, AdminGuard)
 @Controller('admin/comments')
 export class CommentAdminController {
-  constructor(private readonly service: CommentService) {}
+  constructor(private readonly service: CommentService, private readonly auditLogService: AuditLogService) {}
 
   /**
    * Approve a pending comment.
@@ -53,7 +55,27 @@ export class CommentAdminController {
   @ApiResponse({ status: 404, description: 'Comment or moderation entry not found' })
   async approveComment(@Param('id') id: string, @Req() req: RequestWithUser) {
     const user = req.user as User;
-    return this.service.moderateComment(+id, ModerationStatus.APPROVED, user);
+    const result = await this.service.moderateComment(+id, ModerationStatus.APPROVED, user);
+    this.auditLogService.log({
+      actionType: AuditActionType.COMMENT_APPROVED,
+      metadata: {
+        commentId: id,
+        entityType: 'comment',
+        entityId: id,
+        status: ModerationStatus.APPROVED,
+      },
+      context: {
+        userId: String(user.id),
+        actor: {
+          type: 'admin',
+          id: String(user.id),
+          userId: String(user.id),
+        },
+      },
+    }).catch((error) => {
+      // Audit logging must not break moderation
+    });
+    return result;
   }
 
   /**
@@ -69,6 +91,26 @@ export class CommentAdminController {
   @ApiResponse({ status: 404, description: 'Comment or moderation entry not found' })
   async rejectComment(@Param('id') id: string, @Req() req: RequestWithUser) {
     const user = req.user as User;
-    return this.service.moderateComment(+id, ModerationStatus.REJECTED, user);
+    const result = await this.service.moderateComment(+id, ModerationStatus.REJECTED, user);
+    this.auditLogService.log({
+      actionType: AuditActionType.COMMENT_REJECTED,
+      metadata: {
+        commentId: id,
+        entityType: 'comment',
+        entityId: id,
+        status: ModerationStatus.REJECTED,
+      },
+      context: {
+        userId: String(user.id),
+        actor: {
+          type: 'admin',
+          id: String(user.id),
+          userId: String(user.id),
+        },
+      },
+    }).catch((error) => {
+      // Audit logging must not break moderation
+    });
+    return result;
   }
 }

--- a/xconfess-backend/src/comment/comment.module.ts
+++ b/xconfess-backend/src/comment/comment.module.ts
@@ -8,11 +8,13 @@ import { AnonymousContextMiddleware } from '../middleware/anonymous-context.midd
 import { ModerationComment } from './entities/moderation-comment.entity';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
 import { AnalyticsModule } from '../analytics/analytics.module';
+import { AuditLogModule } from '../audit-log/audit-log.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Comment, ModerationComment, OutboxEvent]),
     AnalyticsModule,
+    AuditLogModule,
   ],
   controllers: [CommentController, CommentAdminController],
   providers: [CommentService],

--- a/xconfess-backend/test/comment-admin-moderation.e2e-spec.ts
+++ b/xconfess-backend/test/comment-admin-moderation.e2e-spec.ts
@@ -1,0 +1,140 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { AdminGuard } from '../src/auth/admin.guard';
+import { JwtAuthGuard } from '../src/auth/jwt-auth.guard';
+import { AuditLogService } from '../src/audit-log/audit-log.service';
+import { CommentAdminController } from '../src/comment/comment-admin.controller';
+import { CommentService } from '../src/comment/comment.service';
+import { ModerationStatus } from '../src/comment/entities/moderation-comment.entity';
+
+class FakeJwtAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) {
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    if (authHeader === 'Bearer admin-token') {
+      request.user = { id: 'admin-1', role: 'admin' };
+      return true;
+    }
+
+    if (authHeader === 'Bearer user-token') {
+      request.user = { id: 'user-1', role: 'user' };
+      return true;
+    }
+
+    throw new UnauthorizedException('Unauthorized');
+  }
+}
+
+describe('Comment Admin Moderation RBAC (e2e)', () => {
+  let app: INestApplication;
+
+  const mockCommentService = {
+    moderateComment: jest.fn(),
+  };
+
+  const mockAuditLogService = {
+    log: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [CommentAdminController],
+      providers: [
+        AdminGuard,
+        {
+          provide: CommentService,
+          useValue: mockCommentService,
+        },
+        {
+          provide: AuditLogService,
+          useValue: mockAuditLogService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useClass(FakeJwtAuthGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCommentService.moderateComment.mockResolvedValue({ success: true, message: '' });
+  });
+
+  it('rejects unauthenticated requests with 401', async () => {
+    await request(app.getHttpServer())
+      .post('/api/admin/comments/1/approve')
+      .expect(401);
+  });
+
+  it('rejects authenticated non-admin users with 403 on approve', async () => {
+    await request(app.getHttpServer())
+      .post('/api/admin/comments/1/approve')
+      .set('Authorization', 'Bearer user-token')
+      .expect(403)
+      .expect(({ body }) => {
+        expect(body.message).toBe('Only admins can access this endpoint');
+      });
+  });
+
+  it('rejects authenticated non-admin users with 403 on reject', async () => {
+    await request(app.getHttpServer())
+      .post('/api/admin/comments/1/reject')
+      .set('Authorization', 'Bearer user-token')
+      .expect(403)
+      .expect(({ body }) => {
+        expect(body.message).toBe('Only admins can access this endpoint');
+      });
+  });
+
+  it('allows admins to approve a comment', async () => {
+    await request(app.getHttpServer())
+      .post('/api/admin/comments/1/approve')
+      .set('Authorization', 'Bearer admin-token')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.success).toBe(true);
+      });
+
+    expect(mockCommentService.moderateComment).toHaveBeenCalledWith(
+      1,
+      ModerationStatus.APPROVED,
+      expect.objectContaining({ id: 'admin-1' }),
+    );
+  });
+
+  it('allows admins to reject a comment', async () => {
+    await request(app.getHttpServer())
+      .post('/api/admin/comments/1/reject')
+      .set('Authorization', 'Bearer admin-token')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.success).toBe(true);
+      });
+
+    expect(mockCommentService.moderateComment).toHaveBeenCalledWith(
+      1,
+      ModerationStatus.REJECTED,
+      expect.objectContaining({ id: 'admin-1' }),
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});


### PR DESCRIPTION
close #1127 

Summary
Enforces admin-only RBAC on all comment moderation endpoints and adds audit log entries for approve/reject actions.

Changes
Audit enums: Added COMMENT_APPROVED and COMMENT_REJECTED to AuditActionType.
Migration: Created 20260623000001-add-comment-moderation-audit-actions.ts to add new enum values to the database.
Controller: Injected AuditLogService into CommentAdminController. Writes audit log rows (with commentId, entityType, status, and actor context) after each successful approve or reject. AuditLogModule added to CommentModule imports.
Tests (unit):
Updated comment-admin.controller.spec.ts to mock AuditLogService.
Added tests verifying log() is called with correct actionType, metadata, and context for both approve and reject.
Tests (e2e): Created test/comment-admin-moderation.e2e-spec.ts covering:
401 for unauthenticated requests
403 for authenticated non-admin users on both /approve and /reject
200 success for admin users
Acceptance Criteria
Non-admin receives 403 on comment admin endpoints
Moderation action creates audit log row