### PR TITLE
[codex] Add draft conflict recovery UI

### DIFF
--- a/xconfess-frontend/app/components/confession/DraftManager.tsx
+++ b/xconfess-frontend/app/components/confession/DraftManager.tsx
@@ -21,6 +21,17 @@ interface DraftManagerProps {
   autoSaveInterval?: number; // in milliseconds
 }
 
+const draftContentKey = (draft: {
+  title?: string;
+  body: string;
+  gender?: string;
+}) =>
+  JSON.stringify({
+    title: draft.title ?? "",
+    body: draft.body,
+    gender: draft.gender ?? "",
+  });
+
 export const DraftManager: React.FC<DraftManagerProps> = ({
   currentDraft,
   onLoadDraft,
@@ -45,9 +56,36 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
     "saved" | "saving" | "unsaved" | "failed"
   >("saved");
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [dismissedConflictKey, setDismissedConflictKey] = useState<
+    string | null
+  >(null);
   const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastSavedRef = useRef<string>("");
   const toast = useGlobalToast();
+  const latestSavedDraft = !isLoading && drafts.length > 0 ? drafts[0] : null;
+  const localDraftHasContent = Boolean(
+    currentDraft.title?.trim() || currentDraft.body.trim(),
+  );
+  const savedDraftContentKey = latestSavedDraft
+    ? draftContentKey(latestSavedDraft)
+    : null;
+  const localDraftContentKey = draftContentKey(currentDraft);
+  const activeConflictKey =
+    latestSavedDraft &&
+    localDraftHasContent &&
+    !currentDraftId &&
+    savedDraftContentKey !== localDraftContentKey
+      ? `${latestSavedDraft.id}:${latestSavedDraft.savedAt}:${savedDraftContentKey}`
+      : null;
+  const hasDraftConflict = Boolean(
+    activeConflictKey && dismissedConflictKey !== activeConflictKey,
+  );
+
+  useEffect(() => {
+    if (!activeConflictKey && dismissedConflictKey) {
+      setDismissedConflictKey(null);
+    }
+  }, [activeConflictKey, dismissedConflictKey]);
 
   // Restore most recent draft on mount if one exists and the composer is empty.
   // Acceptance criteria: "Restore draft on composer mount when user has
@@ -149,6 +187,11 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
       clearTimeout(autoSaveTimerRef.current);
     }
 
+    if (hasDraftConflict) {
+      setSaveMessage("Resolve draft conflict before autosave resumes.");
+      return;
+    }
+
     autoSaveTimerRef.current = setTimeout(() => {
       void persistDraft();
     }, autoSaveInterval);
@@ -172,6 +215,36 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
     setSaveStatus("saved");
     setSaveMessage("Draft saved.");
     setIsModalOpen(false);
+    setDismissedConflictKey(null);
+  };
+
+  const dismissActiveConflict = () => {
+    if (activeConflictKey) {
+      setDismissedConflictKey(activeConflictKey);
+    }
+  };
+
+  const handleKeepLocalDraft = () => {
+    dismissActiveConflict();
+    setSaveStatus("unsaved");
+    setSaveMessage("Unsaved changes");
+  };
+
+  const handleDiscardLocalDraft = () => {
+    const emptyDraft: Draft = {
+      id: "discard-local-draft",
+      title: "",
+      body: "",
+      savedAt: Date.now(),
+      characterCount: 0,
+    };
+
+    onLoadDraft(emptyDraft);
+    setCurrentDraftId(null);
+    lastSavedRef.current = JSON.stringify({ title: "", body: "" });
+    setSaveStatus("saved");
+    setSaveMessage(null);
+    dismissActiveConflict();
   };
 
   const handleDeleteDraft = (id: string, e: React.MouseEvent) => {
@@ -189,38 +262,56 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
     toast.success("All drafts cleared.");
   };
 
-  /**
-   * Called by the composer on successful publish/submit, per acceptance
-   * criteria: "Publishing or submitting clears or archives draft per
-   * product rules." Exposed via a side-effect prop would be cleaner, but
-   * to minimize blast radius on this pass we expose it as a stable
-   * function consumers can call directly through a ref if needed.
-   * TODO(product): confirm clear vs archive semantics with product —
-   * this currently clears (deletes) rather than archiving.
-   */
-  const handlePublishCleanup = async () => {
-    if (currentDraftId) {
-      await deleteDraft(currentDraftId);
-      setCurrentDraftId(null);
-      lastSavedRef.current = "";
-      setSaveStatus("saved");
-      setSaveMessage(null);
-    }
-  };
-
   return (
     <>
       <ConfirmDialog
         open={clearDraftsOpen}
         onOpenChange={setClearDraftsOpen}
         title="Clear all drafts?"
-        description="This will permanently remove every saved draft on this device."
+        description="This permanently deletes every saved draft. Published drafts are cleared after submit rather than archived."
         confirmLabel="Clear drafts"
         variant="danger"
         onConfirm={() => void handleClearDrafts()}
       />
 
       <div className="flex flex-col gap-2">
+        {hasDraftConflict && latestSavedDraft && (
+          <div
+            role="status"
+            className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-50"
+          >
+            <p className="font-medium">Draft conflict detected</p>
+            <p className="mt-1 text-xs text-amber-100/80">
+              A saved server draft differs from your local text. Discard clears
+              only the local composer; Clear All permanently deletes saved
+              drafts. Published drafts are cleared after submit, not archived.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleKeepLocalDraft}
+              >
+                Keep local
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleLoadDraft(latestSavedDraft)}
+              >
+                Use saved draft
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDiscardLocalDraft}
+              >
+                Discard local
+              </Button>
+            </div>
+          </div>
+        )}
+
         <Button
           variant="outline"
           size="sm"

--- a/xconfess-frontend/app/components/confession/__tests__/DraftManager.test.tsx
+++ b/xconfess-frontend/app/components/confession/__tests__/DraftManager.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DraftManager } from "../DraftManager";
+import { useDrafts } from "@/app/lib/hooks/useDrafts";
+import type { Draft } from "@/app/lib/types/draft";
+
+jest.mock("@/app/lib/hooks/useDrafts", () => ({
+  useDrafts: jest.fn(),
+}));
+
+jest.mock("@/app/components/common/Toast", () => ({
+  useGlobalToast: () => ({
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warning: jest.fn(),
+  }),
+}));
+
+jest.mock("@/app/components/ui/modal", () => ({
+  Modal: ({ isOpen, title, children }: any) =>
+    isOpen ? (
+      <section aria-label={title}>
+        <h2>{title}</h2>
+        {children}
+      </section>
+    ) : null,
+}));
+
+jest.mock("@/app/components/admin/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+jest.mock("lucide-react", () => ({
+  Trash2: () => <span data-testid="trash-icon" />,
+  Clock: () => <span data-testid="clock-icon" />,
+  FileText: () => <span data-testid="file-icon" />,
+}));
+
+const savedDraft: Draft = {
+  id: "remote-1",
+  title: "Saved title",
+  body: "Saved server draft",
+  gender: "female",
+  savedAt: Date.now(),
+  characterCount: 18,
+};
+
+function mockDrafts(overrides: Partial<ReturnType<typeof useDrafts>> = {}) {
+  (useDrafts as jest.Mock).mockReturnValue({
+    drafts: [],
+    isLoading: false,
+    error: null,
+    isRemote: true,
+    saveDraft: jest.fn().mockResolvedValue("new-draft"),
+    updateDraft: jest.fn().mockResolvedValue(true),
+    deleteDraft: jest.fn().mockResolvedValue(undefined),
+    clearDrafts: jest.fn().mockResolvedValue(undefined),
+    loadDraft: jest.fn(),
+    ...overrides,
+  });
+}
+
+describe("DraftManager conflict recovery", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("offers keep local, use saved draft, and discard local choices when drafts conflict", async () => {
+    const onLoadDraft = jest.fn();
+    mockDrafts({
+      drafts: [savedDraft],
+      loadDraft: jest.fn().mockReturnValue(undefined),
+    });
+
+    render(
+      <DraftManager
+        currentDraft={{ title: "Local title", body: "Unsaved local draft" }}
+        onLoadDraft={onLoadDraft}
+        autoSaveInterval={60_000}
+      />,
+    );
+
+    expect(screen.getByText("Draft conflict detected")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /keep local/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /use saved draft/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /discard local/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /use saved draft/i }));
+
+    expect(onLoadDraft).toHaveBeenCalledWith(savedDraft);
+    expect(screen.queryByText("Draft conflict detected")).not.toBeInTheDocument();
+  });
+
+  it("clears the composer when the user discards the local conflict", async () => {
+    const onLoadDraft = jest.fn();
+    mockDrafts({
+      drafts: [savedDraft],
+      loadDraft: jest.fn().mockReturnValue(undefined),
+    });
+
+    render(
+      <DraftManager
+        currentDraft={{ body: "Unsaved local draft" }}
+        onLoadDraft={onLoadDraft}
+        autoSaveInterval={60_000}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /discard local/i }));
+
+    expect(onLoadDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ body: "", characterCount: 0 }),
+    );
+    expect(screen.queryByText("Draft conflict detected")).not.toBeInTheDocument();
+  });
+
+  it("keeps the local draft without loading the saved draft", async () => {
+    const onLoadDraft = jest.fn();
+    mockDrafts({
+      drafts: [savedDraft],
+      loadDraft: jest.fn().mockReturnValue(undefined),
+    });
+
+    render(
+      <DraftManager
+        currentDraft={{ body: "Unsaved local draft" }}
+        onLoadDraft={onLoadDraft}
+        autoSaveInterval={60_000}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /keep local/i }));
+
+    expect(onLoadDraft).not.toHaveBeenCalled();
+    expect(screen.queryByText("Draft conflict detected")).not.toBeInTheDocument();
+  });
+
+  it("shows a retryable failure state when autosave fails", async () => {
+    const saveDraft = jest.fn().mockResolvedValue(null);
+    mockDrafts({
+      error: "Remote save failed.",
+      saveDraft,
+      loadDraft: jest.fn().mockReturnValue(undefined),
+    });
+
+    render(
+      <DraftManager
+        currentDraft={{ body: "Draft that should autosave" }}
+        onLoadDraft={jest.fn()}
+        autoSaveInterval={1}
+      />,
+    );
+
+    await waitFor(() => expect(saveDraft).toHaveBeenCalled());
+    expect(await screen.findByText(/remote save failed/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1228.

- add a draft conflict recovery state when the local composer differs from the latest saved server draft
- offer explicit Keep local, Use saved draft, and Discard local recovery choices
- pause autosave while a conflict is unresolved so the saved draft is not overwritten before the user chooses
- make clear/delete/archive semantics explicit in the conflict state and clear-all confirmation

## Validation

- `npm run test --workspace=xconfess-frontend -- --runTestsByPath app/components/confession/__tests__/DraftManager.test.tsx --runInBand`
- `npm run test --workspace=xconfess-frontend -- --runTestsByPath app/components/confession/__tests__/EnhancedConfessionForm.test.tsx --runInBand`
- `npm run test --workspace=xconfess-frontend -- DraftManager --runInBand`
- `npm run lint --workspace=xconfess-frontend -- app/components/confession/DraftManager.tsx app/components/confession/__tests__/DraftManager.test.tsx`
- `git diff --check`
