### PR TITLE
fix: resolve Stellar Wave issues #1240, #1255, #1295, #1302

### DIFF
--- a/xconfess-frontend/app/(dashboard)/admin/dashboard/loading.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { AdminDashboardSkeleton } from '@/app/components/confession/LoadingSkeleton';
+
+export default function AdminDashboardLoading() {
+  return <AdminDashboardSkeleton />;
+}

--- a/xconfess-frontend/app/(dashboard)/admin/diagnostics/loading.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/diagnostics/loading.tsx
@@ -1,0 +1,29 @@
+export default function DiagnosticsLoading() {
+  return (
+    <div
+      className="space-y-6 max-w-4xl mx-auto p-4"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading diagnostics"
+    >
+      <div className="space-y-2">
+        <div className="h-8 w-56 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="h-4 w-96 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-28 animate-pulse rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-900"
+          />
+        ))}
+      </div>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="h-48 animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-900"
+        />
+      ))}
+    </div>
+  );
+}

--- a/xconfess-frontend/app/(dashboard)/admin/diagnostics/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/admin/diagnostics/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchStellarDiagnostics } from '@/app/lib/api/stellar';
-import { adminApi } from '@/app/lib/api/admin';
+import { adminApi, SystemHealthResponse } from '@/app/lib/api/admin';
 import { queryKeys } from '@/app/lib/api/queryKeys';
 import type { StellarDiagnosticsResponse, HorizonStatus } from '@/app/lib/api/stellar';
 
@@ -48,6 +49,64 @@ function Skeleton() {
       {Array.from({ length: 2 }).map((_, i) => (
         <div key={i} className="h-48 bg-gray-100 dark:bg-gray-800 rounded-xl" />
       ))}
+    </div>
+  );
+}
+
+const STATUS_STYLES: Record<string, { badge: string; icon: string; label: string }> = {
+  up: {
+    badge: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300 border border-green-200 dark:border-green-800',
+    icon: '●',
+    label: 'Healthy',
+  },
+  down: {
+    badge: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300 border border-red-200 dark:border-red-800',
+    icon: '✕',
+    label: 'Down',
+  },
+  unknown: {
+    badge: 'bg-gray-100 text-gray-800 dark:bg-gray-900/40 dark:text-gray-300 border border-gray-200 dark:border-gray-800',
+    icon: '?',
+    label: 'Unknown',
+  },
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const cfg = STATUS_STYLES[status] || STATUS_STYLES.unknown;
+  return (
+    <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold ${cfg.badge}`}>
+      <span>{cfg.icon}</span>
+      {cfg.label}
+    </span>
+  );
+}
+
+function ServiceStatusCard({
+  name,
+  status,
+  details,
+}: {
+  name: string;
+  status: string;
+  details?: Record<string, any>;
+}) {
+  const resolvedStatus = status === 'up' ? 'up' : 'down';
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5 shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold text-gray-900 dark:text-white">{name}</h4>
+        <StatusBadge status={resolvedStatus} />
+      </div>
+      {details && Object.keys(details).length > 0 && (
+        <dl className="space-y-1">
+          {Object.entries(details).filter(([k]) => k !== 'status').map(([key, value]) => (
+            <div key={key} className="flex justify-between text-xs">
+              <dt className="text-gray-500 dark:text-gray-400 capitalize">{key.replace(/([A-Z])/g, ' $1').trim()}</dt>
+              <dd className="text-gray-900 dark:text-white font-mono">{String(value)}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
     </div>
   );
 }
@@ -107,22 +166,9 @@ function HorizonStatusCard({
       </div>
 
       <dl className="divide-y divide-gray-100 dark:divide-gray-800">
-        <ConfigRow
-          label="Endpoint"
-          value={horizonUrl}
-          mono
-          description="The Horizon REST API endpoint that was pinged."
-        />
-        <ConfigRow
-          label="Latency"
-          value={latencyMs !== null ? `${latencyMs} ms` : 'N/A'}
-          description="Round-trip time for the liveness ping to Horizon."
-        />
-        <ConfigRow
-          label="Checked at"
-          value={new Date(checkedAt).toLocaleString()}
-          description="Timestamp when this diagnostic snapshot was taken."
-        />
+        <ConfigRow label="Endpoint" value={horizonUrl} mono />
+        <ConfigRow label="Latency" value={latencyMs !== null ? `${latencyMs} ms` : 'N/A'} />
+        <ConfigRow label="Checked at" value={new Date(checkedAt).toLocaleString()} />
       </dl>
 
       {status !== 'ok' && (
@@ -139,57 +185,215 @@ function HorizonStatusCard({
 }
 
 export default function DiagnosticsPage() {
+  const [autoRefresh, setAutoRefresh] = useState(false);
+
+  const {
+    data: health,
+    isLoading: healthLoading,
+    error: healthError,
+    refetch: refetchHealth,
+  } = useQuery<SystemHealthResponse>({
+    queryKey: ['admin', 'system-health'],
+    queryFn: () => adminApi.getSystemHealth(),
+    retry: 1,
+    staleTime: 30_000,
+    refetchInterval: autoRefresh ? 30_000 : false,
+  });
+
   const {
     data: diagnostics,
     isLoading,
     error,
+    refetch: refetchDiagnostics,
   } = useQuery<StellarDiagnosticsResponse>({
     queryKey: ['stellar', 'diagnostics'],
     queryFn: fetchStellarDiagnostics,
     retry: 2,
     staleTime: 60_000,
+    refetchInterval: autoRefresh ? 30_000 : false,
   });
 
   const {
     data: observability,
     isLoading: observabilityLoading,
     error: observabilityError,
+    refetch: refetchObservability,
   } = useQuery({
     queryKey: queryKeys.admin.observability.all(),
     queryFn: () => adminApi.getObservability(),
     staleTime: 60_000,
     retry: 2,
+    refetchInterval: autoRefresh ? 30_000 : false,
   });
+
+  const handleRefresh = useCallback(() => {
+    refetchHealth();
+    refetchDiagnostics();
+    refetchObservability();
+  }, [refetchHealth, refetchDiagnostics, refetchObservability]);
+
+  const serviceStatuses = health?.details
+    ? Object.entries(health.details).map(([name, info]) => ({
+        name: name.charAt(0).toUpperCase() + name.slice(1),
+        status: info.status,
+        details: info,
+      }))
+    : [];
 
   return (
     <div className="space-y-6 max-w-4xl mx-auto p-4">
-      <div>
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-          Stellar Diagnostics
-        </h2>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Network environments and configured smart contract addresses. Includes a live
-          Horizon reachability check.
-        </p>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+            System Diagnostics
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Service health, queue metrics, and operational overview.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+              className="rounded border-gray-300 dark:border-gray-700"
+            />
+            Auto-refresh
+          </label>
+          <button
+            onClick={handleRefresh}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Refresh
+          </button>
+        </div>
       </div>
 
-      {isLoading && <Skeleton />}
+      {/* Service Status Cards */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+          Service Status
+        </h3>
+        {healthLoading && <Skeleton />}
+        {healthError && (
+          <div className="rounded-xl border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/40 p-4">
+            <p className="text-sm text-red-700 dark:text-red-300">
+              Failed to fetch system health. Backend may be unreachable.
+            </p>
+          </div>
+        )}
+        {health && (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <ServiceStatusCard
+              name="Backend"
+              status={health.status === 'ok' ? 'up' : 'down'}
+              details={{ overall: health.status }}
+            />
+            {serviceStatuses.map((svc) => (
+              <ServiceStatusCard
+                key={svc.name}
+                name={svc.name}
+                status={svc.status}
+                details={svc.details}
+              />
+            ))}
+            {diagnostics && (
+              <ServiceStatusCard
+                name="Stellar Horizon"
+                status={diagnostics.horizonStatus === 'ok' ? 'up' : 'down'}
+                details={{
+                  latency: diagnostics.horizonLatencyMs !== null ? `${diagnostics.horizonLatencyMs}ms` : 'N/A',
+                  network: diagnostics.network,
+                }}
+              />
+            )}
+          </div>
+        )}
+      </div>
 
+      {/* Queue Metrics */}
+      {observabilityLoading && <Skeleton />}
+      {observabilityError && (
+        <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950 p-4">
+          <p className="text-sm text-red-700 dark:text-red-300">
+            Failed to load queue metrics.
+          </p>
+        </div>
+      )}
+      {observability && (
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            BullMQ Queue Metrics
+          </h3>
+          <dl className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            {[
+              { label: 'Active', value: observability.notifications.main.active },
+              { label: 'Waiting', value: observability.notifications.main.waiting },
+              { label: 'Failed', value: observability.notifications.main.failed },
+              { label: 'DLQ Failed', value: observability.notifications.dlq.failed },
+              { label: 'DLQ Waiting', value: observability.notifications.dlq.waiting },
+              { label: 'DLQ Delayed', value: observability.notifications.dlq.delayed },
+            ].map(({ label, value }) => (
+              <div
+                key={label}
+                className="rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 p-4"
+              >
+                <dt className="text-sm text-gray-500 dark:text-gray-400">{label}</dt>
+                <dd className="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
+
+      {/* Audit Activity */}
+      {observability && (
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            Audit Activity
+          </h3>
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 p-4">
+              <dt className="text-sm text-gray-500 dark:text-gray-400">Total logs</dt>
+              <dd className="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
+                {observability.audit.totalLogs}
+              </dd>
+            </div>
+            {observability.audit.actionTypeCounts.map((count) => (
+              <div
+                key={count.actionType}
+                className="rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 p-4"
+              >
+                <dt className="text-sm text-gray-500 dark:text-gray-400">
+                  {count.actionType}
+                </dt>
+                <dd className="mt-2 text-xl font-semibold text-gray-900 dark:text-white">
+                  {count.count}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
+
+      {/* Stellar Diagnostics */}
+      {isLoading && <Skeleton />}
       {error && (
         <div className="rounded-xl border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/40 p-5 space-y-2">
           <p className="text-sm font-semibold text-red-800 dark:text-red-400">
             Failed to load Stellar diagnostics.
           </p>
           <p className="text-xs text-red-700 dark:text-red-300/80">
-            Ensure the backend is running and accessible, and that your session has admin
-            permissions.
+            Ensure the backend is running and accessible, and that your session has admin permissions.
           </p>
         </div>
       )}
 
       {diagnostics && (
         <div className="grid gap-6">
-          {/* Horizon ping status */}
           <HorizonStatusCard
             status={diagnostics.horizonStatus}
             latencyMs={diagnostics.horizonLatencyMs}
@@ -197,94 +401,38 @@ export default function DiagnosticsPage() {
             checkedAt={diagnostics.checkedAt}
           />
 
-          {/* Network Info */}
           <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 shadow-sm">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
               Network Profile
             </h3>
-            <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
-              Active network context and RPC endpoints.
-            </p>
             <dl className="divide-y divide-gray-100 dark:divide-gray-800">
-              <ConfigRow
-                label="Target Network"
-                value={diagnostics.network}
-                mono
-                description="The target environment (e.g., testnet, mainnet) governing ledger operations."
-              />
-              <ConfigRow
-                label="Horizon URL"
-                value={diagnostics.horizonUrl}
-                mono
-                description="REST API gateway for ledger statistics, account metadata, and history."
-              />
-              <ConfigRow
-                label="Soroban RPC URL"
-                value={diagnostics.sorobanRpcUrl}
-                mono
-                description="Execution node gateway for smart contract invocations."
-              />
+              <ConfigRow label="Target Network" value={diagnostics.network} mono />
+              <ConfigRow label="Horizon URL" value={diagnostics.horizonUrl} mono />
+              <ConfigRow label="Soroban RPC URL" value={diagnostics.sorobanRpcUrl} mono />
             </dl>
           </div>
 
-          {/* Contract IDs */}
           <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 shadow-sm">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
               Smart Contract Deployments
             </h3>
-            <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
-              Soroban contract IDs anchoring active WASM state machines to the network.
-            </p>
             <dl className="divide-y divide-gray-100 dark:divide-gray-800">
-              <ConfigRow
-                label="Confession Anchor"
-                value={diagnostics.contractIds?.confessionAnchor}
-                mono
-                description="Tracks data hashes for anonymized confessions on-chain."
-              />
-              <ConfigRow
-                label="Reputation Badges"
-                value={diagnostics.contractIds?.reputationBadges}
-                mono
-                description="Manages profile reward distribution and gamification tiers."
-              />
-              <ConfigRow
-                label="Tipping System"
-                value={diagnostics.contractIds?.tippingSystem}
-                mono
-                description="Handles atomic peer micro-payments between users."
-              />
+              <ConfigRow label="Confession Anchor" value={diagnostics.contractIds?.confessionAnchor} mono />
+              <ConfigRow label="Reputation Badges" value={diagnostics.contractIds?.reputationBadges} mono />
+              <ConfigRow label="Tipping System" value={diagnostics.contractIds?.tippingSystem} mono />
             </dl>
           </div>
 
-          {/* Deployment Metadata */}
           <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
               Deployment Metadata
             </h3>
             <dl className="divide-y divide-gray-100 dark:divide-gray-800">
-              <ConfigRow
-                label="Loaded"
-                value={diagnostics.deploymentMetadata.loaded ? 'Yes' : 'No'}
-              />
-              <ConfigRow
-                label="Generated at (UTC)"
-                value={diagnostics.deploymentMetadata.generatedAtUtc}
-                mono
-              />
-              <ConfigRow
-                label="Age (days)"
-                value={diagnostics.deploymentMetadata.ageDays?.toString() ?? null}
-              />
-              <ConfigRow
-                label="Stale"
-                value={diagnostics.deploymentMetadata.isStale ? 'Yes' : 'No'}
-              />
-              <ConfigRow
-                label="Load error"
-                value={diagnostics.deploymentMetadata.loadError}
-                mono
-              />
+              <ConfigRow label="Loaded" value={diagnostics.deploymentMetadata.loaded ? 'Yes' : 'No'} />
+              <ConfigRow label="Generated at (UTC)" value={diagnostics.deploymentMetadata.generatedAtUtc} mono />
+              <ConfigRow label="Age (days)" value={diagnostics.deploymentMetadata.ageDays?.toString() ?? null} />
+              <ConfigRow label="Stale" value={diagnostics.deploymentMetadata.isStale ? 'Yes' : 'No'} />
+              <ConfigRow label="Load error" value={diagnostics.deploymentMetadata.loadError} mono />
             </dl>
             {diagnostics.deploymentMetadata.loadError && (
               <div className="mt-4 rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950 p-3 text-sm text-red-700 dark:text-red-300">
@@ -295,90 +443,8 @@ export default function DiagnosticsPage() {
         </div>
       )}
 
-      {/* Admin Observability */}
-      <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6">
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
-          <div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-              Admin Observability
-            </h3>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              Audit activity and notification queue health for operational review.
-            </p>
-          </div>
-        </div>
-
-        {observabilityLoading && <Skeleton />}
-
-        {observabilityError && (
-          <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950 p-4">
-            <p className="text-sm text-red-700 dark:text-red-300">
-              Failed to load admin observability metrics. Ensure the backend is running and
-              accessible.
-            </p>
-          </div>
-        )}
-
-        {observability && (
-          <div className="grid gap-6">
-            <div>
-              <h4 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
-                Audit activity
-              </h4>
-              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-                <div className="rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 p-4">
-                  <dt className="text-sm text-gray-500 dark:text-gray-400">Total logs</dt>
-                  <dd className="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
-                    {observability.audit.totalLogs}
-                  </dd>
-                </div>
-                {observability.audit.actionTypeCounts.map((count) => (
-                  <div
-                    key={count.actionType}
-                    className="rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 p-4"
-                  >
-                    <dt className="text-sm text-gray-500 dark:text-gray-400">
-                      {count.actionType}
-                    </dt>
-                    <dd className="mt-2 text-xl font-semibold text-gray-900 dark:text-white">
-                      {count.count}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-
-            <div>
-              <h4 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
-                Notification queue health
-              </h4>
-              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                {[
-                  { label: 'Active workers', value: observability.notifications.main.active },
-                  { label: 'Waiting jobs', value: observability.notifications.main.waiting },
-                  { label: 'Failed jobs', value: observability.notifications.main.failed },
-                  { label: 'DLQ failed', value: observability.notifications.dlq.failed },
-                  { label: 'DLQ waiting', value: observability.notifications.dlq.waiting },
-                  { label: 'DLQ delayed', value: observability.notifications.dlq.delayed },
-                ].map(({ label, value }) => (
-                  <div
-                    key={label}
-                    className="rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 p-4"
-                  >
-                    <dt className="text-sm text-gray-500 dark:text-gray-400">{label}</dt>
-                    <dd className="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
-                      {value}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-          </div>
-        )}
-      </div>
-
       <div className="text-[11px] font-medium tracking-wide text-gray-400 dark:text-slate-500 text-center bg-gray-50 dark:bg-gray-950/60 py-3 rounded-lg border border-gray-100 dark:border-gray-800/60">
-        🔒 Signer keys, seed phrases, and operational secrets are never exposed in this panel.
+        Signer keys, seed phrases, and operational secrets are never exposed in this panel.
       </div>
     </div>
   );

--- a/xconfess-frontend/app/(dashboard)/loading.tsx
+++ b/xconfess-frontend/app/(dashboard)/loading.tsx
@@ -1,0 +1,17 @@
+import { ConfessionFeedSkeleton } from '@/app/components/confession/LoadingSkeleton';
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-10 w-28 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-800"
+          />
+        ))}
+      </div>
+      <ConfessionFeedSkeleton count={3} />
+    </div>
+  );
+}

--- a/xconfess-frontend/app/(dashboard)/profile/loading.tsx
+++ b/xconfess-frontend/app/(dashboard)/profile/loading.tsx
@@ -1,0 +1,5 @@
+import { ProfilePageSkeleton } from '@/app/components/confession/LoadingSkeleton';
+
+export default function ProfileLoading() {
+  return <ProfilePageSkeleton />;
+}

--- a/xconfess-frontend/app/(dashboard)/search/loading.tsx
+++ b/xconfess-frontend/app/(dashboard)/search/loading.tsx
@@ -1,0 +1,12 @@
+import { SearchResultsSkeleton } from '@/app/components/confession/LoadingSkeleton';
+
+export default function SearchLoading() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="mb-6">
+        <div className="h-12 w-full animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+      <SearchResultsSkeleton count={4} />
+    </div>
+  );
+}

--- a/xconfess-frontend/app/(dashboard)/search/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/search/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Search, Filter, Calendar, TrendingUp } from "lucide-react";
 import { useDebounce } from "@/lib/hooks/useDebounce";
+import { SearchResultsSkeleton } from "@/app/components/confession/LoadingSkeleton";
 
 interface Confession {
   id: string;
@@ -209,9 +210,7 @@ export default function SearchPage() {
         </div>
       )}
 
-      {loading && (
-        <div className="text-center py-8 text-gray-500">Searching...</div>
-      )}
+      {loading && <SearchResultsSkeleton count={4} />}
 
       {!loading && query && results.length === 0 && (
         <div className="text-center py-12">

--- a/xconfess-frontend/app/api/auth/session/route.ts
+++ b/xconfess-frontend/app/api/auth/session/route.ts
@@ -5,6 +5,7 @@ import {
   normalizeAuthError,
   NormalizedAuthError,
 } from "@/lib/normalizeAuthError";
+import { getOrCreateRequestId, requestIdResponseHeaders } from "@/app/lib/utils/requestId";
 
 const API_URL = getApiBaseUrl();
 const SESSION_COOKIE_NAME = "xconfess_session";
@@ -16,7 +17,8 @@ const MAX_RETRIES = 1;
  */
 async function fetchBackendWithRetry(
   url: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  requestId?: string
 ): Promise<{
   success: boolean;
   data?: Record<string, unknown>;
@@ -26,12 +28,15 @@ async function fetchBackendWithRetry(
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        ...(options.headers as Record<string, string>),
+      };
+      if (requestId) headers["x-request-id"] = requestId;
+
       const response = await fetch(url, {
         ...options,
-        headers: {
-          "Content-Type": "application/json",
-          ...options.headers,
-        },
+        headers,
       });
 
       if (!response.ok) {
@@ -103,6 +108,7 @@ async function fetchBackendWithRetry(
 }
 
 export async function POST(request: Request) {
+    const requestId = getOrCreateRequestId(request);
     try {
         const body = await request.json();
         const email = typeof body?.email === "string" ? body.email : undefined;
@@ -117,11 +123,10 @@ export async function POST(request: Request) {
             return createErrorResponse(normalized);
         }
 
-        // Fetch with automatic retry for TRANSIENT errors
         const result = await fetchBackendWithRetry(`${API_URL}/auth/login`, {
             method: "POST",
             body: JSON.stringify({ email, password }),
-        });
+        }, requestId);
 
         if (!result.success) {
             return createErrorResponse(result.normalized!);
@@ -140,10 +145,12 @@ export async function POST(request: Request) {
             path: "/",
         });
 
-        return NextResponse.json({
+        const res = NextResponse.json({
             user: data.user,
             anonymousUserId: data.anonymousUserId ?? null,
         });
+        res.headers.set("x-request-id", requestId);
+        return res;
     } catch (error) {
         const normalized = normalizeAuthError(error);
         return createErrorResponse(normalized);

--- a/xconfess-frontend/app/api/comments/[confessionId]/route.ts
+++ b/xconfess-frontend/app/api/comments/[confessionId]/route.ts
@@ -1,5 +1,6 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
+import { getOrCreateRequestId } from "@/app/lib/utils/requestId";
 
 const BASE_API_URL = getApiBaseUrl();
 
@@ -19,8 +20,7 @@ export async function POST(
       return createApiErrorResponse("Confession ID is required", { status: 400 });
     }
 
-    correlationId =
-      request.headers.get("X-Correlation-ID") ?? crypto.randomUUID();
+    correlationId = getOrCreateRequestId(request);
 
     body = await request.json().catch(() => ({}));
     content = (body.content ?? body.message) as string;
@@ -53,7 +53,7 @@ export async function POST(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Correlation-ID": correlationId,
+        "x-request-id": correlationId,
         ...(authHeader ? { Authorization: authHeader } : {}),
         ...(cookieHeader ? { Cookie: cookieHeader } : {}),
       },
@@ -85,7 +85,7 @@ export async function POST(
           headers: {
             "Content-Type": "application/json",
             "X-Demo-Mode": "true",
-            "X-Correlation-ID": correlationId,
+            "x-request-id": correlationId,
           },
         });
       }
@@ -114,7 +114,7 @@ export async function POST(
       status: 201,
       headers: {
         "Content-Type": "application/json",
-        "X-Correlation-ID": correlationId,
+        "x-request-id": correlationId,
       },
     });
   } catch (error) {

--- a/xconfess-frontend/app/api/confessions/[id]/route.ts
+++ b/xconfess-frontend/app/api/confessions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl } from "@/app/lib/config";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getOrCreateRequestId, requestIdResponseHeaders } from "@/app/lib/utils/requestId";
 
 const BASE_API_URL = getApiBaseUrl();
 
@@ -9,14 +10,15 @@ export async function GET(
 ) {
   try {
     const { id } = await context.params;
+    const requestId = getOrCreateRequestId(_request);
     if (!id) {
-      return createApiErrorResponse("Confession ID is required", { status: 400 });
+      return createApiErrorResponse("Confession ID is required", { status: 400, correlationId: requestId });
     }
 
     const url = `${BASE_API_URL}/confessions/${id}`;
     const response = await fetch(url, {
       method: "GET",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "x-request-id": requestId },
       next: { revalidate: 30 },
     });
 

--- a/xconfess-frontend/app/api/confessions/route.ts
+++ b/xconfess-frontend/app/api/confessions/route.ts
@@ -1,10 +1,11 @@
 import { normalizeConfession } from "../../lib/utils/normalizeConfession";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
+import { getOrCreateRequestId, requestIdResponseHeaders } from "@/app/lib/utils/requestId";
 
 const BASE_API_URL = getApiBaseUrl();
 export async function POST(request: Request) {
-  const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
+  const correlationId = getOrCreateRequestId(request);
 
   try {
     const body = await request.json();
@@ -34,7 +35,7 @@ export async function POST(request: Request) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Correlation-ID": correlationId,
+          "x-request-id": correlationId,
         },
         body: JSON.stringify(backendBody),
       });
@@ -55,7 +56,7 @@ export async function POST(request: Request) {
 
       return new Response(JSON.stringify(normalized), {
         status: 201,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...requestIdResponseHeaders(correlationId) },
       });
     } catch (fetchError) {
       return createApiErrorResponse(fetchError, {
@@ -91,7 +92,7 @@ export async function GET(request: Request) {
     backendParams.append("gender", gender);
   }
 
-  const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
+  const correlationId = getOrCreateRequestId(request);
 
   try {
     const backendUrl = `${BASE_API_URL}/confessions?${backendParams}`;
@@ -100,7 +101,7 @@ export async function GET(request: Request) {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
-        "X-Correlation-ID": correlationId,
+        "x-request-id": correlationId,
       },
       next: {
         revalidate: 30, // Cache for 30 seconds
@@ -141,7 +142,7 @@ export async function GET(request: Request) {
       }),
       {
         status: 200,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...requestIdResponseHeaders(correlationId) },
       },
     );
   } catch (error) {

--- a/xconfess-frontend/app/api/health/ready/route.ts
+++ b/xconfess-frontend/app/api/health/ready/route.ts
@@ -1,0 +1,37 @@
+import { getApiBaseUrl } from "@/app/lib/config";
+import { createApiErrorResponse } from "@/lib/apiErrorHandler";
+import { getOrCreateRequestId, requestIdResponseHeaders } from "@/app/lib/utils/requestId";
+
+const BASE_API_URL = getApiBaseUrl();
+
+export async function GET(request: Request) {
+  const requestId = getOrCreateRequestId(request);
+
+  try {
+    const response = await fetch(`${BASE_API_URL}/health/ready`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "x-request-id": requestId,
+      },
+      next: { revalidate: 0 },
+    });
+
+    const data = await response.json();
+
+    return new Response(JSON.stringify(data), {
+      status: response.status,
+      headers: {
+        "Content-Type": "application/json",
+        ...requestIdResponseHeaders(requestId),
+      },
+    });
+  } catch (error) {
+    return createApiErrorResponse(error, {
+      status: 503,
+      correlationId: requestId,
+      fallbackMessage: "Health check endpoint unreachable",
+      route: "GET /api/health/ready",
+    });
+  }
+}

--- a/xconfess-frontend/app/components/AuthGuard.tsx
+++ b/xconfess-frontend/app/components/AuthGuard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuth } from '../lib/hooks/useAuth';
+import { SessionExpiredBanner } from './SessionExpiredBanner';
 
 /**
  * Maximum number of consecutive redirect attempts before the guard
@@ -94,7 +95,8 @@ export function AuthGuard({ children }: AuthGuardProps) {
     redirectCount.current += 1;
     lastRedirectTime.current = now;
     hasRedirected.current = true;
-    router.push('/login');
+    const returnTo = pathname && pathname !== '/login' ? `?returnTo=${encodeURIComponent(pathname)}` : '';
+    router.push(`/login${returnTo}`);
   }, [pathname, router]);
 
   /**
@@ -114,44 +116,8 @@ export function AuthGuard({ children }: AuthGuardProps) {
     return <>{children}</>;
   }
 
-  // Show session expired UI immediately when session is expired
-  // This provides deterministic recovery without waiting for redirect loops
   if (isSessionExpired && !isAuthenticated) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center max-w-md mx-auto p-6">
-          <div className="rounded-full h-12 w-12 bg-red-100 dark:bg-red-900/30 flex items-center justify-center mx-auto mb-4">
-            <svg
-              className="h-6 w-6 text-red-600 dark:text-red-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-              />
-            </svg>
-          </div>
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
-            Session Expired
-          </h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-            Your session has expired. Please log in again to continue.
-          </p>
-          <button
-            onClick={() => {
-              window.location.href = '/login';
-            }}
-            className="inline-flex items-center justify-center rounded-lg bg-purple-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition-colors"
-          >
-            Go to Login
-          </button>
-        </div>
-      </div>
-    );
+    return <SessionExpiredBanner variant="fullscreen" />;
   }
 
   // Show loading state while checking auth
@@ -166,52 +132,8 @@ export function AuthGuard({ children }: AuthGuardProps) {
     );
   }
 
-  // Redirect loop detected — show a user-friendly error instead of looping
-  // This is a fallback for cases not caught by isSessionExpired
-  if (
-    !isAuthenticated &&
-    maxRedirectsReached
-  ) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center max-w-md mx-auto p-6">
-          <div className="rounded-full h-12 w-12 bg-red-100 dark:bg-red-900/30 flex items-center justify-center mx-auto mb-4">
-            <svg
-              className="h-6 w-6 text-red-600 dark:text-red-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-              />
-            </svg>
-          </div>
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
-            Authentication Error
-          </h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-            Unable to verify your session. Please try logging in again.
-          </p>
-          <button
-            onClick={() => {
-              // Reset the loop counter so the user can try again
-              redirectCount.current = 0;
-              lastRedirectTime.current = 0;
-              hasRedirected.current = false;
-              setMaxRedirectsReached(false);
-              window.location.href = '/login';
-            }}
-            className="inline-flex items-center justify-center rounded-lg bg-purple-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition-colors"
-          >
-            Go to Login
-          </button>
-        </div>
-      </div>
-    );
+  if (!isAuthenticated && maxRedirectsReached) {
+    return <SessionExpiredBanner variant="fullscreen" />;
   }
 
   // Don't render protected content if not authenticated

--- a/xconfess-frontend/app/components/SessionExpiredBanner.tsx
+++ b/xconfess-frontend/app/components/SessionExpiredBanner.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+
+interface SessionExpiredBannerProps {
+  variant?: 'banner' | 'fullscreen';
+}
+
+export function SessionExpiredBanner({ variant = 'banner' }: SessionExpiredBannerProps) {
+  const pathname = usePathname();
+
+  const handleLogin = useCallback(() => {
+    const returnTo = pathname && pathname !== '/login' ? pathname : '/';
+    window.location.href = `/login?returnTo=${encodeURIComponent(returnTo)}`;
+  }, [pathname]);
+
+  if (variant === 'fullscreen') {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center max-w-md mx-auto p-6">
+          <div className="rounded-full h-12 w-12 bg-red-100 dark:bg-red-900/30 flex items-center justify-center mx-auto mb-4">
+            <svg
+              className="h-6 w-6 text-red-600 dark:text-red-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+              />
+            </svg>
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+            Session Expired
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+            Your session has expired. Please log in again to continue.
+          </p>
+          <button
+            onClick={handleLogin}
+            className="inline-flex items-center justify-center rounded-lg bg-purple-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 transition-colors"
+          >
+            Go to Login
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="alert"
+      className="sticky top-0 z-50 flex items-center justify-between gap-3 border-b border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/60 px-4 py-3"
+    >
+      <div className="flex items-center gap-3 min-w-0">
+        <svg
+          className="h-5 w-5 shrink-0 text-red-600 dark:text-red-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+          />
+        </svg>
+        <p className="text-sm font-medium text-red-800 dark:text-red-200 truncate">
+          Your session has expired. Please log in again to continue.
+        </p>
+      </div>
+      <button
+        onClick={handleLogin}
+        className="shrink-0 rounded-md bg-red-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+      >
+        Log in
+      </button>
+    </div>
+  );
+}

--- a/xconfess-frontend/app/components/confession/LoadingSkeleton.tsx
+++ b/xconfess-frontend/app/components/confession/LoadingSkeleton.tsx
@@ -95,3 +95,85 @@ export function ConfessionDetailSkeleton() {
     </div>
   );
 }
+
+export function SearchResultsSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div
+      className="space-y-4"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading search results"
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <div
+          key={`search-skeleton-${index}`}
+          className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-4"
+        >
+          <div className="space-y-2 mb-3">
+            <div className="h-4 w-full animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+            <div className="h-4 w-5/6 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="h-3 w-24 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+            <div className="h-3 w-20 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+            <div className="h-3 w-16 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ProfilePageSkeleton() {
+  return (
+    <div
+      className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:px-6"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading profile"
+    >
+      <div className="h-32 animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-800" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div
+            key={index}
+            className="h-28 animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-800"
+          />
+        ))}
+      </div>
+      <div className="h-96 animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-800" />
+    </div>
+  );
+}
+
+export function AdminDashboardSkeleton() {
+  return (
+    <div
+      className="space-y-6"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading admin dashboard"
+    >
+      <div className="space-y-2">
+        <div className="h-8 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="h-4 w-72 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={index}
+            className="h-32 animate-pulse rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-900"
+          />
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, index) => (
+          <div
+            key={index}
+            className="h-64 animate-pulse rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-900"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/xconfess-frontend/app/lib/api/admin.ts
+++ b/xconfess-frontend/app/lib/api/admin.ts
@@ -108,7 +108,18 @@ export interface ReportStats {
   resolvedTodayCount: number;
 }
 
+export interface SystemHealthResponse {
+  status: 'ok' | 'error';
+  details?: Record<string, { status: string; [key: string]: any }>;
+  error?: string;
+}
+
 export const adminApi = {
+  getSystemHealth: async (): Promise<SystemHealthResponse> => {
+    const response = await apiClient.get('/api/health/ready');
+    return response.data;
+  },
+
   // Reports
   getReports: async (params?: {
     status?: string;

--- a/xconfess-frontend/app/lib/providers/AuthProvider.tsx
+++ b/xconfess-frontend/app/lib/providers/AuthProvider.tsx
@@ -61,7 +61,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const normalized = (error.details as any)?.normalized as NormalizedAuthError | undefined;
     
     if (normalized?.type === "TERMINAL") {
-      // Clear auth state immediately
       setStoreUser(null);
       storeLogout();
       setState({
@@ -69,12 +68,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
         isAuthenticated: false,
         isLoading: false,
         error: null,
+        isSessionExpired: true,
       });
-
-      // Redirect to login only if not already there
-      if (typeof window !== 'undefined' && !window.location.pathname.includes('/login')) {
-        router.push('/login');
-      }
     }
   }, [setStoreUser, storeLogout, router]);
 

--- a/xconfess-frontend/app/lib/utils/requestId.ts
+++ b/xconfess-frontend/app/lib/utils/requestId.ts
@@ -1,0 +1,36 @@
+import { randomUUID } from 'crypto';
+
+const REQUEST_ID_HEADER =
+  process.env.REQUEST_ID_HEADER_NAME || 'X-Request-ID';
+
+export function getOrCreateRequestId(request: Request): string {
+  const existing = request.headers.get(REQUEST_ID_HEADER)
+    || request.headers.get('X-Correlation-ID')
+    || request.headers.get('x-request-id');
+
+  if (existing && existing.trim().length > 0) {
+    return existing.trim();
+  }
+
+  return randomUUID();
+}
+
+export function requestIdHeader(): string {
+  return REQUEST_ID_HEADER;
+}
+
+export function withRequestId(
+  headers: Record<string, string>,
+  requestId: string,
+): Record<string, string> {
+  return {
+    ...headers,
+    'x-request-id': requestId,
+  };
+}
+
+export function requestIdResponseHeaders(requestId: string): Record<string, string> {
+  return {
+    'x-request-id': requestId,
+  };
+}

--- a/xconfess-frontend/tests/auth/session-expired-banner.spec.tsx
+++ b/xconfess-frontend/tests/auth/session-expired-banner.spec.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockPush = jest.fn();
+const mockPathname = jest.fn().mockReturnValue("/");
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname(),
+}));
+
+let mockAuthState = {
+  isAuthenticated: false,
+  isLoading: false,
+  isSessionExpired: true,
+  user: null,
+  login: jest.fn(),
+  logout: jest.fn(),
+  register: jest.fn(),
+  checkAuth: jest.fn(),
+  error: null,
+};
+
+jest.mock("@/app/lib/hooks/useAuth", () => ({
+  useAuth: () => mockAuthState,
+}));
+
+import { AuthGuard } from "@/app/components/AuthGuard";
+import { SessionExpiredBanner } from "@/app/components/SessionExpiredBanner";
+
+function ProtectedContent() {
+  return <div>Protected Content</div>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete (window as any).location;
+  (window as any).location = { href: "" };
+  mockAuthState = {
+    isAuthenticated: false,
+    isLoading: false,
+    isSessionExpired: true,
+    user: null,
+    login: jest.fn(),
+    logout: jest.fn(),
+    register: jest.fn(),
+    checkAuth: jest.fn(),
+    error: null,
+  };
+});
+
+describe("SessionExpiredBanner", () => {
+  it("renders banner variant with login button", () => {
+    mockPathname.mockReturnValue("/dashboard");
+    render(<SessionExpiredBanner variant="banner" />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/session has expired/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it("renders fullscreen variant with login button", () => {
+    mockPathname.mockReturnValue("/profile");
+    render(<SessionExpiredBanner variant="fullscreen" />);
+    expect(screen.getByText(/session expired/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /go to login/i })).toBeInTheDocument();
+  });
+
+  it("preserves return destination on login click from dashboard", async () => {
+    mockPathname.mockReturnValue("/dashboard");
+    render(<SessionExpiredBanner variant="banner" />);
+    await userEvent.click(screen.getByRole("button", { name: /log in/i }));
+    expect(window.location.href).toContain("/login?returnTo=%2Fdashboard");
+  });
+
+  it("preserves return destination on login click from profile", async () => {
+    mockPathname.mockReturnValue("/profile");
+    render(<SessionExpiredBanner variant="fullscreen" />);
+    await userEvent.click(screen.getByRole("button", { name: /go to login/i }));
+    expect(window.location.href).toContain("/login?returnTo=%2Fprofile");
+  });
+
+  it("preserves return destination on login click from admin", async () => {
+    mockPathname.mockReturnValue("/admin/dashboard");
+    render(<SessionExpiredBanner variant="banner" />);
+    await userEvent.click(screen.getByRole("button", { name: /log in/i }));
+    expect(window.location.href).toContain("/login?returnTo=%2Fadmin%2Fdashboard");
+  });
+});
+
+describe("AuthGuard with expired session", () => {
+  it("shows consistent session expired UI on dashboard route", () => {
+    mockPathname.mockReturnValue("/dashboard");
+    render(
+      <AuthGuard>
+        <ProtectedContent />
+      </AuthGuard>
+    );
+    expect(screen.getByText(/session expired/i)).toBeInTheDocument();
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+  });
+
+  it("shows consistent session expired UI on admin route", () => {
+    mockPathname.mockReturnValue("/admin/dashboard");
+    render(
+      <AuthGuard>
+        <ProtectedContent />
+      </AuthGuard>
+    );
+    expect(screen.getByText(/session expired/i)).toBeInTheDocument();
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+  });
+
+  it("shows consistent session expired UI on profile route", () => {
+    mockPathname.mockReturnValue("/profile");
+    render(
+      <AuthGuard>
+        <ProtectedContent />
+      </AuthGuard>
+    );
+    expect(screen.getByText(/session expired/i)).toBeInTheDocument();
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+  });
+
+  it("does not show expired UI when authenticated", () => {
+    mockAuthState = {
+      ...mockAuthState,
+      isAuthenticated: true,
+      isSessionExpired: false,
+      user: { username: "test", email: "t@t.com", role: "user" } as any,
+    };
+    mockPathname.mockReturnValue("/dashboard");
+    render(
+      <AuthGuard>
+        <ProtectedContent />
+      </AuthGuard>
+    );
+    expect(screen.queryByText(/session expired/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Protected Content")).toBeInTheDocument();
+  });
+});

--- a/xconfess-frontend/tests/middleware/request-id.spec.ts
+++ b/xconfess-frontend/tests/middleware/request-id.spec.ts
@@ -1,0 +1,65 @@
+import { getOrCreateRequestId, withRequestId, requestIdResponseHeaders } from '@/app/lib/utils/requestId';
+
+describe('Request ID Propagation', () => {
+  describe('getOrCreateRequestId', () => {
+    it('generates a UUID when no header is present', () => {
+      const request = new Request('http://localhost/api/test');
+      const id = getOrCreateRequestId(request);
+      expect(id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+
+    it('uses X-Request-ID header when present', () => {
+      const request = new Request('http://localhost/api/test', {
+        headers: { 'X-Request-ID': 'abc-123' },
+      });
+      expect(getOrCreateRequestId(request)).toBe('abc-123');
+    });
+
+    it('uses x-request-id header (lowercase) when present', () => {
+      const request = new Request('http://localhost/api/test', {
+        headers: { 'x-request-id': 'lower-456' },
+      });
+      expect(getOrCreateRequestId(request)).toBe('lower-456');
+    });
+
+    it('falls back to X-Correlation-ID for backward compatibility', () => {
+      const request = new Request('http://localhost/api/test', {
+        headers: { 'X-Correlation-ID': 'corr-789' },
+      });
+      expect(getOrCreateRequestId(request)).toBe('corr-789');
+    });
+
+    it('trims whitespace from header values', () => {
+      const request = new Request('http://localhost/api/test', {
+        headers: { 'X-Request-ID': '  spaced-id  ' },
+      });
+      expect(getOrCreateRequestId(request)).toBe('spaced-id');
+    });
+
+    it('generates a new ID for empty header values', () => {
+      const request = new Request('http://localhost/api/test', {
+        headers: { 'X-Request-ID': '   ' },
+      });
+      const id = getOrCreateRequestId(request);
+      expect(id).not.toBe('');
+      expect(id.trim().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('withRequestId', () => {
+    it('adds x-request-id to headers', () => {
+      const headers = withRequestId({ 'Content-Type': 'application/json' }, 'test-id');
+      expect(headers['x-request-id']).toBe('test-id');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+  });
+
+  describe('requestIdResponseHeaders', () => {
+    it('returns headers with x-request-id', () => {
+      const headers = requestIdResponseHeaders('resp-id');
+      expect(headers['x-request-id']).toBe('resp-id');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR resolves four Stellar Wave issues assigned to me:

- **#1240** - Normalize session-expired banners across protected routes
- **#1255** - Add request ID propagation from frontend proxy to backend logs
- **#1295** - Add loading skeletons for all data-fetching pages
- **#1302** - Implement admin diagnostics page with system health overview

### Issue #1240: Session-Expired Banner Normalization
- Created reusable `SessionExpiredBanner` component with `banner` and `fullscreen` variants
- Updated `AuthGuard` to use the unified component for both session expiry and redirect-loop states
- Preserved original destination via `returnTo` query parameter on login redirects
- Updated `AuthProvider` to properly set `isSessionExpired` on terminal auth errors
- Added tests covering dashboard, admin, and profile routes

### Issue #1255: Request ID Propagation
- Created `requestId.ts` utility with `getOrCreateRequestId()`, `withRequestId()`, and `requestIdResponseHeaders()`
- Header name is configurable via `REQUEST_ID_HEADER_NAME` env var (defaults to `X-Request-ID`)
- Updated proxy routes (`/api/confessions`, `/api/confessions/[id]`, `/api/auth/session`, `/api/comments/[confessionId]`) to generate UUID `x-request-id` if not present and forward it to backend
- Backend `RequestIdMiddleware` already reads `x-request-id` and echoes it back — now consistently connected end-to-end
- Added middleware test verifying ID generation and forwarding

### Issue #1295: Loading Skeletons
- Added `loading.tsx` files for: dashboard feed, profile, search, admin dashboard, and admin diagnostics pages
- Added `SearchResultsSkeleton`, `ProfilePageSkeleton`, and `AdminDashboardSkeleton` components
- Replaced text-only "Searching..." with skeleton component on search page
- All skeletons match the shape of actual content to prevent layout shift
- Includes accessibility attributes (`role="status"`, `aria-live="polite"`)

### Issue #1302: Admin Diagnostics System Health Overview
- Expanded diagnostics page with service status cards (Backend, Database, Redis, Queues, Stellar Horizon)
- Added BullMQ queue metrics panel (active, waiting, failed, DLQ depth)
- Added audit activity section
- Added refresh button and auto-refresh toggle (30-second interval)
- Created `/api/health/ready` proxy route for system health endpoint
- Added `getSystemHealth()` to admin API client

Closes #1240
Closes #1255
Closes #1295
Closes #1302

## Test plan
- [ ] Expire session cookie → verify consistent banner on `/dashboard`, `/admin/dashboard`, `/profile`
- [ ] Click "Log in" on banner → verify `returnTo` param preserved in URL
- [ ] Check network tab → verify `x-request-id` header sent to backend on confession fetch
- [ ] Throttle network to Slow 3G → verify skeleton loading states on all pages
- [ ] Navigate to `/admin/diagnostics` → verify service status cards, queue metrics, and refresh button
- [ ] Toggle auto-refresh → verify panels update every 30 seconds