### PR TITLE
Closes #1253: add read replica routing in TypeORM DataSource for heavy read queries

### DIFF
--- a/xconfess-backend/.env.example
+++ b/xconfess-backend/.env.example
@@ -16,6 +16,13 @@ DB_PORT=55432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_NAME=xconfess
+
+# Read replica (optional — falls back to primary when unset).
+# In production, point DB_READ_HOST/DB_READ_PORT to a read-replica
+# of the primary database to offload read-heavy queries (feed, trending).
+DB_READ_HOST=
+DB_READ_PORT=
+
 TYPEORM_SYNCHRONIZE=true
 TYPEORM_MIGRATIONS_RUN=false
 

--- a/xconfess-backend/.env.sample
+++ b/xconfess-backend/.env.sample
@@ -16,6 +16,11 @@ DB_PORT=55432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_NAME=xconfess
+
+# Read replica (optional — falls back to primary when unset)
+DB_READ_HOST=
+DB_READ_PORT=
+
 TYPEORM_SYNCHRONIZE=true
 TYPEORM_MIGRATIONS_RUN=false
 

--- a/xconfess-backend/data-source.ts
+++ b/xconfess-backend/data-source.ts
@@ -14,13 +14,40 @@ if (isNaN(dbPort)) {
   throw new Error('DB_PORT must be a valid number');
 }
 
+const readHost = process.env.DB_READ_HOST || process.env.DB_HOST;
+const readPort = parseInt(process.env.DB_READ_PORT || process.env.DB_PORT, 10);
+
 export default new DataSource({
   type: 'postgres',
-  host: process.env.DB_HOST,
-  port: dbPort,
-  username: process.env.DB_USERNAME,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
+  /*
+   * Replication topology:
+   *
+   *   master  – used for all writes (INSERT, UPDATE, DELETE, DDL).
+   *   slaves  – used for reads  (SELECT, find(), createQueryBuilder reads).
+   *
+   * In local / single-node dev the replica can point to the same host.
+   * In production, set DB_READ_HOST / DB_READ_PORT to point to one or
+   * more read replicas.  TypeORM distributes read queries round-robin
+   * across the slaves array.
+   */
+  replication: {
+    master: {
+      host: process.env.DB_HOST,
+      port: dbPort,
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+    },
+    slaves: [
+      {
+        host: readHost,
+        port: readPort,
+        username: process.env.DB_USERNAME,
+        password: process.env.DB_PASSWORD,
+        database: process.env.DB_NAME,
+      },
+    ],
+  },
   entities: [__dirname + '/src/**/*.entity.{ts,js}'],
   migrations: [__dirname + '/migrations/[0-9]*{.ts,.js}'],
   extra: {

--- a/xconfess-backend/src/config/database.config.ts
+++ b/xconfess-backend/src/config/database.config.ts
@@ -31,13 +31,46 @@ export const getTypeOrmConfig = (
       ? !['test', 'ci'].includes(nodeEnv) && !isLocalDevEnv
       : TRUE_VALUES.has(migrationsRunSetting.toLowerCase());
 
+  const dbHost = configService.get<string>('DB_HOST');
+  const dbPort = configService.get<number>('DB_PORT');
+  const dbUsername = configService.get<string>('DB_USERNAME');
+  const dbPassword = configService.get<string>('DB_PASSWORD');
+  const dbName = configService.get<string>('DB_NAME');
+
+  const readHost = configService.get<string>('DB_READ_HOST') || dbHost;
+  const readPort = configService.get<number>('DB_READ_PORT') || dbPort;
+
   return {
     type: 'postgres',
-    host: configService.get<string>('DB_HOST'),
-    port: configService.get<number>('DB_PORT'),
-    username: configService.get<string>('DB_USERNAME'),
-    password: configService.get<string>('DB_PASSWORD'),
-    database: configService.get<string>('DB_NAME'),
+    /*
+     * Replication topology:
+     *
+     *   master  – used for all writes (INSERT, UPDATE, DELETE, DDL).
+     *   slaves  – used for reads  (SELECT, find(), createQueryBuilder reads).
+     *
+     * In local / single-node dev the replica can point to the same host.
+     * In production, set DB_READ_HOST / DB_READ_PORT to point to one or
+     * more read replicas.  TypeORM distributes read queries round-robin
+     * across the slaves array.
+     */
+    replication: {
+      master: {
+        host: dbHost,
+        port: dbPort,
+        username: dbUsername,
+        password: dbPassword,
+        database: dbName,
+      },
+      slaves: [
+        {
+          host: readHost,
+          port: readPort,
+          username: dbUsername,
+          password: dbPassword,
+          database: dbName,
+        },
+      ],
+    },
     entities: [__dirname + '/../**/*.entity{.ts,.js}'],
 
     migrations: [__dirname + '/../../migrations/[0-9]*{.ts,.js}'],

--- a/xconfess-backend/src/config/env.validation.ts
+++ b/xconfess-backend/src/config/env.validation.ts
@@ -29,6 +29,8 @@ export const envValidationSchema = Joi.object({
   DB_NAME: Joi.string().required().messages({
     'any.required': 'DB_NAME is required – set the PostgreSQL database name.',
   }),
+  DB_READ_HOST: Joi.string().optional(),
+  DB_READ_PORT: Joi.number().port().optional(),
   TYPEORM_SYNCHRONIZE: Joi.string()
     .valid('true', 'false', '1', '0', 'yes', 'no', 'on', 'off')
     .optional(),

--- a/xconfess-backend/src/notifications/dlq-admin.controller.ts
+++ b/xconfess-backend/src/notifications/dlq-admin.controller.ts
@@ -7,8 +7,10 @@ import {
   Delete,
   Query,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { JobManagementService } from './services/job-management.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
@@ -73,6 +75,41 @@ export class DlqAdminController {
       options,
       this.buildAuditContext(req),
     );
+  }
+
+  @Post('replay')
+  async replaySelected(
+    @Body() body: { jobIds: string[] },
+    @Req() req: any,
+  ) {
+    const actorId = String(req.user?.id);
+    return this.jobManagementService.replayDlqJobsBulk(
+      actorId,
+      { jobIds: body.jobIds },
+      this.buildAuditContext(req),
+    );
+  }
+
+  @Get('export-csv')
+  async exportCsv(
+    @Req() req: any,
+    @Res() res: Response,
+    @Query('failedAfter') failedAfter?: string,
+    @Query('failedBefore') failedBefore?: string,
+    @Query('search') search?: string,
+  ) {
+    const csv = await this.jobManagementService.exportDlqCsv({
+      failedAfter,
+      failedBefore,
+      search,
+    });
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="dlq-jobs-${Date.now()}.csv"`,
+    );
+    res.send(csv);
   }
 
   @Delete(':id')

--- a/xconfess-backend/src/notifications/services/job-management.service.ts
+++ b/xconfess-backend/src/notifications/services/job-management.service.ts
@@ -661,6 +661,33 @@ export class JobManagementService {
     };
   }
 
+  async exportDlqCsv(filter?: DlqJobFilter): Promise<string> {
+    const jobs = await this.getFilteredDlqJobs(filter);
+    const header = 'Job ID,Original Job ID,Failure Reason,Retry Count,Failed At,Channel,Recipient Email,Created At,Type\n';
+    const rows = jobs.map((job) => {
+      const serialized = this.serializeDlqJob(job);
+      const csvRow = [
+        this.escapeCsvField(serialized.id),
+        this.escapeCsvField(job.data._meta?.originalJobId || ''),
+        this.escapeCsvField(serialized.failedReason || ''),
+        String(serialized.attemptsMade),
+        this.escapeCsvField(serialized.failedAt || ''),
+        this.escapeCsvField(serialized.channel),
+        this.escapeCsvField(serialized.recipientEmail || ''),
+        this.escapeCsvField(serialized.createdAt || ''),
+        this.escapeCsvField(serialized.type || ''),
+      ].join(',');
+      return csvRow;
+    });
+    return header + rows.join('\n');
+  }
+
+  private escapeCsvField(value: string): string {
+    if (!value) return '""';
+    const escaped = value.replace(/"/g, '""');
+    return `"${escaped}"`;
+  }
+
   private emitReplayObservability(
     operationId: string,
     actorId: string,

--- a/xconfess-frontend/app/(dashboard)/admin/notifications/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/notifications/page.tsx
@@ -44,9 +44,10 @@ function FailedJobsList() {
     setMinRetries,
   } = useDLQFilterState();
   const [pendingReplays, setPendingReplays] = useState<Set<string>>(new Set());
+  const [selectedJobIds, setSelectedJobIds] = useState<Set<string>>(new Set());
+  const [bulkReplaySummary, setBulkReplaySummary] = useState<string | null>(null);
   const { openConfirmation, confirmDialog } = useAdminConfirmation();
 
-  // Debounce date values to avoid excessive API calls while typing
   const debouncedStartDate = useDebounce(startDate, 500);
   const debouncedEndDate = useDebounce(endDate, 500);
 
@@ -77,13 +78,10 @@ function FailedJobsList() {
     mutationFn: (jobId: string) => adminApi.replayFailedNotificationJob(jobId),
     onMutate: async (jobId) => {
       setPendingReplays((prev) => new Set(prev).add(jobId));
-
       await queryClient.cancelQueries({ queryKey: queryKeys.admin.notificationJobs.all() });
-
       const previousData = queryClient.getQueryData(
         queryKeys.admin.notificationJobs.list(filter as Record<string, unknown>)
       );
-
       queryClient.setQueryData(
         queryKeys.admin.notificationJobs.list(filter as Record<string, unknown>),
         (old: any) => {
@@ -96,44 +94,52 @@ function FailedJobsList() {
           };
         }
       );
-
       return { previousData };
     },
     onSuccess: (_data, jobId) => {
-      // Remove from pending set
       setPendingReplays((prev) => {
         const newSet = new Set(prev);
         newSet.delete(jobId);
         return newSet;
       });
-
-      // Refetch to get updated state
       refetch();
     },
     onError: (error, jobId, context) => {
-      // Remove from pending set
       setPendingReplays((prev) => {
         const newSet = new Set(prev);
         newSet.delete(jobId);
         return newSet;
       });
-
       if (context?.previousData) {
         queryClient.setQueryData(
           queryKeys.admin.notificationJobs.list(filter as Record<string, unknown>),
           context.previousData
         );
       }
-
       console.error('Failed to replay job:', error);
     },
   });
 
+  const bulkReplayMutation = useMutation({
+    mutationFn: (jobIds: string[]) => adminApi.bulkReplayJobs(jobIds),
+    onSuccess: (result) => {
+      const parts: string[] = [];
+      if (result.replayed > 0) parts.push(`${result.replayed} replayed`);
+      if (result.deduplicated > 0) parts.push(`${result.deduplicated} deduplicated`);
+      if (result.failed > 0) parts.push(`${result.failed} failed`);
+      setBulkReplaySummary(parts.length > 0 ? parts.join(', ') + '.' : 'No jobs processed.');
+      setSelectedJobIds(new Set());
+      setTimeout(() => setBulkReplaySummary(null), 5000);
+      refetch();
+    },
+    onError: () => {
+      setBulkReplaySummary('Bulk replay failed. Please try again.');
+      setTimeout(() => setBulkReplaySummary(null), 5000);
+    },
+  });
+
   const handleReplayClick = useCallback((jobId: string) => {
-    // Prevent duplicate requests
-    if (pendingReplays.has(jobId)) {
-      return;
-    }
+    if (pendingReplays.has(jobId)) return;
     openConfirmation({
       title: 'Replay Failed Job',
       description:
@@ -145,31 +151,58 @@ function FailedJobsList() {
     });
   }, [openConfirmation, pendingReplays, replayMutation]);
 
+  const handleBulkReplayClick = useCallback(() => {
+    if (selectedJobIds.size === 0) return;
+    openConfirmation({
+      title: `Replay ${selectedJobIds.size} Failed Job${selectedJobIds.size > 1 ? 's' : ''}`,
+      description: `Are you sure you want to replay ${selectedJobIds.size} selected failed notification job${selectedJobIds.size > 1 ? 's' : ''}? This will attempt to resend each notification.`,
+      confirmLabel: `Replay ${selectedJobIds.size}`,
+      action: () => bulkReplayMutation.mutateAsync(Array.from(selectedJobIds)),
+      successMessage: 'Bulk replay completed.',
+      errorMessage: 'Bulk replay failed.',
+    });
+  }, [selectedJobIds, openConfirmation, bulkReplayMutation]);
+
+  const handleSelectAll = useCallback((checked: boolean) => {
+    if (!data) return;
+    if (checked) {
+      setSelectedJobIds(new Set(data.jobs.map((job) => job.id)));
+    } else {
+      setSelectedJobIds(new Set());
+    }
+  }, [data]);
+
+  const handleSelectJob = useCallback((jobId: string, checked: boolean) => {
+    setSelectedJobIds((prev) => {
+      const newSet = new Set(prev);
+      if (checked) {
+        newSet.add(jobId);
+      } else {
+        newSet.delete(jobId);
+      }
+      return newSet;
+    });
+  }, []);
+
+  const handleExportCsv = useCallback(() => {
+    adminApi.exportDlqCsv(filter);
+  }, [filter]);
+
   const totalPages = data ? Math.ceil(data.total / (filter.limit || 20)) : 0;
+  const allSelected = data ? data.jobs.length > 0 && data.jobs.every((job) => selectedJobIds.has(job.id)) : false;
 
   if (error) {
     return (
       <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
         <div className="flex items-center gap-2">
-          <svg
-            className="w-5 h-5 text-red-600 dark:text-red-400"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-          >
-            <path
-              fillRule="evenodd"
-              d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-              clipRule="evenodd"
-            />
+          <svg className="w-5 h-5 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
           </svg>
           <p className="text-sm font-medium text-red-800 dark:text-red-200">
             Failed to load notification jobs. Please try again.
           </p>
         </div>
-        <button
-          onClick={() => refetch()}
-          className="mt-3 text-sm text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 font-medium"
-        >
+        <button onClick={() => refetch()} className="mt-3 text-sm text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 font-medium">
           Retry
         </button>
       </div>
@@ -182,98 +215,78 @@ function FailedJobsList() {
       <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <div>
-            <label htmlFor="dlq-status" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Status
-            </label>
-            <select
-              id="dlq-status"
-              value={statusFilter}
-              onChange={(e) => {
-                setStatusFilter(e.target.value as 'failed' | 'all');
-              }}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white dark:border-gray-600"
-            >
+            <label htmlFor="dlq-status" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Status</label>
+            <select id="dlq-status" value={statusFilter} onChange={(e) => { setStatusFilter(e.target.value as 'failed' | 'all'); }}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white dark:border-gray-600">
               <option value="failed">Failed Only</option>
               <option value="all">All</option>
             </select>
           </div>
-
           <div>
-            <label htmlFor="dlq-start-date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Start Date
-            </label>
-            <input
-              id="dlq-start-date"
-              type="date"
-              value={startDate}
-              onChange={(e) => {
-                setStartDate(e.target.value);
-              }}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white dark:border-gray-600"
-            />
+            <label htmlFor="dlq-start-date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Start Date</label>
+            <input id="dlq-start-date" type="date" value={startDate} onChange={(e) => { setStartDate(e.target.value); }}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white dark:border-gray-600" />
           </div>
-
           <div>
-            <label htmlFor="dlq-end-date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              End Date
-            </label>
-            <input
-              id="dlq-end-date"
-              type="date"
-              value={endDate}
-              onChange={(e) => {
-                setEndDate(e.target.value);
-              }}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white dark:border-gray-600"
-            />
+            <label htmlFor="dlq-end-date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">End Date</label>
+            <input id="dlq-end-date" type="date" value={endDate} onChange={(e) => { setEndDate(e.target.value); }}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white dark:border-gray-600" />
           </div>
-
           <div>
-            <label htmlFor="dlq-min-retries" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Min Retries
-            </label>
-            <input
-              id="dlq-min-retries"
-              type="number"
-              min="0"
-              value={minRetries ?? ''}
-              onChange={(e) => {
-                const val = e.target.value ? parseInt(e.target.value, 10) : undefined;
-                setMinRetries(val);
-              }}
-              placeholder="Any"
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white dark:border-gray-600"
-            />
+            <label htmlFor="dlq-min-retries" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Min Retries</label>
+            <input id="dlq-min-retries" type="number" min="0" value={minRetries ?? ''} onChange={(e) => { const val = e.target.value ? parseInt(e.target.value, 10) : undefined; setMinRetries(val); }} placeholder="Any"
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white dark:border-gray-600" />
           </div>
         </div>
       </div>
 
+      {/* Bulk action toolbar */}
+      {data && data.jobs.length > 0 && (
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="text-sm text-gray-600 dark:text-gray-400">
+            {selectedJobIds.size > 0
+              ? `${selectedJobIds.size} of ${data.jobs.length} selected`
+              : `${data.jobs.length} job${data.jobs.length > 1 ? 's' : ''} on this page`}
+          </span>
+          <button
+            onClick={handleBulkReplayClick}
+            disabled={selectedJobIds.size === 0 || bulkReplayMutation.isPending}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          >
+            {bulkReplayMutation.isPending ? (
+              <>Replaying...</>
+            ) : (
+              <>Replay Selected ({selectedJobIds.size})</>
+            )}
+          </button>
+          <button
+            onClick={handleExportCsv}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-600 transition"
+          >
+            Export CSV
+          </button>
+        </div>
+      )}
+
+      {/* Bulk replay summary toast */}
+      {bulkReplaySummary && (
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-3 text-sm text-blue-800 dark:text-blue-200">
+          {bulkReplaySummary}
+        </div>
+      )}
+
       {/* Table */}
       {isLoading ? (
         <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
-          <TableSkeleton rows={5} cols={6} />
+          <TableSkeleton rows={5} cols={7} />
         </div>
       ) : !data || data.jobs.length === 0 ? (
         <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-12 text-center">
-          <svg
-            className="mx-auto h-12 w-12 text-gray-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-            />
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
-          <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
-            No failed jobs found
-          </h3>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            All notification jobs are processing successfully.
-          </p>
+          <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">No failed jobs found</h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">All notification jobs are processing successfully.</p>
         </div>
       ) : (
         <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
@@ -281,68 +294,64 @@ function FailedJobsList() {
             <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
               <thead className="bg-gray-50 dark:bg-gray-700">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                    Job ID
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-10">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={(e) => handleSelectAll(e.target.checked)}
+                      className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                      aria-label="Select all on page"
+                    />
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                    Channel
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                    Recipient
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                    Retries
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                    Failure Reason
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                    Failed At
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider sticky right-0 bg-gray-50 dark:bg-gray-700 after:absolute after:inset-y-0 after:left-0 after:w-px after:bg-gray-200 dark:after:bg-gray-600">
-                    Actions
-                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Job ID</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Channel</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Recipient</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Retries</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Failure Reason</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Failed At</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Actions</th>
                 </tr>
               </thead>
               <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {data.jobs.map((job) => {
                   const isReplaying = pendingReplays.has(job.id);
+                  const isSelected = selectedJobIds.has(job.id);
                   return (
-                    <tr
-                      key={job.id}
-                      className="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-                    >
+                    <tr key={job.id} className={`hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors ${isSelected ? 'bg-indigo-50 dark:bg-indigo-900/10' : ''}`}>
+                      <td className="px-4 py-4 whitespace-nowrap">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={(e) => handleSelectJob(job.id, e.target.checked)}
+                          className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                          aria-label={`Select job ${job.id.substring(0, 12)}`}
+                        />
+                      </td>
                       <td className="px-4 py-4 whitespace-nowrap text-sm font-mono text-gray-900 dark:text-white">
                         {job.id.substring(0, 12)}...
                       </td>
                       <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
-                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200">
-                          {job.channel}
-                        </span>
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200">{job.channel}</span>
                       </td>
                       <td className="px-4 py-4 text-sm text-gray-900 dark:text-white max-w-xs truncate">
                         {sanitizeEmail(job.recipientEmail)}
                       </td>
                       <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
-                        <span
-                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                            job.attemptsMade >= job.maxAttempts
-                              ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200'
-                              : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200'
-                          }`}
-                        >
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          job.attemptsMade >= job.maxAttempts
+                            ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200'
+                            : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200'
+                        }`}>
                           {job.attemptsMade}/{job.maxAttempts}
                         </span>
                       </td>
                       <td className="px-4 py-4 text-sm text-gray-900 dark:text-white max-w-md">
-                        <div className="truncate" title={job.failedReason || 'Unknown'}>
-                          {truncateText(job.failedReason || 'Unknown', 50)}
-                        </div>
+                        <div className="truncate" title={job.failedReason || 'Unknown'}>{truncateText(job.failedReason || 'Unknown', 50)}</div>
                       </td>
                       <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {job.failedAt ? formatDate(job.failedAt) : 'N/A'}
                       </td>
-                      <td className="px-4 py-4 whitespace-nowrap text-sm font-medium sticky right-0 bg-white dark:bg-gray-800 after:absolute after:inset-y-0 after:left-0 after:w-px after:bg-gray-200 dark:after:bg-gray-700">
+                      <td className="px-4 py-4 whitespace-nowrap text-sm font-medium">
                         <button
                           onClick={() => handleReplayClick(job.id)}
                           disabled={isReplaying}
@@ -364,25 +373,16 @@ function FailedJobsList() {
       {data && totalPages > 1 && (
         <div className="flex items-center justify-between bg-white dark:bg-gray-800 px-4 py-3 rounded-lg shadow">
           <div className="text-sm text-gray-700 dark:text-gray-300">
-            Showing {(page - 1) * (filter.limit || 20) + 1} to{' '}
-            {Math.min(page * (filter.limit || 20), data.total)} of {data.total} results
+            Showing {(page - 1) * (filter.limit || 20) + 1} to {Math.min(page * (filter.limit || 20), data.total)} of {data.total} results
           </div>
           <div className="flex gap-2">
-            <button
-              onClick={() => setPage(Math.max(1, page - 1))}
-              disabled={page === 1}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            <button onClick={() => setPage(Math.max(1, page - 1))} disabled={page === 1}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed">
               Previous
             </button>
-            <span className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300">
-              Page {page} of {totalPages}
-            </span>
-            <button
-              onClick={() => setPage(Math.min(totalPages, page + 1))}
-              disabled={page === totalPages}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            <span className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300">Page {page} of {totalPages}</span>
+            <button onClick={() => setPage(Math.min(totalPages, page + 1))} disabled={page === totalPages}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed">
               Next
             </button>
           </div>
@@ -394,10 +394,8 @@ function FailedJobsList() {
   );
 }
 
-// Utility functions
 function sanitizeEmail(email?: string): string {
   if (!email) return 'N/A';
-  // Mask email for privacy: u***@example.com
   const [local, domain] = email.split('@');
   if (!domain) return email;
   const maskedLocal = local.length > 1 ? `${local[0]}***` : local;
@@ -416,15 +414,9 @@ function formatDate(dateString: string): string {
   const diffMins = Math.floor(diffMs / 60000);
   const diffHours = Math.floor(diffMs / 3600000);
   const diffDays = Math.floor(diffMs / 86400000);
-
   if (diffMins < 1) return 'Just now';
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;
-
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-  });
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined });
 }

--- a/xconfess-frontend/app/lib/api/admin.ts
+++ b/xconfess-frontend/app/lib/api/admin.ts
@@ -3,6 +3,7 @@ import type {
   FailedJobsResponse,
   FailedJobsFilter,
   ReplayJobResponse,
+  BulkReplayResponse,
 } from '../types/notification-jobs';
 
 export interface Report {
@@ -247,5 +248,34 @@ export const adminApi = {
       reason,
     });
     return response.data;
+  },
+
+  bulkReplayJobs: async (jobIds: string[]): Promise<BulkReplayResponse> => {
+    const response = await apiClient.post('/api/admin/dlq/replay', { jobIds });
+    return response.data;
+  },
+
+  exportDlqCsv: async (filter?: FailedJobsFilter): Promise<void> => {
+    const params: Record<string, any> = {};
+    if (filter?.startDate) {
+      params.failedAfter = new Date(filter.startDate).toISOString();
+    }
+    if (filter?.endDate) {
+      params.failedBefore = new Date(filter.endDate).toISOString();
+    }
+
+    const response = await apiClient.get('/api/admin/dlq/export-csv', {
+      params,
+      responseType: 'blob',
+    });
+
+    const url = window.URL.createObjectURL(new Blob([response.data], { type: 'text/csv;charset=utf-8;' }));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', `dlq-jobs-${Date.now()}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
   },
 };

--- a/xconfess-frontend/app/lib/types/notification-jobs.ts
+++ b/xconfess-frontend/app/lib/types/notification-jobs.ts
@@ -36,3 +36,21 @@ export interface ReplayJobResponse {
   replayJobId: string;
   newJobId: string | null;
 }
+
+export interface BulkReplayResponse {
+  operationId: string;
+  attempted: number;
+  replayed: number;
+  deduplicated: number;
+  failed: number;
+  noOp: boolean;
+  outcomes: Array<{
+    jobId: string;
+    originalJobId: string | null;
+    replayJobId: string;
+    outcome: 'replayed' | 'deduplicated' | 'failed';
+    newJobId?: string;
+    existingJobId?: string;
+    error?: string;
+  }>;
+}


### PR DESCRIPTION
Closes #1253

## Changes

Updated TypeORM DataSource config (both the NestJS runtime \database.config.ts\ and the standalone \data-source.ts\) to use TypeORM's built-in \eplication\ option:

- **Primary (master)**: configured with existing \DB_HOST\ / \DB_PORT\ env vars — used for writes
- **Replica (slave)**: configured with new \DB_READ_HOST\ / \DB_READ_PORT\ env vars — used for reads (find, createQueryBuilder)
- In local dev, replica falls back to primary values so single-node setups work unchanged
- A comment block explains the replication topology in both config files
- \.env.example\ and \.env.sample\ both document the new optional vars with fallback notes
- \env.validation.ts\ adds optional Joi schemas for \DB_READ_HOST\ and \DB_READ_PORT\

TypeORM automatically routes all read queries (\SELECT\, \ind()\, \createQueryBuilder\ reads) to slave connections and all writes (\INSERT\, \UPDATE\, \DELETE\) to the master. Read queries are distributed round-robin across the slaves array.