### PR TITLE
feat : implement search API input validation and structured error res…

### DIFF
--- a/xconfess-backend/src/confession/confession.controller.ts
+++ b/xconfess-backend/src/confession/confession.controller.ts
@@ -3,6 +3,8 @@ import {
   Post,
   UsePipes,
   ValidationPipe,
+  ValidationError,
+  BadRequestException,
   Body,
   Get,
   Query,
@@ -31,6 +33,39 @@ import { SearchConfessionDto } from './dto/search-confession.dto';
 import { UpdateConfessionDto } from './dto/update-confession.dto';
 import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
 import { SearchDiscoveryService } from '../search-discovery/search-discovery.service';
+
+const flattenValidationErrors = (
+  errors: ValidationError[],
+  parentPath = '',
+): Record<string, string[]> => {
+  const fieldErrors: Record<string, string[]> = {};
+
+  for (const error of errors) {
+    const path = parentPath ? `${parentPath}.${error.property}` : error.property;
+
+    if (error.constraints) {
+      fieldErrors[path] = Object.values(error.constraints);
+    }
+
+    if (error.children && error.children.length > 0) {
+      Object.assign(fieldErrors, flattenValidationErrors(error.children, path));
+    }
+  }
+
+  return fieldErrors;
+};
+
+const searchValidationPipe = new ValidationPipe({
+  transform: true,
+  whitelist: true,
+  exceptionFactory: (validationErrors: ValidationError[]) => {
+    const fields = flattenValidationErrors(validationErrors);
+    return new BadRequestException({
+      message: 'Validation failed for search parameters',
+      details: { fields },
+    });
+  },
+});
 
 @ApiTags('Confessions')
 @Controller('confessions')
@@ -99,7 +134,7 @@ export class ConfessionController {
   @Get('search')
   @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({ summary: 'Search confessions (hybrid)' })
-  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  @UsePipes(searchValidationPipe)
   async search(@Query() dto: SearchConfessionDto, @Req() req: any) {
     const result = await this.service.search(dto);
     if (req.user && req.user.id) {
@@ -111,7 +146,7 @@ export class ConfessionController {
   @Get('search/fulltext')
   @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({ summary: 'Full-text search confessions' })
-  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  @UsePipes(searchValidationPipe)
   async fullTextSearch(@Query() dto: SearchConfessionDto, @Req() req: any) {
     const result = await this.service.fullTextSearch(dto);
     if (req.user && req.user.id) {

--- a/xconfess-backend/src/confession/dto/search-confession.dto.ts
+++ b/xconfess-backend/src/confession/dto/search-confession.dto.ts
@@ -3,6 +3,7 @@ import {
   IsString,
   IsNotEmpty,
   MinLength,
+  MaxLength,
   IsOptional,
   IsInt,
   Min,
@@ -13,6 +14,7 @@ import {
   IsEnum,
   IsArray,
   ValidateIf,
+  Matches,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -24,27 +26,46 @@ export enum SortBy {
   RELEVANCE = 'relevance',
 }
 
+const SEARCH_QUERY_MAX_LENGTH = 120;
+const SEARCH_PAGE_MAX = 1000;
+// Allow Unicode letters/numbers + common separators/punctuation used in search.
+const SEARCH_QUERY_ALLOWED_CHARS =
+  /^[\p{L}\p{N}\p{Zs}.,!?'"@#$%&*()_\-:+/[\]{}]+$/u;
+
 export class SearchConfessionDto {
   @ApiProperty({
     description: 'Search query string',
     example: 'work stress',
     minLength: 1,
+    maxLength: SEARCH_QUERY_MAX_LENGTH,
   })
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @IsString()
   @IsNotEmpty()
   @MinLength(1)
+  @MaxLength(SEARCH_QUERY_MAX_LENGTH, {
+    message: `q must not exceed ${SEARCH_QUERY_MAX_LENGTH} characters`,
+  })
+  @Matches(SEARCH_QUERY_ALLOWED_CHARS, {
+    message:
+      'q contains unsupported characters; use letters, numbers, spaces, or common punctuation',
+  })
   q: string;
 
   @ApiPropertyOptional({
     description: 'Page number for pagination',
     example: 1,
     minimum: 1,
+    maximum: SEARCH_PAGE_MAX,
     default: 1,
   })
   @IsOptional()
   @Transform(({ value }) => parseInt(value))
   @IsInt()
   @Min(1)
+  @Max(SEARCH_PAGE_MAX)
   page?: number = 1;
 
   @ApiPropertyOptional({

--- a/xconfess-backend/test/api-error-contract.e2e-spec.ts
+++ b/xconfess-backend/test/api-error-contract.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from './../src/app.module';
 import { HttpExceptionFilter } from './../src/common/filters/http-exception.filter';
 import { ThrottlerExceptionFilter } from './../src/common/filters/throttler-exception.filter';
@@ -36,7 +36,7 @@ describe('API Error Contract (e2e)', () => {
   });
 
   const expectErrorEnvelope = (
-    response: request.Response,
+    response: any,
     expectedStatus: number,
   ) => {
     expect(response.status).toBe(expectedStatus);
@@ -62,6 +62,57 @@ describe('API Error Contract (e2e)', () => {
 
       expectErrorEnvelope(response, 400);
       expect(response.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('should return field-level validation details for empty search query', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: '', page: 1, limit: 10 });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+      expect(response.body.message).toBe(
+        'Validation failed for search parameters',
+      );
+      expect(response.body.details).toBeDefined();
+      expect(response.body.details.fields).toBeDefined();
+      expect(response.body.details.fields.q).toEqual(
+        expect.arrayContaining([expect.stringContaining('q should not be empty')]),
+      );
+    });
+
+    it('should return field-level validation details for unsupported query charset', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: 'work\u0007stress', page: 1, limit: 10 });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+      expect(response.body.message).toBe(
+        'Validation failed for search parameters',
+      );
+      expect(response.body.details.fields.q).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('unsupported characters'),
+        ]),
+      );
+    });
+
+    it('should reject over-max pagination limit with field-level message', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/confessions/search')
+        .query({ q: 'stress', page: 1, limit: 999 });
+
+      expectErrorEnvelope(response, 400);
+      expect(response.body.code).toBe('BAD_REQUEST');
+      expect(response.body.message).toBe(
+        'Validation failed for search parameters',
+      );
+      expect(response.body.details.fields.limit).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('must not be greater than 50'),
+        ]),
+      );
     });
   });
 


### PR DESCRIPTION
##Summary
-Added strict validation for search query params on confession search endpoints.
-Enforced stable 400 error responses with field-level details for invalid search inputs.
-Extended API error contract e2e coverage for search boundary cases.

closes #1128 

##Acceptance criteria mapping
Empty query returns 400 with clear message ✅
Over-max limit clamped or rejected per rule ✅ (rejected with 400)
Error contract e2e spec extended ✅ (tests added)

##Test notes
Ran: npm run test --workspace=xconfess-backend -- src/confession/confession.search.spec.ts ✅ passed.
api-error-contract.e2e execution was blocked by unrelated existing workspace compile issues (admin.service missing symbols), not by this change.