### PR TITLE
docs: define dead letter queue glossary term

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -10,6 +10,12 @@ The process of recording a cryptographic hash (SHA-256) of a confession on the S
 
 A Stellar-based feature that allows users to send tips to confession authors without revealing their identity. Users sign and submit tip transactions through their wallet, then send the transaction hash to the backend for verification. The system validates the transaction on-chain and records tip amounts idempotently, ensuring no double-crediting even with replayed verification requests. Supports optional settlement proof metadata for off-chain reconciliation. See the [Anonymous Tipping contract reference](contract-abi-reference.md#anonymous-tipping-contract) and the [Stellar anchoring and tipping runbook](stellar-anchor-and-tipping-runbook.md) for operational details.
 
+## D
+
+### Dead Letter Queue (DLQ)
+
+A protected operational queue for work that exhausted its normal retry policy and needs administrator review. In XConfess, notification jobs from the `notifications` BullMQ queue are copied into the `notifications-dlq` queue as `dead-letter` jobs after their final failed attempt. Each DLQ entry keeps the original notification payload plus failure metadata such as the original job id, failure time, attempts made, and last error. Administrators can inspect, filter, replay, export, or clean up these entries through the admin notification DLQ surfaces, including the protected `/api/admin/dlq` endpoints and the admin notifications dashboard. Replay and cleanup actions are recorded in the audit log so operators can track who handled failed notification work and why.
+
 ## H
 
 ### Health Endpoints


### PR DESCRIPTION
Closes #1386.

## Summary

- add a `Dead Letter Queue (DLQ)` glossary entry
- explain that exhausted notification jobs from `notifications` are copied to `notifications-dlq`
- describe the retained failure metadata and protected admin DLQ surfaces for inspect/filter/replay/export/cleanup
- note that replay and cleanup actions are audit logged

## Validation

- `rg -n 'Dead Letter Queue|notifications-dlq|/api/admin/dlq|notification_queue_dlq_total|dead-letter' docs/GLOSSARY.md xconfess-backend/src/notifications/processors/notification.processor.ts xconfess-backend/src/notifications/dlq-admin.controller.ts xconfess-backend/src/audit-log/audit-log.service.ts xconfess-frontend/app/lib/api/admin.ts`
- `git diff --check`

This is a documentation-only change, so I did not run the app test suite.
