### PR TITLE
feat: add confession bookmark/save-for-later backend module

### DIFF
--- a/xconfess-backend/src/app.module.ts
+++ b/xconfess-backend/src/app.module.ts
@@ -31,6 +31,7 @@ import { EncryptionModule } from './encryption/encryption.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { DatabaseModule } from './database/database.module';
 import { FeatureFlagsModule } from './feature-flags/feature-flags.module';
+import { BookmarkModule } from './bookmark/bookmark.module';
 // ✅ Canonical queue stack: @nestjs/bullmq (BullMQ v4 + ioredis)
 // The legacy @nestjs/bull import has been removed. All queues use BullMQ.
 import { BullModule } from '@nestjs/bullmq';
@@ -140,6 +141,7 @@ import { BullModule } from '@nestjs/bullmq';
     CacheModule,
     DatabaseModule,
     FeatureFlagsModule,
+    BookmarkModule,
   ],
   controllers: [AppController],
   providers: [

--- a/xconfess-backend/src/bookmark/bookmark.controller.ts
+++ b/xconfess-backend/src/bookmark/bookmark.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Post,
+  Delete,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { BookmarkService } from './bookmark.service';
+import { BookmarkListQueryDto } from './dto/bookmark-list-query.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { GetUser } from '../auth/get-user.decorator';
+import { RequestUser } from '../auth/interfaces/jwt-payload.interface';
+
+@Controller('bookmarks')
+@UseGuards(JwtAuthGuard)
+export class BookmarkController {
+  constructor(private readonly bookmarkService: BookmarkService) {}
+
+  /**
+   * POST /bookmarks/:confessionId
+   * Toggle bookmark — adds if absent, removes if present.
+   */
+  @Post(':confessionId')
+  @HttpCode(HttpStatus.OK)
+  async toggle(
+    @GetUser() user: RequestUser,
+    @Param('confessionId', ParseUUIDPipe) confessionId: string,
+  ) {
+    const result = await this.bookmarkService.toggle(user.id, confessionId);
+    return {
+      success: true,
+      ...result,
+    };
+  }
+
+  /**
+   * GET /bookmarks
+   * List all bookmarked confessions for the authenticated user, newest first.
+   */
+  @Get()
+  async list(@GetUser() user: RequestUser, @Query() query: BookmarkListQueryDto) {
+    const { page = 1, limit = 20 } = query;
+    const result = await this.bookmarkService.list(user.id, page, limit);
+    return {
+      success: true,
+      data: result.items,
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+    };
+  }
+
+  /**
+   * GET /bookmarks/:confessionId/status
+   * Check if a specific confession is bookmarked by the current user.
+   */
+  @Get(':confessionId/status')
+  async status(
+    @GetUser() user: RequestUser,
+    @Param('confessionId', ParseUUIDPipe) confessionId: string,
+  ) {
+    const bookmarked = await this.bookmarkService.isBookmarked(user.id, confessionId);
+    return { bookmarked };
+  }
+
+  /**
+   * DELETE /bookmarks/:confessionId
+   * Explicitly remove a bookmark. Returns 404 if not bookmarked.
+   */
+  @Delete(':confessionId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @GetUser() user: RequestUser,
+    @Param('confessionId', ParseUUIDPipe) confessionId: string,
+  ) {
+    await this.bookmarkService.remove(user.id, confessionId);
+  }
+
+  /**
+   * GET /bookmarks/count
+   * Returns the total number of bookmarks for the authenticated user.
+   */
+  @Get('count')
+  async count(@GetUser() user: RequestUser) {
+    const total = await this.bookmarkService.countForUser(user.id);
+    return { total };
+  }
+}

--- a/xconfess-backend/src/bookmark/bookmark.module.ts
+++ b/xconfess-backend/src/bookmark/bookmark.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Bookmark } from './entities/bookmark.entity';
+import { AnonymousConfession } from '../confession/entities/confession.entity';
+import { BookmarkService } from './bookmark.service';
+import { BookmarkController } from './bookmark.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Bookmark, AnonymousConfession])],
+  controllers: [BookmarkController],
+  providers: [BookmarkService],
+  exports: [BookmarkService],
+})
+export class BookmarkModule {}

--- a/xconfess-backend/src/bookmark/bookmark.service.spec.ts
+++ b/xconfess-backend/src/bookmark/bookmark.service.spec.ts
@@ -1,0 +1,185 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { BookmarkService } from './bookmark.service';
+import { Bookmark } from './entities/bookmark.entity';
+import { AnonymousConfession } from '../confession/entities/confession.entity';
+
+// ─── Factories ────────────────────────────────────────────────────────────────
+
+const makeConfession = (overrides: Partial<AnonymousConfession> = {}): AnonymousConfession =>
+  ({ id: 'conf-uuid-1', message: 'Test', ...overrides }) as AnonymousConfession;
+
+const makeBookmark = (overrides: Partial<Bookmark> = {}): Bookmark =>
+  ({
+    id: 'bm-uuid-1',
+    userId: 42,
+    confessionId: 'conf-uuid-1',
+    confession: makeConfession(),
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }) as Bookmark;
+
+// ─── Mock repo factory ────────────────────────────────────────────────────────
+
+const repoMock = () => ({
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+  count: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+});
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+describe('BookmarkService', () => {
+  let service: BookmarkService;
+  let bookmarkRepo: ReturnType<typeof repoMock>;
+  let confessionRepo: ReturnType<typeof repoMock>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookmarkService,
+        { provide: getRepositoryToken(Bookmark), useFactory: repoMock },
+        { provide: getRepositoryToken(AnonymousConfession), useFactory: repoMock },
+      ],
+    }).compile();
+
+    service = module.get(BookmarkService);
+    bookmarkRepo = module.get(getRepositoryToken(Bookmark));
+    confessionRepo = module.get(getRepositoryToken(AnonymousConfession));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── toggle ──────────────────────────────────────────────────────────────────
+
+  describe('toggle', () => {
+    it('adds a bookmark when none exists', async () => {
+      confessionRepo.findOne.mockResolvedValue(makeConfession());
+      bookmarkRepo.findOne.mockResolvedValue(null);
+      const bm = makeBookmark();
+      bookmarkRepo.create.mockReturnValue(bm);
+      bookmarkRepo.save.mockResolvedValue(bm);
+
+      const result = await service.toggle(42, 'conf-uuid-1');
+
+      expect(bookmarkRepo.create).toHaveBeenCalledWith({ userId: 42, confessionId: 'conf-uuid-1' });
+      expect(bookmarkRepo.save).toHaveBeenCalledWith(bm);
+      expect(result).toEqual({ bookmarked: true, bookmarkId: 'bm-uuid-1' });
+    });
+
+    it('removes a bookmark when one exists', async () => {
+      confessionRepo.findOne.mockResolvedValue(makeConfession());
+      const existing = makeBookmark();
+      bookmarkRepo.findOne.mockResolvedValue(existing);
+      bookmarkRepo.remove.mockResolvedValue(undefined);
+
+      const result = await service.toggle(42, 'conf-uuid-1');
+
+      expect(bookmarkRepo.remove).toHaveBeenCalledWith(existing);
+      expect(result).toEqual({ bookmarked: false, bookmarkId: null });
+    });
+
+    it('throws NotFoundException when confession does not exist', async () => {
+      confessionRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.toggle(42, 'missing-id')).rejects.toThrow(NotFoundException);
+      expect(bookmarkRepo.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── list ────────────────────────────────────────────────────────────────────
+
+  describe('list', () => {
+    it('returns paginated bookmarks for the user', async () => {
+      const bm = makeBookmark();
+      bookmarkRepo.findAndCount.mockResolvedValue([[bm], 1]);
+
+      const result = await service.list(42, 1, 20);
+
+      expect(bookmarkRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 42 }, take: 20, skip: 0 }),
+      );
+      expect(result).toEqual({ items: [bm], total: 1, page: 1, limit: 20 });
+    });
+
+    it('clamps limit to 100', async () => {
+      bookmarkRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.list(42, 1, 999);
+
+      expect(bookmarkRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 }),
+      );
+    });
+
+    it('calculates correct skip for page 2', async () => {
+      bookmarkRepo.findAndCount.mockResolvedValue([[], 50]);
+
+      await service.list(42, 2, 10);
+
+      expect(bookmarkRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 10, take: 10 }),
+      );
+    });
+
+    it('returns empty list when user has no bookmarks', async () => {
+      bookmarkRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.list(99, 1, 20);
+
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  // ── isBookmarked ─────────────────────────────────────────────────────────────
+
+  describe('isBookmarked', () => {
+    it('returns true when bookmark exists', async () => {
+      bookmarkRepo.count.mockResolvedValue(1);
+      expect(await service.isBookmarked(42, 'conf-uuid-1')).toBe(true);
+    });
+
+    it('returns false when bookmark does not exist', async () => {
+      bookmarkRepo.count.mockResolvedValue(0);
+      expect(await service.isBookmarked(42, 'conf-uuid-1')).toBe(false);
+    });
+  });
+
+  // ── remove ───────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('removes the bookmark when it exists', async () => {
+      const bm = makeBookmark();
+      bookmarkRepo.findOne.mockResolvedValue(bm);
+      bookmarkRepo.remove.mockResolvedValue(undefined);
+
+      await expect(service.remove(42, 'conf-uuid-1')).resolves.toBeUndefined();
+      expect(bookmarkRepo.remove).toHaveBeenCalledWith(bm);
+    });
+
+    it('throws NotFoundException when bookmark does not exist', async () => {
+      bookmarkRepo.findOne.mockResolvedValue(null);
+      await expect(service.remove(42, 'conf-uuid-1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── countForUser ─────────────────────────────────────────────────────────────
+
+  describe('countForUser', () => {
+    it('returns the total bookmark count for the user', async () => {
+      bookmarkRepo.count.mockResolvedValue(7);
+      expect(await service.countForUser(42)).toBe(7);
+      expect(bookmarkRepo.count).toHaveBeenCalledWith({ where: { userId: 42 } });
+    });
+
+    it('returns 0 for a user with no bookmarks', async () => {
+      bookmarkRepo.count.mockResolvedValue(0);
+      expect(await service.countForUser(99)).toBe(0);
+    });
+  });
+});

--- a/xconfess-backend/src/bookmark/bookmark.service.ts
+++ b/xconfess-backend/src/bookmark/bookmark.service.ts
@@ -1,0 +1,93 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Bookmark } from './entities/bookmark.entity';
+import { AnonymousConfession } from '../confession/entities/confession.entity';
+
+export interface BookmarkToggleResult {
+  bookmarked: boolean;
+  bookmarkId: string | null;
+}
+
+export interface BookmarkPage {
+  items: Bookmark[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+@Injectable()
+export class BookmarkService {
+  constructor(
+    @InjectRepository(Bookmark)
+    private readonly bookmarkRepo: Repository<Bookmark>,
+    @InjectRepository(AnonymousConfession)
+    private readonly confessionRepo: Repository<AnonymousConfession>,
+  ) {}
+
+  /**
+   * Toggle bookmark on a confession for a user.
+   * Returns { bookmarked: true, bookmarkId } on add, { bookmarked: false, bookmarkId: null } on remove.
+   */
+  async toggle(userId: number, confessionId: string): Promise<BookmarkToggleResult> {
+    const confession = await this.confessionRepo.findOne({ where: { id: confessionId } });
+    if (!confession) {
+      throw new NotFoundException('Confession not found');
+    }
+
+    const existing = await this.bookmarkRepo.findOne({
+      where: { userId, confessionId },
+    });
+
+    if (existing) {
+      await this.bookmarkRepo.remove(existing);
+      return { bookmarked: false, bookmarkId: null };
+    }
+
+    const bookmark = this.bookmarkRepo.create({ userId, confessionId });
+    const saved = await this.bookmarkRepo.save(bookmark);
+    return { bookmarked: true, bookmarkId: saved.id };
+  }
+
+  /** Paginated list of bookmarks for a user, newest first. */
+  async list(userId: number, page: number, limit: number): Promise<BookmarkPage> {
+    const take = Math.min(limit, 100);
+    const skip = (page - 1) * take;
+
+    const [items, total] = await this.bookmarkRepo.findAndCount({
+      where: { userId },
+      relations: ['confession'],
+      order: { createdAt: 'DESC' },
+      take,
+      skip,
+    });
+
+    return { items, total, page, limit: take };
+  }
+
+  /** Check if a single confession is bookmarked by the user. */
+  async isBookmarked(userId: number, confessionId: string): Promise<boolean> {
+    const count = await this.bookmarkRepo.count({ where: { userId, confessionId } });
+    return count > 0;
+  }
+
+  /** Remove a bookmark explicitly (non-toggle, returns 404 if not bookmarked). */
+  async remove(userId: number, confessionId: string): Promise<void> {
+    const existing = await this.bookmarkRepo.findOne({
+      where: { userId, confessionId },
+    });
+    if (!existing) {
+      throw new NotFoundException('Bookmark not found');
+    }
+    await this.bookmarkRepo.remove(existing);
+  }
+
+  /** Total bookmark count for a user (private, not exposed publicly). */
+  async countForUser(userId: number): Promise<number> {
+    return this.bookmarkRepo.count({ where: { userId } });
+  }
+}

--- a/xconfess-backend/src/bookmark/dto/bookmark-list-query.dto.ts
+++ b/xconfess-backend/src/bookmark/dto/bookmark-list-query.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class BookmarkListQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/xconfess-backend/src/bookmark/entities/bookmark.entity.ts
+++ b/xconfess-backend/src/bookmark/entities/bookmark.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+  Index,
+} from 'typeorm';
+import { AnonymousConfession } from '../../confession/entities/confession.entity';
+
+@Entity('bookmarks')
+@Unique(['userId', 'confessionId'])
+export class Bookmark {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  @Index()
+  userId: number;
+
+  @Column({ name: 'confession_id' })
+  confessionId: string;
+
+  @ManyToOne(() => AnonymousConfession, { onDelete: 'CASCADE', eager: false })
+  @JoinColumn({ name: 'confession_id' })
+  confession: AnonymousConfession;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}


### PR DESCRIPTION
Closes #1294
Closes #1304
Closes #1307
Closes #1309

## Summary

Implements the bookmark (save-for-later) backend module for issue #1294.

### New files — `xconfess-backend/src/bookmark/`

**`entities/bookmark.entity.ts`**
- `bookmarks` table with `userId` (number) + `confessionId` (UUID) unique composite constraint
- `ManyToOne` relation to `AnonymousConfession` with `CASCADE` delete — bookmarks auto-removed when a confession is deleted
- Indexed on `userId` for fast per-user list queries

**`bookmark.service.ts`**
- `toggle(userId, confessionId)` — adds bookmark if absent, removes if present; returns `{ bookmarked, bookmarkId }` — one call handles both states
- `list(userId, page, limit)` — paginated list newest-first, limit clamped to 100; returns `{ items, total, page, limit }`
- `isBookmarked(userId, confessionId)` — lightweight `count` check
- `remove(userId, confessionId)` — explicit delete; throws `NotFoundException` if not bookmarked
- `countForUser(userId)` — private total count (not publicly exposed)

**`bookmark.controller.ts`** — all routes `@UseGuards(JwtAuthGuard)`:
| Method | Path | Description |
|---|---|---|
| `POST` | `/bookmarks/:confessionId` | Toggle bookmark (add or remove) |
| `GET` | `/bookmarks` | Paginated list of saved confessions |
| `GET` | `/bookmarks/:confessionId/status` | Check if a confession is bookmarked |
| `DELETE` | `/bookmarks/:confessionId` | Explicit remove (204 No Content) |
| `GET` | `/bookmarks/count` | Total bookmark count for the user |

**`bookmark.service.spec.ts`** — 13 unit tests (mock repositories, no DB):
- Toggle adds new bookmark
- Toggle removes existing bookmark
- Toggle throws `NotFoundException` for unknown confession
- List returns paginated results with correct metadata
- List clamps limit to 100
- List calculates correct `skip` for page 2
- List returns empty result for user with no bookmarks
- `isBookmarked` returns `true` / `false` correctly
- `remove` deletes when bookmark exists
- `remove` throws `NotFoundException` when not bookmarked
- `countForUser` returns correct count and zero for no bookmarks

**`bookmark.module.ts`** — registers `TypeOrmModule.forFeature([Bookmark, AnonymousConfession])`, exports `BookmarkService` for other modules (e.g., data-export ZIP builder, user profile).

**`app.module.ts`** — `BookmarkModule` added to module imports.

## Test plan

- [ ] `POST /bookmarks/:confessionId` with valid JWT and existing confession → `{ bookmarked: true, bookmarkId: "..." }`
- [ ] Same call again → `{ bookmarked: false, bookmarkId: null }` (toggle removes)
- [ ] `GET /bookmarks` → paginated list including bookmarked confession
- [ ] Navigate away and back; bookmark state persists (`GET /bookmarks/:id/status → { bookmarked: true }`)
- [ ] `DELETE /bookmarks/:confessionId` → 204; subsequent list no longer includes it
- [ ] `GET /bookmarks/count` → correct total after multiple bookmark/unbookmark cycles
- [ ] Deleting a confession cascade-removes its bookmark entry (no orphan rows)
- [ ] `npm run test -- bookmark` → all 13 unit tests pass