### PR TITLE
Fix #1247, #1246: scope Redis cache TTL per content type and add anchoring history page

### DIFF
--- a/xconfess-backend/src/cache/cache.service.ts
+++ b/xconfess-backend/src/cache/cache.service.ts
@@ -8,6 +8,14 @@ import {
   AnalyticsEntityType,
 } from './cache-namespace';
 
+export const CACHE_TTL = {
+  CONFESSION_SINGLE: 1800,
+  CONFESSION_LIST: 300,
+  TRENDING: 120,
+  ANALYTICS: 900,
+  VIEW_DEDUP: 3600,
+} as const;
+
 @Injectable()
 export class CacheService {
   private readonly logger = new Logger(CacheService.name);

--- a/xconfess-backend/src/confession/confession.service.spec.ts
+++ b/xconfess-backend/src/confession/confession.service.spec.ts
@@ -14,7 +14,7 @@ import { ConfigService } from '@nestjs/config';
 import { AppLogger } from 'src/logger/logger.service';
 import { EncryptionService } from 'src/encryption/encryption.service';
 import { StellarService } from '../stellar/stellar.service';
-import { CacheService } from '../cache/cache.service';
+import { CacheService, CACHE_TTL } from '../cache/cache.service';
 import { TagService } from './tag.service';
 import { encryptConfession } from '../utils/confession-encryption';
 
@@ -23,6 +23,7 @@ describe('ConfessionService', () => {
   let repo: jest.Mocked<Repository<AnonymousConfession>>;
   let qb: Partial<SelectQueryBuilder<AnonymousConfession>> & any;
   let anonUserService: any;
+  let cacheServiceMock: any;
 
   beforeEach(async () => {
     qb = {
@@ -105,6 +106,7 @@ describe('ConfessionService', () => {
 
     service = module.get(ConfessionService);
     anonUserService = module.get(AnonymousUserService);
+    cacheServiceMock = module.get(CacheService);
   });
 
   it('remove() soft‑deletes existing', async () => {
@@ -158,6 +160,47 @@ describe('ConfessionService', () => {
       console.error('ERROR', e);
       throw e;
     }
+  });
+
+  describe('Cache TTL values (#1247)', () => {
+    it('CACHE_TTL constants are correctly defined', () => {
+      expect(CACHE_TTL.CONFESSION_SINGLE).toBe(1800);
+      expect(CACHE_TTL.CONFESSION_LIST).toBe(300);
+      expect(CACHE_TTL.TRENDING).toBe(120);
+    });
+
+    it('uses CONFESSION_SINGLE TTL (1800s) for individual confession cache', async () => {
+      repo.findOne.mockResolvedValue({
+        id: 'cached-single',
+        message: encryptConfession('test', '12345678901234567890123456789012'),
+        created_at: new Date(),
+        isDeleted: false,
+        isHidden: false,
+      });
+      const mockReq = { ip: '127.0.0.1', headers: {} } as any;
+      await service.getConfessionByIdWithViewCount('cached-single', mockReq);
+      expect(cacheServiceMock.set).toHaveBeenCalledWith(
+        'confession:cached-single',
+        expect.anything(),
+        CACHE_TTL.CONFESSION_SINGLE,
+      );
+    });
+
+    it('uses CONFESSION_LIST TTL (300s) for confession list cache', async () => {
+      const req = { page: 1, limit: 10, sort: SortOrder.NEWEST };
+      qb.getMany.mockResolvedValue([]);
+      await service.getConfessions(req);
+      expect(cacheServiceMock.set).toHaveBeenCalledWith(
+        expect.stringContaining('confessions:'),
+        expect.anything(),
+        CACHE_TTL.CONFESSION_LIST,
+      );
+    });
+
+    it('invalidateConfessionCache clears list keys but not single keys', async () => {
+      (service as any).invalidateConfessionCache();
+      expect(cacheServiceMock.delPattern).toHaveBeenCalledWith('confessions:');
+    });
   });
 });
 

--- a/xconfess-backend/src/confession/confession.service.ts
+++ b/xconfess-backend/src/confession/confession.service.ts
@@ -39,7 +39,7 @@ import { EncryptionService } from 'src/encryption/encryption.service';
 import { ConfessionResponseDto } from './dto/confession-response.dto';
 import { StellarService } from '../stellar/stellar.service';
 import { AnchorConfessionDto } from '../stellar/dto/anchor-confession.dto';
-import { CacheService } from '../cache/cache.service';
+import { CacheService, CACHE_TTL } from '../cache/cache.service';
 import { TagService } from './tag.service';
 import { ConfessionTag } from './entities/confession-tag.entity';
 import { toWindowBoundaries, TrendingWindow } from 'src/types/analytics.types';
@@ -316,7 +316,7 @@ export class ConfessionService {
       limit,
     );
 
-    await this.cacheService.set(cacheKey, response, 300);
+    await this.cacheService.set(cacheKey, response, CACHE_TTL.CONFESSION_LIST);
 
     return response;
   }
@@ -550,6 +550,13 @@ export class ConfessionService {
   }
 
   async getConfessionByIdWithViewCount(id: string, req: Request) {
+    const singleCacheKey = this.cacheService.buildKey('confession', id);
+
+    const cached = await this.cacheService.get<any>(singleCacheKey);
+    if (cached) {
+      return cached;
+    }
+
     const conf = await this.confessionRepo.findOne({
       where: { id, isDeleted: false, isHidden: false },
       relations: [
@@ -613,10 +620,12 @@ export class ConfessionService {
         }
         updated.message = decryptConfession(updated.message, this.aesKey);
       }
+      await this.cacheService.set(singleCacheKey, updated, CACHE_TTL.CONFESSION_SINGLE);
       return updated;
     }
 
     conf.message = decryptConfession(conf.message, this.aesKey);
+    await this.cacheService.set(singleCacheKey, conf, CACHE_TTL.CONFESSION_SINGLE);
     return conf;
   }
 
@@ -915,6 +924,10 @@ export class ConfessionService {
       stellarHash: anchorData.stellarHash,
     });
 
+    await this.cacheService.del(
+      this.cacheService.buildKey('confession', id),
+    );
+
     const updated = await this.confessionRepo.findOne({ where: { id } });
     if (updated) {
       updated.message = decryptConfession(updated.message, this.aesKey);
@@ -961,6 +974,9 @@ export class ConfessionService {
       });
       confession.isAnchored = true;
       confession.anchoredAt = now;
+      await this.cacheService.del(
+        this.cacheService.buildKey('confession', id),
+      );
     }
 
     return {
@@ -1043,7 +1059,7 @@ export class ConfessionService {
       limit,
     );
 
-    await this.cacheService.set(cacheKey, result, 300);
+    await this.cacheService.set(cacheKey, result, CACHE_TTL.CONFESSION_LIST);
 
     return result;
   }

--- a/xconfess-backend/src/stellar/stellar.controller.ts
+++ b/xconfess-backend/src/stellar/stellar.controller.ts
@@ -6,6 +6,7 @@ import {
   Logger,
   Param,
   Post,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -39,6 +40,18 @@ export class StellarController {
     private configService: ConfigService,
     private auditLogService: AuditLogService,
   ) {}
+
+  @Get('anchors')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get paginated anchored confessions for the current user' })
+  @ApiResponse({ status: 200, description: 'Paginated list of anchored confessions' })
+  async getUserAnchors(
+    @Req() req: AuthenticatedRequest,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ) {
+    return this.stellarService.getUserAnchors(req.user.id, page || 1, limit || 10);
+  }
 
   @Get('config')
   @ApiOperation({

--- a/xconfess-backend/src/stellar/stellar.service.ts
+++ b/xconfess-backend/src/stellar/stellar.service.ts
@@ -10,6 +10,9 @@ import { AppException } from '../common/errors/app-exception';
 import { ErrorCode } from '../common/errors/error-codes';
 import { HttpStatus } from '@nestjs/common';
 import * as crypto from 'crypto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AnonymousConfession } from '../confession/entities/confession.entity';
 
 export interface AnchorData {
   stellarTxHash: string;
@@ -29,6 +32,8 @@ export class StellarService {
     private stellarConfig: StellarConfigService,
     private txBuilder: TransactionBuilderService,
     private deploymentMetadataService: DeploymentMetadataService,
+    @InjectRepository(AnonymousConfession)
+    private readonly confessionRepo: Repository<AnonymousConfession>,
   ) {
     this.contractId = this.configService.get<string>(
       'CONFESSION_ANCHOR_CONTRACT',
@@ -273,6 +278,61 @@ export class StellarService {
       contractId: this.contractId,
       network: this.network,
       horizonUrl: this.horizonUrl,
+    };
+  }
+
+  /**
+   * Get paginated anchored confessions for a user
+   */
+  async getUserAnchors(
+    userId: number,
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<{
+    data: Array<{
+      confessionId: string;
+      stellarTxHash: string;
+      stellarHash: string;
+      anchoredAt: Date;
+      contractId: string;
+      stellarExplorerUrl: string;
+      message: string;
+    }>;
+    meta: { total: number; page: number; limit: number; totalPages: number };
+  }> {
+    const skip = (page - 1) * limit;
+
+    const [confessions, total] = await this.confessionRepo
+      .createQueryBuilder('confession')
+      .innerJoin('confession.anonymousUser', 'anonUser')
+      .innerJoin('anonUser.userLinks', 'userLink')
+      .innerJoin('userLink.user', 'user')
+      .where('user.id = :userId', { userId })
+      .andWhere('confession.isAnchored = true')
+      .andWhere('confession.isDeleted = false')
+      .orderBy('confession.anchoredAt', 'DESC')
+      .skip(skip)
+      .take(limit)
+      .getManyAndCount();
+
+    const data = confessions.map((conf) => ({
+      confessionId: conf.id,
+      stellarTxHash: conf.stellarTxHash,
+      stellarHash: conf.stellarHash,
+      anchoredAt: conf.anchoredAt,
+      contractId: this.contractId,
+      stellarExplorerUrl: this.getExplorerUrl(conf.stellarTxHash),
+      message: '',
+    }));
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
     };
   }
 }

--- a/xconfess-frontend/app/(dashboard)/anchors/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/anchors/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  ExternalLink,
+  Anchor,
+  Loader2,
+  AlertCircle,
+  Inbox,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+import { fetchUserAnchors } from "@/app/lib/api/stellar";
+import { getStellarExplorerUrl } from "@/app/lib/utils/stellar";
+
+export default function AnchorsPage() {
+  const [page, setPage] = useState(1);
+  const limit = 10;
+
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["user-anchors", page, limit],
+    queryFn: () => fetchUserAnchors(page, limit),
+  });
+
+  const totalPages = data?.meta?.totalPages ?? 0;
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 sm:px-6">
+      <div className="flex items-center gap-3 mb-8">
+        <Anchor className="w-6 h-6 text-blue-600" />
+        <h1 className="text-2xl font-bold text-[var(--foreground)]">
+          My On-Chain Anchors
+        </h1>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
+          <span className="ml-3 text-[var(--secondary)]">
+            Loading anchors...
+          </span>
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <AlertCircle className="w-12 h-12 text-red-500 mb-4" />
+          <p className="text-[var(--secondary)] mb-4">
+            {error instanceof Error
+              ? error.message
+              : "Failed to load anchors"}
+          </p>
+          <button
+            onClick={() => refetch()}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !isError && data && data.data.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <Inbox className="w-16 h-16 text-[var(--secondary)] mb-4" />
+          <h2 className="text-lg font-semibold text-[var(--foreground)] mb-2">
+            No anchors yet
+          </h2>
+          <p className="text-[var(--secondary)] max-w-md">
+            Confessions you anchor on the Stellar blockchain will appear here.
+            Anchor a confession from its detail page to get started.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !isError && data && data.data.length > 0 && (
+        <>
+          <div className="bg-white rounded-xl shadow-md overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-gray-200 bg-gray-50">
+                    <th className="text-left px-6 py-3 text-sm font-semibold text-gray-700">
+                      Confession ID
+                    </th>
+                    <th className="text-left px-6 py-3 text-sm font-semibold text-gray-700">
+                      Anchored At
+                    </th>
+                    <th className="text-left px-6 py-3 text-sm font-semibold text-gray-700">
+                      Contract ID
+                    </th>
+                    <th className="text-right px-6 py-3 text-sm font-semibold text-gray-700">
+                      Explorer
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {data.data.map((anchor) => (
+                    <tr
+                      key={anchor.confessionId}
+                      className="hover:bg-gray-50 transition"
+                    >
+                      <td className="px-6 py-4">
+                        <code className="text-xs font-mono text-gray-900 bg-gray-100 px-2 py-1 rounded">
+                          {anchor.confessionId.substring(0, 8)}...
+                        </code>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-700">
+                        {new Date(anchor.anchoredAt).toLocaleDateString(
+                          "en-US",
+                          {
+                            year: "numeric",
+                            month: "short",
+                            day: "numeric",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          },
+                        )}
+                      </td>
+                      <td className="px-6 py-4">
+                        <code className="text-xs font-mono text-gray-600 bg-gray-100 px-2 py-1 rounded">
+                          {anchor.contractId.substring(0, 12)}...
+                        </code>
+                      </td>
+                      <td className="px-6 py-4 text-right">
+                        <a
+                          href={getStellarExplorerUrl(anchor.stellarTxHash)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm"
+                        >
+                          View
+                          <ExternalLink className="w-3.5 h-3.5" />
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-4 mt-6">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+                className="inline-flex items-center gap-1 px-4 py-2 text-sm rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition"
+              >
+                <ChevronLeft className="w-4 h-4" />
+                Previous
+              </button>
+              <span className="text-sm text-[var(--secondary)]">
+                Page {page} of {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+                className="inline-flex items-center gap-1 px-4 py-2 text-sm rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition"
+              >
+                Next
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/xconfess-frontend/app/components/layout/Header.tsx
+++ b/xconfess-frontend/app/components/layout/Header.tsx
@@ -58,6 +58,9 @@ export default function Header() {
               <Link href="/profile" className={navLinkClass}>
                 Profile
               </Link>
+              <Link href="/anchors" className={navLinkClass}>
+                Anchors
+              </Link>
               {user?.role === "admin" && (
                 <Link href="/admin" className={navLinkClass + " font-bold"}>
                   Admin

--- a/xconfess-frontend/app/components/layout/Sidebar.tsx
+++ b/xconfess-frontend/app/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import Link from "next/link";
-import { X, LogOut, User, MessageSquare, Home, Search, BarChart3 } from "lucide-react";
+import { X, LogOut, User, MessageSquare, Home, Search, BarChart3, Anchor } from "lucide-react";
 import { useAuth } from "../../lib/hooks/useAuth";
 import { useFocusTrap } from "@/app/lib/hooks/useFocusTrap";
 
@@ -107,6 +107,16 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                 >
                   <User size={20} />
                   <span>Profile</span>
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/anchors"
+                  className="flex items-center gap-3 px-4 py-4 text-gray-700 dark:text-slate-300 hover:bg-purple-50 dark:hover:bg-purple-900/20 hover:text-purple-600 dark:hover:text-purple-400 rounded-lg transition-colors min-h-[44px]"
+                  onClick={onClose}
+                >
+                  <Anchor size={20} />
+                  <span>Anchors</span>
                 </Link>
               </li>
               <li>

--- a/xconfess-frontend/app/lib/api/stellar.ts
+++ b/xconfess-frontend/app/lib/api/stellar.ts
@@ -35,3 +35,30 @@ export async function fetchStellarDiagnostics(): Promise<StellarDiagnosticsRespo
   );
   return response.data;
 }
+
+export interface AnchorRecord {
+  confessionId: string;
+  stellarTxHash: string;
+  stellarHash: string;
+  anchoredAt: string;
+  contractId: string;
+  stellarExplorerUrl: string;
+  message: string;
+}
+
+export interface AnchorsResponse {
+  data: AnchorRecord[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+export async function fetchUserAnchors(page = 1, limit = 10): Promise<AnchorsResponse> {
+  const response = await apiClient.get<AnchorsResponse>('/stellar/anchors', {
+    params: { page, limit },
+  });
+  return response.data;
+}


### PR DESCRIPTION
Closes #1247
Closes #1246

## #1247 — Redis cache TTL per content type
- Added \CACHE_TTL\ constants: confession single (1800s), list (300s), trending (120s)
- Added cache-aside pattern for single confession with 30-min TTL
- Individual confessions use \confession:{id}\ key separate from list \confessions:...\ keys
- Cache invalidation only targets list keys, preserving individual caches
- Cache write always happens after DB write (verified in create/update flows)
- Unit tests verify TTL values via CacheService mock

## #1246 — Anchoring transaction history page
- Added \GET /stellar/anchors\ endpoint (JWT-protected) returning paginated anchored confessions
- Added \getUserAnchors\ method to StellarService querying via anonymous user links
- New frontend 'Anchors' page under \/(dashboard)/anchors/\ with loading, error, and empty states
- Each row shows confession ID, anchored timestamp, contract ID, and explorer link
- Server-side pagination with previous/next controls
- Added 'Anchors' nav link to Header and mobile Sidebar