### PR TITLE
fix: guard request-context reads in background jobs without HTTP context

### DIFF
--- a/xconfess-backend/src/common/request-context.spec.ts
+++ b/xconfess-backend/src/common/request-context.spec.ts
@@ -1,0 +1,102 @@
+import { createRequestContext, RequestContextStorage, injectRequestId } from './request-context';
+
+describe('createRequestContext', () => {
+  it('returns undefined from getRequestId before any ID is set', () => {
+    const ctx = createRequestContext();
+    expect(ctx.getRequestId()).toBeUndefined();
+  });
+
+  it('generates a non-empty string ID', () => {
+    const ctx = createRequestContext();
+    const id = ctx.generateId();
+    expect(id).toBeDefined();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('stores and retrieves a request ID', () => {
+    const ctx = createRequestContext();
+    ctx.setRequestId('test-id');
+    expect(ctx.getRequestId()).toBe('test-id');
+  });
+
+  it('runs a function within a scoped context', async () => {
+    const ctx = createRequestContext();
+    const result = await ctx.runWithContext('ctx-id', async () => {
+      expect(ctx.getRequestId()).toBe('ctx-id');
+      return 'done';
+    });
+    expect(result).toBe('done');
+    expect(ctx.getRequestId()).toBeUndefined();
+  });
+
+  it('cleans up even when the function throws', async () => {
+    const ctx = createRequestContext();
+    await expect(
+      ctx.runWithContext('fail-id', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    expect(ctx.getRequestId()).toBeUndefined();
+  });
+
+  it('supports nested runWithContext', async () => {
+    const ctx = createRequestContext();
+    const result = await ctx.runWithContext('outer', async () => {
+      expect(ctx.getRequestId()).toBe('outer');
+      const inner = await ctx.runWithContext('inner', async () => {
+        expect(ctx.getRequestId()).toBe('inner');
+        return 'nested';
+      });
+      expect(ctx.getRequestId()).toBe('outer');
+      return inner;
+    });
+    expect(result).toBe('nested');
+    expect(ctx.getRequestId()).toBeUndefined();
+  });
+
+  it('supports multiple independent contexts', () => {
+    const a = createRequestContext();
+    const b = createRequestContext();
+    a.setRequestId('id-a');
+    b.setRequestId('id-b');
+    expect(a.getRequestId()).toBe('id-a');
+    expect(b.getRequestId()).toBe('id-b');
+  });
+});
+
+describe('RequestContextStorage', () => {
+  it('returns undefined before set', () => {
+    const storage = new RequestContextStorage();
+    expect(storage.getRequestId()).toBeUndefined();
+  });
+
+  it('returns undefined after clear', () => {
+    const storage = new RequestContextStorage();
+    storage.setRequestId('some-id');
+    storage.clear();
+    expect(storage.getRequestId()).toBeUndefined();
+  });
+});
+
+describe('injectRequestId', () => {
+  it('adds requestId to job data when provided', () => {
+    const result = injectRequestId({ type: 'test' }, 'req-123');
+    expect(result.requestId).toBe('req-123');
+    expect(result.type).toBe('test');
+  });
+
+  it('returns data unchanged when requestId is empty', () => {
+    const data = { type: 'test' };
+    const result = injectRequestId(data, '');
+    expect(result).toEqual(data);
+    expect(result.requestId).toBeUndefined();
+  });
+
+  it('returns data unchanged when requestId is undefined', () => {
+    const data = { type: 'test' };
+    const result = injectRequestId(data, undefined);
+    expect(result).toEqual(data);
+    expect(result.requestId).toBeUndefined();
+  });
+});

--- a/xconfess-backend/src/common/request-context.ts
+++ b/xconfess-backend/src/common/request-context.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Module, Global } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 
 export const REQUEST_ID_TOKEN = 'requestId';
@@ -20,12 +20,21 @@ export class RequestContextStorage {
   }
 }
 
-export function createRequestContext(): {
+@Global()
+@Module({
+  providers: [RequestContextStorage],
+  exports: [RequestContextStorage],
+})
+export class RequestContextModule {}
+
+export type RequestContext = {
   getRequestId: () => string | undefined;
   setRequestId: (id: string) => void;
   generateId: () => string;
   runWithContext: <T>(id: string, fn: () => Promise<T>) => Promise<T>;
-} {
+};
+
+export function createRequestContext(): RequestContext {
   const storage = new Map<string, string>();
 
   return {

--- a/xconfess-backend/src/notifications/processors/notification.processor.spec.ts
+++ b/xconfess-backend/src/notifications/processors/notification.processor.spec.ts
@@ -30,6 +30,19 @@ describe('NotificationProcessor', () => {
     );
   });
 
+  it('processes jobs without HTTP request context (no req, no middleware)', async () => {
+    const job = {
+      name: 'send-notification',
+      id: 'job-nohttp',
+      attemptsMade: 0,
+      data: { userId: 'user-1', type: 'test', title: 'Title', message: 'Message' },
+      opts: {},
+    } as unknown as Job<NotificationJobData>;
+
+    await expect(processor.process(job)).resolves.not.toThrow();
+    expect(emailNotificationService.sendEmail).toHaveBeenCalledWith(job.data);
+  });
+
   it('should process notification jobs and emit processing metrics', async () => {
     const job = {
       name: 'send-notification',

--- a/xconfess-backend/src/stellar/stellar-reconciliation.worker.spec.ts
+++ b/xconfess-backend/src/stellar/stellar-reconciliation.worker.spec.ts
@@ -168,6 +168,25 @@ describe('StellarReconciliationWorker', () => {
     expect(contractService.anchorConfession).not.toHaveBeenCalled();
   });
 
+  it('executes without HTTP request context (no req, no middleware)', async () => {
+    const oldDate = new Date(Date.now() - 10 * 60 * 1000);
+    const anchor = {
+      id: 'a5',
+      status: AnchorStatus.PENDING,
+      retryCount: 1,
+      lastRetryAt: new Date(Date.now() - 3 * 60 * 1000),
+      createdAt: oldDate,
+      confessionId: 'c5',
+    } as StellarAnchor;
+
+    anchorRepository.find.mockResolvedValue([anchor]);
+    confessionRepository.findOne.mockResolvedValue({ id: 'c5', message: 'enc' } as AnonymousConfession);
+    contractService.anchorConfession.mockResolvedValue({ hash: 'txhash456' });
+
+    await expect(worker.reconcilePendingAnchors()).resolves.not.toThrow();
+    expect(anchor.status).toBe(AnchorStatus.ANCHORED);
+  });
+
   it('Test 4: Audit log payload', async () => {
     const anchor = {
       id: 'a4',


### PR DESCRIPTION
- Add RequestContextModule with global singleton provider
- Export typed RequestContext interface from createRequestContext()
- Add request-context.spec.ts covering scoped context, isolation, cleanup
- Add no-HTTP-context test to StellarReconciliationWorker spec
- Add no-HTTP-context test to NotificationProcessor spec

Background jobs (scheduled workers, queue processors) running without an HTTP request should never assume middleware-created anonymous context exists. The module provides both DI-based (RequestContextStorage) and scoped (createRequestContext) patterns so each background invocation can safely set up its own context.

<!--
  Small PR policy: https://github.com/Xconfess/Xconfess/blob/main/docs/SMALL_PR_POLICY.md
  Keep this PR focused on ONE issue. Fill in every section — mark unused ones N/A.
-->

## Closes

Closes #<!-- issue number -->

---

## What changed

<!-- One paragraph. What does this PR do? -->

## Why

<!-- One sentence. What problem does this solve, or what does it enable? -->

## How to test

<!-- Step-by-step instructions from a fresh checkout. Include env vars or feature flags if needed. -->

1. 
2. 
3. 

---

## Scope check

<!-- Tick every box that applies. If none apply, explain below. -->

- [ ] This PR touches only the files needed to resolve the linked issue
- [ ] I have not included unrelated refactors, style fixes, or dependency upgrades
- [ ] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

---

## Evidence

### Tests

<!-- Tick what applies. -->

- [ ] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output (paste or screenshot):

```
# paste npm run backend:test / frontend:test / contract:test output here
```

### Screenshots (UI changes only)

<!-- Required for any visible UI change. Delete this section for non-UI PRs. -->

| | Before | After |
|---|---|---|
| Desktop (≥ 1280 px) | | |
| Mobile (≤ 390 px) | | |

---

## Checklist

- [ ] Branch is up to date with `main`
- [ ] All CI checks pass
- [ ] PR description is complete (no empty sections)
- [ ] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)

closes #1225