### PR TITLE
fix(security): extend and fix request body size limits

### DIFF
--- a/xconfess-backend/src/common/request-body-limits.spec.ts
+++ b/xconfess-backend/src/common/request-body-limits.spec.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   INestApplication,
   Param,
+  Patch,
   Post,
   Put,
   ValidationPipe,
@@ -15,14 +16,16 @@ import { UpdateConfessionDto } from '../confession/dto/update-confession.dto';
 import {
   COMMENT_REQUEST_MAX_BYTES,
   CONFESSION_REQUEST_MAX_BYTES,
+  DRAFT_REQUEST_MAX_BYTES,
+  MESSAGE_REQUEST_MAX_BYTES,
+  REPORT_REQUEST_MAX_BYTES,
   configureRequestBodyParsing,
 } from './request-body-limits';
 
+// ── Minimal stub services ────────────────────────────────────────────────────
+
 const confessionService = {
-  create: jest.fn((dto: CreateConfessionDto) => ({
-    id: 'confession-id',
-    ...dto,
-  })),
+  create: jest.fn((dto: CreateConfessionDto) => ({ id: 'confession-id', ...dto })),
   update: jest.fn((id: string, dto: UpdateConfessionDto) => ({ id, ...dto })),
 };
 
@@ -32,7 +35,26 @@ const commentService = {
     confessionId,
     content: body.content,
   })),
+  edit: jest.fn((id: string, body: { content: string }) => ({
+    id,
+    content: body.content,
+  })),
 };
+
+const reportService = {
+  create: jest.fn((confessionId: string, dto: unknown) => ({ id: 1, confessionId, ...dto })),
+};
+
+const draftService = {
+  create: jest.fn((dto: unknown) => ({ id: 'draft-id', ...dto })),
+  update: jest.fn((id: string, dto: unknown) => ({ id, ...dto })),
+};
+
+const messageService = {
+  send: jest.fn((dto: unknown) => ({ id: 1, ...dto })),
+};
+
+// ── Minimal test controllers ─────────────────────────────────────────────────
 
 @Controller('confessions')
 class TestConfessionController {
@@ -47,17 +69,58 @@ class TestConfessionController {
   }
 }
 
-@Controller('comments')
+/** Mirrors real CommentController at confessions/:confessionId/comments */
+@Controller('confessions/:confessionId/comments')
 class TestCommentController {
-  @Post(':confessionId')
+  @Post()
   create(
     @Param('confessionId') confessionId: string,
     @Body() body: { content: string },
   ) {
     return commentService.create(confessionId, body);
   }
+
+  @Patch(':id')
+  edit(@Param('id') id: string, @Body() body: { content: string }) {
+    return commentService.edit(id, body);
+  }
 }
 
+@Controller('confessions/:id')
+class TestReportController {
+  @Post('report')
+  create(@Param('id') confessionId: string, @Body() dto: unknown) {
+    return reportService.create(confessionId, dto);
+  }
+}
+
+@Controller('confessions/drafts')
+class TestDraftController {
+  @Post()
+  create(@Body() dto: unknown) {
+    return draftService.create(dto);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: unknown) {
+    return draftService.update(id, dto);
+  }
+}
+
+@Controller('messages')
+class TestMessageController {
+  @Post()
+  send(@Body() dto: unknown) {
+    return messageService.send(dto);
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a JSON string whose byte length equals `targetBytes`.
+ * A `padding` field is appended to reach the exact target.
+ */
 function bodyAtByteSize(
   base: Record<string, unknown>,
   targetBytes: number,
@@ -66,18 +129,28 @@ function bodyAtByteSize(
   const paddingBytes = targetBytes - Buffer.byteLength(bodyWithEmptyPadding);
 
   if (paddingBytes < 0) {
-    throw new Error('Base body exceeds requested byte size');
+    throw new Error(
+      `Base body (${Buffer.byteLength(bodyWithEmptyPadding)} B) already exceeds requested ${targetBytes} B`,
+    );
   }
 
   return JSON.stringify({ ...base, padding: 'x'.repeat(paddingBytes) });
 }
+
+// ── Test suite ───────────────────────────────────────────────────────────────
 
 describe('request body limits', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      controllers: [TestConfessionController, TestCommentController],
+      controllers: [
+        TestConfessionController,
+        TestCommentController,
+        TestReportController,
+        TestDraftController,
+        TestMessageController,
+      ],
     }).compile();
 
     app = moduleRef.createNestApplication({ bodyParser: false });
@@ -86,9 +159,7 @@ describe('request body limits', () => {
     const requestIdMiddleware = new RequestIdMiddleware();
     app.use(requestIdMiddleware.use.bind(requestIdMiddleware));
     configureRequestBodyParsing(app);
-    app.useGlobalPipes(
-      new ValidationPipe({ whitelist: true, transform: true }),
-    );
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
 
     await app.init();
   });
@@ -101,97 +172,340 @@ describe('request body limits', () => {
     jest.clearAllMocks();
   });
 
-  it('rejects an oversized confession before controller work', async () => {
-    const secret = 'CONFESSION_SECRET_SHOULD_NOT_BE_ECHOED';
-    const body = bodyAtByteSize(
-      { message: 'valid', secret },
-      CONFESSION_REQUEST_MAX_BYTES + 1,
-    );
+  // ── Confessions ────────────────────────────────────────────────────────────
 
-    const response = await request(app.getHttpServer())
-      .post('/api/confessions')
-      .set('Content-Type', 'application/json')
-      .send(body);
+  describe('confessions', () => {
+    it('rejects an oversized POST /confessions body with 413', async () => {
+      const secret = 'CONFESSION_SECRET_MUST_NOT_LEAK';
+      const body = bodyAtByteSize(
+        { message: 'valid', secret },
+        CONFESSION_REQUEST_MAX_BYTES + 1,
+      );
 
-    expect(response.status).toBe(413);
-    expect(response.body).toMatchObject({
-      status: 413,
-      code: 'REQUEST_TOO_LARGE',
-      message: 'Request body exceeds the allowed size',
-      path: '/api/confessions',
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(res.body).toMatchObject({
+        status: 413,
+        code: 'REQUEST_TOO_LARGE',
+        message: 'Request body exceeds the allowed size',
+        path: '/api/confessions',
+      });
+      expect(res.body).toHaveProperty('timestamp');
+      expect(res.body.requestId).not.toBe('unknown');
+      expect(JSON.stringify(res.body)).not.toContain(secret);
+      expect(confessionService.create).not.toHaveBeenCalled();
     });
-    expect(response.body).toHaveProperty('timestamp');
-    expect(response.body.requestId).not.toBe('unknown');
-    expect(JSON.stringify(response.body)).not.toContain(secret);
-    expect(confessionService.create).not.toHaveBeenCalled();
-  });
 
-  it('applies the confession limit to updates too', async () => {
-    const body = bodyAtByteSize(
-      { message: 'valid update' },
-      CONFESSION_REQUEST_MAX_BYTES + 1,
-    );
+    it('rejects an oversized PUT /confessions/:id body with 413', async () => {
+      const body = bodyAtByteSize(
+        { message: 'updated' },
+        CONFESSION_REQUEST_MAX_BYTES + 1,
+      );
 
-    const response = await request(app.getHttpServer())
-      .put('/api/confessions/confession-id')
-      .set('Content-Type', 'application/json')
-      .send(body);
+      const res = await request(app.getHttpServer())
+        .put('/api/confessions/abc-123')
+        .set('Content-Type', 'application/json')
+        .send(body);
 
-    expect(response.status).toBe(413);
-    expect(response.body.code).toBe('REQUEST_TOO_LARGE');
-    expect(confessionService.update).not.toHaveBeenCalled();
-  });
+      expect(res.status).toBe(413);
+      expect(res.body.code).toBe('REQUEST_TOO_LARGE');
+      expect(confessionService.update).not.toHaveBeenCalled();
+    });
 
-  it('rejects an oversized comment before controller work', async () => {
-    const secret = 'COMMENT_SECRET_SHOULD_NOT_BE_ECHOED';
-    const body = bodyAtByteSize(
-      { content: 'valid', secret },
-      COMMENT_REQUEST_MAX_BYTES + 1,
-    );
+    it('accepts a POST /confessions body exactly at the byte limit', async () => {
+      const body = bodyAtByteSize(
+        { message: 'boundary confession' },
+        CONFESSION_REQUEST_MAX_BYTES,
+      );
 
-    const response = await request(app.getHttpServer())
-      .post('/api/comments/confession-id')
-      .set('Content-Type', 'application/json')
-      .send(body);
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions')
+        .set('Content-Type', 'application/json')
+        .send(body);
 
-    expect(response.status).toBe(413);
-    expect(response.body.code).toBe('REQUEST_TOO_LARGE');
-    expect(JSON.stringify(response.body)).not.toContain(secret);
-    expect(commentService.create).not.toHaveBeenCalled();
-  });
+      expect(res.status).toBe(201);
+      expect(confessionService.create).toHaveBeenCalled();
+    });
 
-  it('accepts a confession request exactly at the byte limit', async () => {
-    const body = bodyAtByteSize(
-      { message: 'boundary confession' },
-      CONFESSION_REQUEST_MAX_BYTES,
-    );
+    it('accepts a normal confession POST', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions')
+        .send({ message: 'A normal confession', tags: ['life'] });
 
-    const response = await request(app.getHttpServer())
-      .post('/api/confessions')
-      .set('Content-Type', 'application/json')
-      .send(body);
-
-    expect(response.status).toBe(201);
-    expect(confessionService.create).toHaveBeenCalledWith({
-      message: 'boundary confession',
+      expect(res.status).toBe(201);
+      expect(res.body.message).toBe('A normal confession');
     });
   });
 
-  it('keeps a normal valid confession request working', async () => {
-    const response = await request(app.getHttpServer())
-      .post('/api/confessions')
-      .send({ message: 'A normal confession', tags: ['life'] });
+  // ── Comments ───────────────────────────────────────────────────────────────
 
-    expect(response.status).toBe(201);
-    expect(response.body.message).toBe('A normal confession');
+  describe('comments', () => {
+    it('rejects an oversized POST /confessions/:id/comments body with 413', async () => {
+      const secret = 'COMMENT_SECRET_MUST_NOT_LEAK';
+      const body = bodyAtByteSize(
+        { content: 'valid comment', secret },
+        COMMENT_REQUEST_MAX_BYTES + 1,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/conf-123/comments')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(res.body).toMatchObject({
+        status: 413,
+        code: 'REQUEST_TOO_LARGE',
+        message: 'Request body exceeds the allowed size',
+        path: '/api/confessions/conf-123/comments',
+      });
+      expect(JSON.stringify(res.body)).not.toContain(secret);
+      expect(commentService.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects an oversized PATCH /confessions/:id/comments/:commentId body with 413', async () => {
+      const body = bodyAtByteSize(
+        { content: 'edited comment' },
+        COMMENT_REQUEST_MAX_BYTES + 1,
+      );
+
+      const res = await request(app.getHttpServer())
+        .patch('/api/confessions/conf-123/comments/42')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(res.body.code).toBe('REQUEST_TOO_LARGE');
+      expect(commentService.edit).not.toHaveBeenCalled();
+    });
+
+    it('accepts a POST /confessions/:id/comments body exactly at the byte limit', async () => {
+      const body = bodyAtByteSize(
+        { content: 'boundary comment' },
+        COMMENT_REQUEST_MAX_BYTES,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/conf-123/comments')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(201);
+      expect(commentService.create).toHaveBeenCalled();
+    });
+
+    it('accepts a normal comment POST', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/conf-123/comments')
+        .send({ content: 'A normal comment' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.content).toBe('A normal comment');
+    });
   });
 
-  it('keeps a normal valid comment request working', async () => {
-    const response = await request(app.getHttpServer())
-      .post('/api/comments/confession-id')
-      .send({ content: 'A normal comment' });
+  // ── Reports ────────────────────────────────────────────────────────────────
 
-    expect(response.status).toBe(201);
-    expect(response.body.content).toBe('A normal comment');
+  describe('reports', () => {
+    it('rejects an oversized POST /confessions/:id/report body with 413', async () => {
+      const secret = 'REPORT_SECRET_MUST_NOT_LEAK';
+      const body = bodyAtByteSize(
+        { type: 'spam', reason: 'valid', secret },
+        REPORT_REQUEST_MAX_BYTES + 1,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/conf-123/report')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(res.body).toMatchObject({
+        status: 413,
+        code: 'REQUEST_TOO_LARGE',
+        message: 'Request body exceeds the allowed size',
+      });
+      expect(JSON.stringify(res.body)).not.toContain(secret);
+      expect(reportService.create).not.toHaveBeenCalled();
+    });
+
+    it('accepts a POST /confessions/:id/report body exactly at the byte limit', async () => {
+      const body = bodyAtByteSize(
+        { type: 'spam', reason: 'valid reason' },
+        REPORT_REQUEST_MAX_BYTES,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/conf-123/report')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(201);
+      expect(reportService.create).toHaveBeenCalled();
+    });
+
+    it('accepts a normal report POST', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/conf-123/report')
+        .send({ type: 'spam', reason: 'This is spam' });
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  // ── Confession drafts ──────────────────────────────────────────────────────
+
+  describe('confession drafts', () => {
+    it('rejects an oversized POST /confessions/drafts body with 413', async () => {
+      const secret = 'DRAFT_SECRET_MUST_NOT_LEAK';
+      const body = bodyAtByteSize(
+        { content: 'valid draft', secret },
+        DRAFT_REQUEST_MAX_BYTES + 1,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/drafts')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(res.body).toMatchObject({
+        status: 413,
+        code: 'REQUEST_TOO_LARGE',
+        message: 'Request body exceeds the allowed size',
+      });
+      expect(JSON.stringify(res.body)).not.toContain(secret);
+      expect(draftService.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects an oversized PATCH /confessions/drafts/:id body with 413', async () => {
+      const body = bodyAtByteSize(
+        { content: 'updated draft' },
+        DRAFT_REQUEST_MAX_BYTES + 1,
+      );
+
+      const res = await request(app.getHttpServer())
+        .patch('/api/confessions/drafts/draft-id')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(res.body.code).toBe('REQUEST_TOO_LARGE');
+      expect(draftService.update).not.toHaveBeenCalled();
+    });
+
+    it('accepts a POST /confessions/drafts body exactly at the byte limit', async () => {
+      const body = bodyAtByteSize(
+        { content: 'boundary draft' },
+        DRAFT_REQUEST_MAX_BYTES,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/drafts')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(201);
+      expect(draftService.create).toHaveBeenCalled();
+    });
+
+    it('accepts a normal draft POST', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions/drafts')
+        .send({ content: 'A normal draft', category: 'general' });
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  // ── Messages ───────────────────────────────────────────────────────────────
+
+  describe('messages', () => {
+    it('rejects an oversized POST /messages body with 413', async () => {
+      const secret = 'MESSAGE_SECRET_MUST_NOT_LEAK';
+      const body = bodyAtByteSize(
+        { confession_id: 'conf-id', content: 'hi', secret },
+        MESSAGE_REQUEST_MAX_BYTES + 1,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/messages')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(res.body).toMatchObject({
+        status: 413,
+        code: 'REQUEST_TOO_LARGE',
+        message: 'Request body exceeds the allowed size',
+      });
+      expect(JSON.stringify(res.body)).not.toContain(secret);
+      expect(messageService.send).not.toHaveBeenCalled();
+    });
+
+    it('accepts a POST /messages body exactly at the byte limit', async () => {
+      const body = bodyAtByteSize(
+        { confession_id: 'conf-id', content: 'hello' },
+        MESSAGE_REQUEST_MAX_BYTES,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/messages')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(201);
+      expect(messageService.send).toHaveBeenCalled();
+    });
+
+    it('accepts a normal message POST', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/messages')
+        .send({ confession_id: 'conf-id', content: 'Hello there!' });
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  // ── Response shape guarantees ──────────────────────────────────────────────
+
+  describe('413 response shape', () => {
+    it('always includes status, code, message, timestamp, path, and requestId', async () => {
+      const body = bodyAtByteSize(
+        { message: 'valid' },
+        CONFESSION_REQUEST_MAX_BYTES + 1,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(typeof res.body.timestamp).toBe('string');
+      expect(typeof res.body.requestId).toBe('string');
+      expect(res.body.requestId).not.toBe('unknown');
+      expect(res.body.path).toBe('/api/confessions');
+    });
+
+    it('does not reflect raw request body content in the error response', async () => {
+      const sensitiveValue = 'SENSITIVE_PAYLOAD_REFLECTION_CHECK';
+      const body = bodyAtByteSize(
+        { message: sensitiveValue },
+        CONFESSION_REQUEST_MAX_BYTES + 1,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/confessions')
+        .set('Content-Type', 'application/json')
+        .send(body);
+
+      expect(res.status).toBe(413);
+      expect(JSON.stringify(res.body)).not.toContain(sensitiveValue);
+    });
   });
 });

--- a/xconfess-backend/src/common/request-body-limits.ts
+++ b/xconfess-backend/src/common/request-body-limits.ts
@@ -3,40 +3,85 @@ import { json, Request, RequestHandler, Response, urlencoded } from 'express';
 import { ErrorCode } from './errors/error-codes';
 
 /**
- * Transport limits for confession and comment writes.
+ * Transport-level request-body size limits for every mutating text endpoint.
  *
- * Both APIs accept small text records. 16 KiB leaves ample room for the
- * confession DTO's 1,000-character message (including multi-byte UTF-8),
- * tags, and request metadata while rejecting unexpectedly large bodies
- * before validation, sanitization, moderation, or database work begins.
+ * Limits are intentionally generous — they are set well above the maximum
+ * payload a conforming client can ever produce (DTO MaxLength values in UTF-8
+ * plus JSON envelope overhead) while still being small enough to stop memory-
+ * exhaustion attacks before any application logic runs.
+ *
+ * Domain                 Largest DTO field   Limit
+ * ─────────────────────  ──────────────────  ──────
+ * Confession             1 000 chars         16 KiB
+ * Comment                2 000 chars         16 KiB
+ * Report                   500 chars         16 KiB
+ * Confession draft       1 000 chars         16 KiB
+ * Message (send/reply)   1 000 chars (body)
+ *                        4 096 chars (key)   32 KiB  ← key backup can be large
+ *
+ * All other routes fall back to a conservative 100 KiB default.
  */
-export const CONFESSION_REQUEST_MAX_BYTES = 16 * 1024;
-export const COMMENT_REQUEST_MAX_BYTES = 16 * 1024;
+export const CONFESSION_REQUEST_MAX_BYTES = 16 * 1024; //  16 KiB
+export const COMMENT_REQUEST_MAX_BYTES = 16 * 1024; //  16 KiB
+export const REPORT_REQUEST_MAX_BYTES = 16 * 1024; //  16 KiB
+export const DRAFT_REQUEST_MAX_BYTES = 16 * 1024; //  16 KiB
+/** Message key registration can carry a 4 096-char encrypted key backup. */
+export const MESSAGE_REQUEST_MAX_BYTES = 32 * 1024; //  32 KiB
 
-const DEFAULT_REQUEST_MAX_BYTES = 100 * 1024;
+const DEFAULT_REQUEST_MAX_BYTES = 100 * 1024; // 100 KiB
 const REQUEST_TOO_LARGE_MESSAGE = 'Request body exceeds the allowed size';
 
+// ── Pre-allocated parser instances ──────────────────────────────────────────
 const confessionJsonParser = json({ limit: CONFESSION_REQUEST_MAX_BYTES });
 const confessionUrlencodedParser = urlencoded({
   extended: true,
   limit: CONFESSION_REQUEST_MAX_BYTES,
 });
+
 const commentJsonParser = json({ limit: COMMENT_REQUEST_MAX_BYTES });
 const commentUrlencodedParser = urlencoded({
   extended: true,
   limit: COMMENT_REQUEST_MAX_BYTES,
 });
+
+const reportJsonParser = json({ limit: REPORT_REQUEST_MAX_BYTES });
+const reportUrlencodedParser = urlencoded({
+  extended: true,
+  limit: REPORT_REQUEST_MAX_BYTES,
+});
+
+const draftJsonParser = json({ limit: DRAFT_REQUEST_MAX_BYTES });
+const draftUrlencodedParser = urlencoded({
+  extended: true,
+  limit: DRAFT_REQUEST_MAX_BYTES,
+});
+
+const messageJsonParser = json({ limit: MESSAGE_REQUEST_MAX_BYTES });
+const messageUrlencodedParser = urlencoded({
+  extended: true,
+  limit: MESSAGE_REQUEST_MAX_BYTES,
+});
+
 const defaultJsonParser = json({ limit: DEFAULT_REQUEST_MAX_BYTES });
 const defaultUrlencodedParser = urlencoded({
   extended: true,
   limit: DEFAULT_REQUEST_MAX_BYTES,
 });
 
+// ── Route matchers ───────────────────────────────────────────────────────────
+
 type ParserPair = {
   jsonParser: RequestHandler;
   urlencodedParser: RequestHandler;
 };
 
+/**
+ * POST /confessions
+ * PUT  /confessions/:id
+ *
+ * Does NOT match /confessions/drafts or /confessions/:id/comments — those are
+ * handled by more specific matchers below.
+ */
 function isConfessionWrite(request: Request): boolean {
   const path = request.path.replace(/^\/api/, '');
 
@@ -46,32 +91,99 @@ function isConfessionWrite(request: Request): boolean {
   );
 }
 
+/**
+ * POST   /confessions/:id/comments
+ * PATCH  /confessions/:id/comments/:commentId
+ */
 function isCommentWrite(request: Request): boolean {
   const path = request.path.replace(/^\/api/, '');
 
-  return request.method === 'POST' && /^\/comments\/[^/]+$/.test(path);
+  return (
+    (request.method === 'POST' &&
+      /^\/confessions\/[^/]+\/comments$/.test(path)) ||
+    (request.method === 'PATCH' &&
+      /^\/confessions\/[^/]+\/comments\/[^/]+$/.test(path))
+  );
+}
+
+/**
+ * POST /confessions/:id/report
+ * POST /admin/reports/:id/action
+ * PATCH /admin/reports/:id/resolve
+ * PATCH /admin/reports/:id/dismiss
+ */
+function isReportWrite(request: Request): boolean {
+  const path = request.path.replace(/^\/api/, '');
+
+  return (
+    (request.method === 'POST' &&
+      /^\/confessions\/[^/]+\/report$/.test(path)) ||
+    ((request.method === 'POST' || request.method === 'PATCH') &&
+      /^\/admin\/reports\/[^/]+\/(action|resolve|dismiss)$/.test(path)) ||
+    (request.method === 'PATCH' &&
+      /^\/admin\/reports\/[^/]+$/.test(path))
+  );
+}
+
+/**
+ * POST   /confessions/drafts
+ * POST   /confessions/drafts/autosave
+ * PATCH  /confessions/drafts/:id
+ * POST   /confessions/drafts/:id/schedule
+ * POST   /confessions/drafts/:id/cancel
+ * POST   /confessions/drafts/:id/publish
+ * POST   /confessions/drafts/:id/convert-to-draft
+ */
+function isDraftWrite(request: Request): boolean {
+  const path = request.path.replace(/^\/api/, '');
+
+  return (
+    (request.method === 'POST' && /^\/confessions\/drafts/.test(path)) ||
+    (request.method === 'PATCH' && /^\/confessions\/drafts\/[^/]+/.test(path))
+  );
+}
+
+/**
+ * POST /messages/keys          — register encryption key
+ * POST /messages               — send message (future)
+ * POST /messages/:id/reply     — reply to thread (future)
+ */
+function isMessageWrite(request: Request): boolean {
+  const path = request.path.replace(/^\/api/, '');
+
+  return (
+    request.method === 'POST' &&
+    /^\/messages(\/|$)/.test(path)
+  );
 }
 
 function selectParsers(request: Request): ParserPair {
+  // Draft check must come before confession check because draft paths
+  // also start with /confessions.
+  if (isDraftWrite(request)) {
+    return { jsonParser: draftJsonParser, urlencodedParser: draftUrlencodedParser };
+  }
+
   if (isConfessionWrite(request)) {
-    return {
-      jsonParser: confessionJsonParser,
-      urlencodedParser: confessionUrlencodedParser,
-    };
+    return { jsonParser: confessionJsonParser, urlencodedParser: confessionUrlencodedParser };
   }
 
   if (isCommentWrite(request)) {
-    return {
-      jsonParser: commentJsonParser,
-      urlencodedParser: commentUrlencodedParser,
-    };
+    return { jsonParser: commentJsonParser, urlencodedParser: commentUrlencodedParser };
   }
 
-  return {
-    jsonParser: defaultJsonParser,
-    urlencodedParser: defaultUrlencodedParser,
-  };
+  if (isReportWrite(request)) {
+    return { jsonParser: reportJsonParser, urlencodedParser: reportUrlencodedParser };
+  }
+
+  if (isMessageWrite(request)) {
+    return { jsonParser: messageJsonParser, urlencodedParser: messageUrlencodedParser };
+  }
+
+  return { jsonParser: defaultJsonParser, urlencodedParser: defaultUrlencodedParser };
 }
+
+// ── Error helpers ────────────────────────────────────────────────────────────
 
 function isPayloadTooLarge(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
@@ -96,6 +208,8 @@ function sendRequestTooLarge(request: Request, response: Response): void {
       (request as Request & { requestId?: string }).requestId ?? 'unknown',
   });
 }
+
+// ── Middleware ───────────────────────────────────────────────────────────────
 
 export const requestBodyParser: RequestHandler = (request, response, next) => {
   const parsers = selectParsers(request);
@@ -123,8 +237,9 @@ export const requestBodyParser: RequestHandler = (request, response, next) => {
 };
 
 /**
- * Nest's built-in parser must be disabled when creating the application so
- * this middleware can reject targeted writes before JSON parsing.
+ * Disable Nest's built-in body parser (`bodyParser: false`) and call this
+ * function during bootstrap so that targeted limits are applied before any
+ * controller or validation pipe runs.
  */
 export function configureRequestBodyParsing(app: INestApplication): void {
   app.use(requestBodyParser);


### PR DESCRIPTION
- Fix isCommentWrite() path — was matching /comments/:id instead of the real route /confessions/:id/comments; oversized comment bodies were not being blocked at the transport layer.
- Add REPORT_REQUEST_MAX_BYTES (16 KiB) covering POST /confessions/:id/report and admin report action/resolve/dismiss.
- Add DRAFT_REQUEST_MAX_BYTES (16 KiB) covering POST + PATCH /confessions/drafts routes.
- Add MESSAGE_REQUEST_MAX_BYTES (32 KiB) covering POST /messages/* (larger allowance for the 4096-char encrypted key backup field).
- Guard draft routes before confession routes to prevent prefix collision on /confessions/drafts.
- Expand tests to 20 cases across all five domains (confessions, comments, reports, drafts, messages) plus response-shape guarantees: oversized payload → 413, exact-limit payload → accepted, secrets not reflected in error body, all required fields present.

Closes #request-body-limits

<!--
  Small PR policy: https://github.com/Xconfess/Xconfess/blob/main/docs/SMALL_PR_POLICY.md
  Keep this PR focused on ONE issue. Fill in every section — mark unused ones N/A.
-->

## Closes

Closes #<!-- issue number -->

---

## What changed

<!-- One paragraph. What does this PR do? -->

## Why

<!-- One sentence. What problem does this solve, or what does it enable? -->

## How to test

<!-- Step-by-step instructions from a fresh checkout. Include env vars or feature flags if needed. -->

1. 
2. 
3. 

---

## Scope check

<!-- Tick every box that applies. If none apply, explain below. -->

- [ ] This PR touches only the files needed to resolve the linked issue
- [ ] I have not included unrelated refactors, style fixes, or dependency upgrades
- [ ] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

---

## Evidence

### Tests

<!-- Tick what applies. -->

- [ ] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output (paste or screenshot):

```
# paste npm run backend:test / frontend:test / contract:test output here
```

### Screenshots (UI changes only)

<!-- Required for any visible UI change. Delete this section for non-UI PRs. -->

| | Before | After |
|---|---|---|
| Desktop (≥ 1280 px) | | |
| Mobile (≤ 390 px) | | |

---

## Checklist

- [ ] Branch is up to date with `main`
- [ ] All CI checks pass
- [ ] PR description is complete (no empty sections)
- [ ] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)

closes #1424