### PR TITLE
fix(frontend): make reaction controls screen-reader accessible

### DIFF
--- a/xconfess-frontend/app/components/confession/ReactionButtons.tsx
+++ b/xconfess-frontend/app/components/confession/ReactionButtons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { cn } from "@/app/lib/utils/cn";
 import { useReactions } from "@/app/lib/hooks/useReactions";
 import type { ReactionType } from "@/app/lib/types/reaction";
@@ -18,6 +18,7 @@ export const ReactionButton = ({
   confessionId,
   isActive = false,
 }: Props) => {
+  const id = useId();
   const [isAnimating, setIsAnimating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { addReaction, isPending, optimisticState, liveCounts, connectionState } = useReactions({
@@ -34,6 +35,16 @@ export const ReactionButton = ({
   const displayCount = optimisticState?.counts[type] ?? liveCounts[type] ?? count;
   const computedIsActive = optimisticState?.userReaction === type || isActive;
   const statusLabel = `Reaction live status: ${connectionState}`;
+  const countLabel = `${displayCount} ${
+    displayCount === 1 ? "reaction" : "reactions"
+  }`;
+  const selectedLabel = computedIsActive ? "selected" : "not selected";
+  const descriptionId = `${id}-reaction-description`;
+  const statusId = `${id}-reaction-status`;
+  const errorId = `${id}-reaction-error`;
+  const describedBy = [descriptionId, statusId, error ? errorId : null]
+    .filter(Boolean)
+    .join(" ");
 
   const react = async () => {
     setError(null);
@@ -49,17 +60,20 @@ export const ReactionButton = ({
     }
   };
 
-  const label = computedIsActive
-    ? `Reacted with ${type}, current count ${displayCount}`
-    : `React with ${type}, current count ${displayCount}`;
+  const label = `${type} reaction, ${countLabel}, ${selectedLabel}`;
 
   return (
-    <div className="relative">
+    <div
+      className="relative"
+      role="group"
+      aria-label={`${type} reaction controls`}
+    >
       <button
         onClick={react}
         disabled={isPending}
         aria-label={label}
         aria-pressed={computedIsActive}
+        aria-describedby={describedBy}
         title={error || undefined}
         className={cn(
           "relative flex items-center gap-2 px-4 py-2 rounded-full",
@@ -73,14 +87,24 @@ export const ReactionButton = ({
           error && "ring-2 ring-red-500"
         )}
       >
-        <span className="text-lg select-none">
+        <span className="text-lg select-none" aria-hidden="true">
           {type === "like" ? "👍" : "❤️"}
         </span>
 
         <span className="text-sm font-medium">{displayCount}</span>
+        <span id={descriptionId} className="sr-only">
+          {type} reaction {selectedLabel}. {countLabel}.
+        </span>
         <span
+          id={statusId}
           role="status"
-          aria-label={statusLabel}
+          aria-live="polite"
+          className="sr-only"
+        >
+          {statusLabel}
+        </span>
+        <span
+          aria-hidden="true"
           title={statusLabel}
           className={cn(
             "h-2 w-2 rounded-full",
@@ -92,7 +116,11 @@ export const ReactionButton = ({
       </button>
 
       {error && (
-        <div role="alert" className="absolute top-full mt-1 left-1/2 -translate-x-1/2 whitespace-nowrap">
+        <div
+          id={errorId}
+          role="alert"
+          className="absolute top-full mt-1 left-1/2 -translate-x-1/2 whitespace-nowrap"
+        >
           <div className="text-xs text-red-500 bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded">
             {error}
           </div>

--- a/xconfess-frontend/app/components/confession/ReactionTooltip.tsx
+++ b/xconfess-frontend/app/components/confession/ReactionTooltip.tsx
@@ -1,12 +1,17 @@
 interface Props {
+  id?: string;
   label: string;
   count: number;
   active: boolean;
 }
 
-export const ReactionTooltip = ({ label, count, active }: Props) => {
+export const ReactionTooltip = ({ id, label, count, active }: Props) => {
   return (
-    <div className="absolute bottom-full mb-2 rounded-md bg-black px-3 py-1 text-xs text-white shadow-lg">
+    <div
+      id={id}
+      role="tooltip"
+      className="absolute bottom-full mb-2 rounded-md bg-black px-3 py-1 text-xs text-white shadow-lg"
+    >
       {label} • {count}
       {active && <span className="ml-1 text-pink-400">(You)</span>}
     </div>

--- a/xconfess-frontend/app/components/confession/__tests__/ReactionButton.test.tsx
+++ b/xconfess-frontend/app/components/confession/__tests__/ReactionButton.test.tsx
@@ -3,7 +3,14 @@
  */
 
 import React from "react";
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  within,
+} from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactionButton } from "../ReactionButtons";
@@ -22,7 +29,7 @@ const mockSocket = {
     on: jest.fn(),
   },
 };
-const mockIo = jest.fn((..._args: unknown[]) => mockSocket);
+const mockIo = jest.fn(() => mockSocket);
 jest.mock("socket.io-client", () => ({
   io: (...args: unknown[]) => mockIo(...args),
 }));
@@ -106,6 +113,47 @@ describe("ReactionButton — optimistic count and active state", () => {
     });
 
     expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("exposes the reaction as a named control group with count and selected state", () => {
+    mockAddReaction.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <Wrapper>
+        <ReactionButton type="like" count={5} confessionId="c-1" />
+      </Wrapper>,
+    );
+
+    const group = screen.getByRole("group", {
+      name: "like reaction controls",
+    });
+    const button = within(group).getByRole("button", {
+      name: "like reaction, 5 reactions, not selected",
+    });
+
+    expect(button).toHaveAccessibleDescription(
+      /like reaction not selected\. 5 reactions\. Reaction live status: (disconnected|reconnecting)/,
+    );
+  });
+
+  it("updates the accessible name when optimistic state changes count and selection", async () => {
+    mockAddReaction.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <Wrapper>
+        <ReactionButton type="like" count={5} confessionId="c-1" />
+      </Wrapper>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: "like reaction, 6 reactions, selected",
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
   });
 
   it("rolls back the displayed count when the reaction API fails (feed surface)", async () => {
@@ -261,11 +309,11 @@ describe("ReactionButton — optimistic count and active state", () => {
     await act(async () => {
       triggerSocketEvent("connect");
     });
-    expect(screen.getByLabelText("Reaction live status: connected")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Reaction live status: connected");
 
     await act(async () => {
       triggerSocketEvent("disconnect");
     });
-    expect(screen.getByLabelText("Reaction live status: reconnecting")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Reaction live status: reconnecting");
   });
 });

--- a/xconfess-frontend/tests/accessibility/auth-feed-admin.a11y.spec.tsx
+++ b/xconfess-frontend/tests/accessibility/auth-feed-admin.a11y.spec.tsx
@@ -43,8 +43,12 @@ jest.mock("@/app/lib/hooks/useAuth", () => ({
 
 jest.mock("@/app/lib/hooks/useReactions", () => ({
   useReactions: () => ({
-    addReaction: mockAddReaction,
+    addReaction: (confessionId: string, type: string) =>
+      mockAddReaction({ confessionId, type }),
     isPending: false,
+    optimisticState: null,
+    liveCounts: { like: 5, love: 0 },
+    connectionState: "connected",
   }),
 }));
 
@@ -259,6 +263,21 @@ describe("ReactionButton accessibility", () => {
     const button = screen.getByRole("button");
     expect(button.getAttribute("aria-label")).toContain("like");
     expect(button.getAttribute("aria-label")).toContain("5");
+  });
+
+  it("exposes a named reaction control group with selected state and live status", () => {
+    render(<ReactionButton {...defaultProps} />);
+
+    const group = screen.getByRole("group", {
+      name: "like reaction controls",
+    });
+    const button = within(group).getByRole("button", {
+      name: "like reaction, 5 reactions, not selected",
+    });
+
+    expect(button).toHaveAccessibleDescription(
+      "like reaction not selected. 5 reactions. Reaction live status: connected",
+    );
   });
 
   it("can be triggered with Enter key", async () => {


### PR DESCRIPTION
Closes #1230.

## Summary

- add a named reaction control group for each reaction button
- expose count, selected state, sync status, and errors through `aria-describedby` / live regions
- mark decorative emoji/status-dot visuals as hidden from assistive technology
- give reaction tooltips `role="tooltip"` and optional id support
- extend component and accessibility tests for keyboard/screen-reader state

## Validation

- `node node_modules/jest/bin/jest.js app/components/confession/__tests__/ReactionButton.test.tsx --runInBand`
- `node node_modules/jest/bin/jest.js tests/accessibility/auth-feed-admin.a11y.spec.tsx -t ReactionButton --runInBand`
- `node node_modules/jest/bin/jest.js Reaction --runInBand`
- `node node_modules/eslint/bin/eslint.js app/components/confession/ReactionButtons.tsx app/components/confession/ReactionTooltip.tsx app/components/confession/__tests__/ReactionButton.test.tsx tests/accessibility/auth-feed-admin.a11y.spec.tsx --fix`
- `git diff --check`

I also tried `node node_modules/typescript/bin/tsc --noEmit`, but the existing checkout has unrelated JSX syntax errors in `app/(dashboard)/search/page.tsx` and `app/components/confession/ConfessionFeed.tsx`, so full typecheck is currently blocked outside this PR's files.
