### PR TITLE
fix(backend): enforce production-strength JWT and app secret minimums

### DIFF
--- a/xconfess-backend/.env.example
+++ b/xconfess-backend/.env.example
@@ -27,8 +27,12 @@ TYPEORM_SYNCHRONIZE=true
 TYPEORM_MIGRATIONS_RUN=false
 
 # Auth
-JWT_SECRET=change-me-to-a-long-local-secret
-APP_SECRET=change-me-to-a-long-local-app-secret
+# JWT_SECRET and APP_SECRET must be at least 32 characters (APP_SECRET is
+# only enforced as required in production/staging, but if set locally it
+# must still meet the length minimum).
+# Generate strong values with: openssl rand -base64 48
+JWT_SECRET=local-dev-jwt-secret-please-replace-with-32-plus-chars
+APP_SECRET=local-dev-app-secret-please-replace-with-32-plus-chars
 
 # Redis
 REDIS_HOST=localhost

--- a/xconfess-backend/src/config/env.validation.spec.ts
+++ b/xconfess-backend/src/config/env.validation.spec.ts
@@ -9,7 +9,7 @@ describe('Environment Validation', () => {
     DB_USERNAME: 'test',
     DB_PASSWORD: 'test',
     DB_NAME: 'test',
-    JWT_SECRET: 'testsecret123',
+    JWT_SECRET: 'a'.repeat(32),
   };
 
   const validKey =
@@ -91,4 +91,64 @@ describe('Environment Validation', () => {
     const { error } = envValidationSchema.validate(config);
     expect(error).toBeUndefined();
   });
+
+  it('should fail if JWT_SECRET is shorter than 32 characters', () => {
+    const config = {
+      ...baseConfig,
+      JWT_SECRET: 'short-secret',
+      CONFESSION_ENCRYPTION_KEY: validKey,
+    };
+    const { error } = envValidationSchema.validate(config);
+    expect(error).toBeDefined();
+    expect(error!.message).toContain(
+      'JWT_SECRET must be at least 32 characters long',
+    );
+  });
+
+  it('should fail boot in production if APP_SECRET is missing', () => {
+    const config = {
+      ...baseConfig,
+      NODE_ENV: 'production',
+      CONFESSION_ENCRYPTION_KEY: validKey,
+    };
+    const { error } = envValidationSchema.validate(config);
+    expect(error).toBeDefined();
+    expect(error!.message).toContain('APP_SECRET is required');
+  });
+
+  it('should fail boot in staging if APP_SECRET is too short', () => {
+    const config = {
+      ...baseConfig,
+      NODE_ENV: 'staging',
+      CONFESSION_ENCRYPTION_KEY: validKey,
+      APP_SECRET: 'too-short',
+    };
+    const { error } = envValidationSchema.validate(config);
+    expect(error).toBeDefined();
+    expect(error!.message).toContain(
+      'APP_SECRET must be at least 32 characters long',
+    );
+  });
+
+  it('should pass in production when APP_SECRET meets the minimum length', () => {
+    const config = {
+      ...baseConfig,
+      NODE_ENV: 'production',
+      CONFESSION_ENCRYPTION_KEY: validKey,
+      APP_SECRET: 'a'.repeat(32),
+    };
+    const { error } = envValidationSchema.validate(config);
+    expect(error).toBeUndefined();
+  });
+
+  it('should allow APP_SECRET to be omitted in development', () => {
+    const config = {
+      ...baseConfig,
+      NODE_ENV: 'development',
+      CONFESSION_ENCRYPTION_KEY: validKey,
+    };
+    const { error } = envValidationSchema.validate(config);
+    expect(error).toBeUndefined();
+  });
 });
+

--- a/xconfess-backend/src/config/env.validation.ts
+++ b/xconfess-backend/src/config/env.validation.ts
@@ -39,13 +39,27 @@ export const envValidationSchema = Joi.object({
     .optional(),
 
   // ── Auth ──────────────────────────────────────────────────────────────
-  JWT_SECRET: Joi.string().min(8).required().messages({
-    'any.required': 'JWT_SECRET is required – generate a strong random string.',
-    'string.min': 'JWT_SECRET must be at least 8 characters.',
+ JWT_SECRET: Joi.string().min(32).required().messages({
+    'any.required':
+      'JWT_SECRET is required – generate a strong random string (e.g. `openssl rand -base64 48`).',
+    'string.min':
+      'JWT_SECRET must be at least 32 characters long for production-strength signing.',
   }),
 
   // ── App / URLs ────────────────────────────────────────────────────────
-  APP_SECRET: Joi.string().optional(),
+ APP_SECRET: Joi.string()
+    .min(32)
+    .when('NODE_ENV', {
+      is: Joi.valid('production', 'staging'),
+      then: Joi.required(),
+      otherwise: Joi.optional(),
+    })
+    .messages({
+      'any.required':
+        'APP_SECRET is required in production and staging – generate a strong random string (e.g. `openssl rand -base64 48`).',
+      'string.min':
+        'APP_SECRET must be at least 32 characters long for production-strength security.',
+    }),
   BACKEND_URL: Joi.string().uri().optional(),
   FRONTEND_URL: Joi.string().default('http://localhost:3000'),
 


### PR DESCRIPTION
## Summary
Closes #1415

Raises secret validation strength for `JWT_SECRET` and `APP_SECRET` to
prevent weak secrets from undermining authenticated API and admin flows.

## Changes
- Raised `JWT_SECRET` minimum length validation from 8 to 32 characters
  in `env.validation.ts`.
- `APP_SECRET` is now required (min 32 characters) when `NODE_ENV` is
  `production` or `staging`, via a Joi conditional (`when`). It remains
  optional in `development`/`test`.
- Added clear, actionable boot-time validation error messages for both
  secrets, including a suggested command to generate a compliant value
  (`openssl rand -base64 48`).
- Updated `.env.example` with documented placeholder values that satisfy
  the new minimums, so local/test setup is unaffected.
- Updated `env.validation.spec.ts`:
  - Bumped `baseConfig.JWT_SECRET` to a 32-character value so existing
    tests still pass under the new minimum.
  - Added tests covering:
    - `JWT_SECRET` shorter than 32 characters fails validation.
    - `APP_SECRET` missing in production fails boot.
    - `APP_SECRET` too short in staging fails boot.
    - `APP_SECRET` meeting the minimum passes in production.
    - `APP_SECRET` can still be omitted in development.

## Testing
- `npm run backend:test -- --runTestsByPath src/config/env.validation.spec.ts` ✅
- `npm run backend:build` ✅

## Notes for reviewers
- No changes required to existing local `.env` files as long as
  `JWT_SECRET` is already 32+ characters; otherwise local boot will now
  fail with a clear message pointing at the fix.
- Anyone deploying to production/staging with a short or missing secret
  will need to rotate/set it before the app will boot — this is a
  deploy-time consideration, not a code risk introduced by this PR.