### PR TITLE
fix(backend): protect Swagger docs behind explicit enable flag

### DIFF
--- a/xconfess-backend/.env.example
+++ b/xconfess-backend/.env.example
@@ -2,6 +2,11 @@
 NODE_ENV=development
 APP_ENV=local
 PORT=5000
+
+# API Docs
+# Swagger UI at /api/docs is opt-in only — set to true for local development.
+# Never enable this in production or staging.
+ENABLE_SWAGGER=false
 FRONTEND_URL=http://localhost:3000
 BACKEND_URL=http://localhost:5000
 

--- a/xconfess-backend/README.md
+++ b/xconfess-backend/README.md
@@ -178,7 +178,12 @@ npm run migration:revert
 
 ## API Documentation
 
-When running locally, Swagger docs are available at `/api/api-docs`.
+Swagger UI is opt-in and disabled by default. To enable it locally, set
+`ENABLE_SWAGGER=true` in your `.env` file, then start the server — the docs
+will be available at `/api/docs`.
+
+Swagger should never be enabled in production or staging, regardless of
+`NODE_ENV`, since it exposes the full API surface.
 
 For route inventory, DTO examples, and the **`GET /api/health`** contract (including schema readiness for `anonymous_confessions`), see [API_DOCUMENTATION.md](./API_DOCUMENTATION.md).
 

--- a/xconfess-backend/src/config/env.validation.spec.ts
+++ b/xconfess-backend/src/config/env.validation.spec.ts
@@ -91,4 +91,35 @@ describe('Environment Validation', () => {
     const { error } = envValidationSchema.validate(config);
     expect(error).toBeUndefined();
   });
+
+  it('should default ENABLE_SWAGGER to false when not set', () => {
+    const config = {
+      ...baseConfig,
+      CONFESSION_ENCRYPTION_KEY: validKey,
+    };
+    const { error, value } = envValidationSchema.validate(config);
+    expect(error).toBeUndefined();
+    expect(value.ENABLE_SWAGGER).toBe('false');
+  });
+
+  it('should allow ENABLE_SWAGGER to be explicitly enabled', () => {
+    const config = {
+      ...baseConfig,
+      CONFESSION_ENCRYPTION_KEY: validKey,
+      ENABLE_SWAGGER: 'true',
+    };
+    const { error, value } = envValidationSchema.validate(config);
+    expect(error).toBeUndefined();
+    expect(value.ENABLE_SWAGGER).toBe('true');
+  });
+
+  it('should reject a non-boolean-like value for ENABLE_SWAGGER', () => {
+    const config = {
+      ...baseConfig,
+      CONFESSION_ENCRYPTION_KEY: validKey,
+      ENABLE_SWAGGER: 'yes',
+    };
+    const { error } = envValidationSchema.validate(config);
+    expect(error).toBeDefined();
+  });
 });

--- a/xconfess-backend/src/config/env.validation.ts
+++ b/xconfess-backend/src/config/env.validation.ts
@@ -15,6 +15,12 @@ export const envValidationSchema = Joi.object({
   APP_ENV: Joi.string().optional(),
   PORT: Joi.number().port().default(3000),
 
+  // ── API Docs ──────────────────────────────────────────────────────────
+  // Swagger must be explicitly opted into. It is never derived from
+  // NODE_ENV, so a mislabeled or unexpected environment name can't
+  // accidentally expose the full API surface.
+  ENABLE_SWAGGER: Joi.string().valid('true', 'false').default('false'),
+
   // ── Database ──────────────────────────────────────────────────────────
   DB_HOST: Joi.string().required().messages({
     'any.required': 'DB_HOST is required – set the PostgreSQL hostname.',

--- a/xconfess-backend/src/main.ts
+++ b/xconfess-backend/src/main.ts
@@ -111,7 +111,7 @@ async function bootstrap() {
     new ThrottlerExceptionFilter(),
   );
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (configService.get<string>('ENABLE_SWAGGER', 'false') === 'true') {
     const config = new DocumentBuilder()
       .setTitle('xConfess API')
       .setDescription(


### PR DESCRIPTION
## Problem
Swagger UI was gated on `NODE_ENV !== 'production'`, meaning any environment
not explicitly named `production` — a typo, a new staging label, a
misconfigured deploy — would silently expose the full API surface at
`/api/docs`.

## Fix
Replaced this with an explicit `ENABLE_SWAGGER` flag, validated at boot via
Joi alongside the other boolean-style flags already in this codebase (e.g.
`STELLAR_FEATURES_ENABLED`). Swagger now stays off unless
`ENABLE_SWAGGER=true` is set, regardless of `NODE_ENV`.

## Bonus fix
Found and fixed a pre-existing doc bug while in here: the README pointed to
`/api/api-docs`, but the actual mount path (confirmed in `main.ts`, combined
with the global `api` prefix) is `/api/docs`.

## Testing
Added tests in `env.validation.spec.ts`:
- Defaults to `false` when unset
- Accepts an explicit `true`
- Rejects non-boolean-like values (e.g. `"yes"`)

## Verification notes
Two pre-existing, unrelated issues on `main` limited how I could verify this:
1. Jest fails repo-wide with `SyntaxError: Unexpected token 'export'`
   (ESM dependency issue) — confirmed on unmodified `main`, not caused by
   this change. Verified the schema logic directly instead, by compiling
   `env.validation.ts` in isolation and exercising it with Node: confirms
   correct default (`false`), acceptance of `true`, and rejection of
   invalid values.
2. `npm run start:dev` fails to boot at all on unmodified `main`, unrelated
   to Swagger — `user.controller.ts` calls three methods
   (`getPublicProfile`, `updateSettings`, `deleteAccount`) that don't exist
   on `UserService`. This blocks the manual `/api/docs` on/off check the
   issue's "How To Test" section describes. Flagging this in case it's
   useful — happy to open it as a separate issue if that's helpful.

`tsc --noEmit` passes clean on every file this PR touches (`main.ts` itself
compiles with zero errors); remaining errors in the project are pre-existing
and unrelated (`confession.entity.ts` encoding issue, `user.controller.ts`
type mismatch), both confirmed present on unmodified `main`.

Closes #1418