### PR TITLE
docs: document backend test-light directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ npm test
 
 Root `npm test` runs backend unit tests, then contract tests via `npm run contract:test`. Use it when you want the same contract coverage as CI without running the full `npm run ci` pipeline.
 
+For backend directories that are intentionally test-light, such as migrations, type definitions, and DTOs, see the [backend testing notes](xconfess-backend/README.md#intentionally-test-light-directories).
+
 ### Soroban contracts (Rust / `cargo`)
 
 Rust commands for `xconfess-contracts` must be run with that directory as the working directory (or use the root `npm run contract:*` scripts, which delegate there automatically).

--- a/xconfess-backend/README.md
+++ b/xconfess-backend/README.md
@@ -124,6 +124,16 @@ npm run test:e2e
 npm run test:cov
 ```
 
+### Intentionally Test-Light Directories
+
+Some backend directories are expected to have few or no dedicated `*.spec.ts` files:
+
+| Directory | Why it is test-light |
+| --- | --- |
+| `migrations/` and `src/migrations/` | TypeORM migration files are mostly timestamped schema changes. They are reviewed for SQL/schema correctness and exercised when a database is migrated, with focused specs added only for migration helpers or unusually risky data movement. |
+| `src/types/` | Shared TypeScript-only type definitions compile away at runtime, so coverage comes from `tsc` and the code that consumes those types. |
+| `src/**/dto/` | DTOs are mostly declarative validation and API-shape classes. Add focused specs when a DTO contains custom validation, transformation, or other behavior; otherwise controller and e2e tests cover the request/response paths that use them. |
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and update the values:


### PR DESCRIPTION
## Summary
- Document backend directories that are intentionally test-light and why
- Link the root testing section to the backend testing notes

Closes #1371

## Tests
- Not run (documentation-only change)