### PR TITLE
validate moderation webhook signatures with replay protection

### DIFF
--- a/xconfess-backend/src/audit-log/audit-log.entity.ts
+++ b/xconfess-backend/src/audit-log/audit-log.entity.ts
@@ -20,6 +20,9 @@ export enum AuditActionType {
   COMMENT_APPROVED = 'comment_approved',
   COMMENT_REJECTED = 'comment_rejected',
 
+  // Webhook security
+  WEBHOOK_REJECTED = 'webhook_rejected',
+
   // Report actions
   REPORT_CREATED = 'report_created',
   REPORT_RESOLVED = 'report_resolved',
@@ -61,8 +64,8 @@ export enum AuditActionType {
   EXPORT_GENERATION_COMPLETED = 'export_generation_completed',
   EXPORT_LINK_REFRESHED = 'export_link_refreshed',
   EXPORT_DOWNLOADED = 'export_downloaded',
-  EXPORT_TOKEN_EXPIRED = 'export_token_expired',   // <-- ADDED
-  EXPORT_EXPIRED = 'export_expired',               // <-- ADDED
+  EXPORT_TOKEN_EXPIRED = 'export_token_expired', // <-- ADDED
+  EXPORT_EXPIRED = 'export_expired', // <-- ADDED
 
   // Admin CSV export actions initiated from the frontend
   ADMIN_CSV_EXPORT = 'admin_csv_export',

--- a/xconfess-backend/src/moderation/moderation-webhook-idempotency.spec.ts
+++ b/xconfess-backend/src/moderation/moderation-webhook-idempotency.spec.ts
@@ -1,5 +1,10 @@
 /**
- * Issue #782: Test moderation webhook idempotency and signature safety
+ * Issue #41: Test moderation webhook idempotency, signature safety, and audit logging
+ *
+ * Acceptance Criteria:
+ * - Unsigned, stale, malformed, and replayed webhooks fail.
+ * - Valid webhook is processed once.
+ * - Failure logs are redacted and correlated.
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { ModerationWebhookController } from './moderation-webhook.controller';
@@ -10,6 +15,8 @@ import { Repository } from 'typeorm';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { ModerationRepositoryService } from './moderation-repository.service';
 import { ModerationStatus } from './ai-moderation.service';
+import { AuditLogService } from '../audit-log/audit-log.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
 import { UnauthorizedException, BadRequestException } from '@nestjs/common';
 import * as crypto from 'crypto';
 
@@ -17,20 +24,58 @@ describe('ModerationWebhookController - Idempotency and Signature Safety', () =>
   let controller: ModerationWebhookController;
   let confessionRepo: Repository<AnonymousConfession>;
   let moderationRepoService: ModerationRepositoryService;
-  let configService: ConfigService;
+  let auditLogService: { log: jest.Mock };
 
   const mockWebhookSecret = 'test-webhook-secret';
 
-  const mockPayload = {
+  const buildPayload = (overrides: Record<string, any> = {}) => ({
+    eventId: crypto.randomUUID(),
     confessionId: 'confession-123',
     moderationScore: 0.85,
     moderationFlags: ['spam'],
     moderationStatus: ModerationStatus.FLAGGED,
     details: { spam: 0.85 },
     timestamp: new Date().toISOString(),
+    ...overrides,
+  });
+
+  /**
+   * Builds a timestamped signature header in the format:
+   * "t=<unix_seconds>,v1=<hmac_hex>"
+   * where HMAC is computed over "<timestamp>.<serialized_payload>"
+   */
+  const buildSignatureHeader = (
+    payload: unknown,
+    secret = mockWebhookSecret,
+  ) => {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const serialized = JSON.stringify(payload);
+    const signedMessage = `${timestamp}.${serialized}`;
+    const hmac = crypto
+      .createHmac('sha256', secret)
+      .update(signedMessage)
+      .digest('hex');
+    return `t=${timestamp},v1=${hmac}`;
+  };
+
+  /** Builds a stale signature header (timestamp too old) */
+  const buildStaleSignatureHeader = (
+    payload: unknown,
+    secret = mockWebhookSecret,
+  ) => {
+    const timestamp = Math.floor((Date.now() - 600_000) / 1000).toString(); // 10 minutes ago
+    const serialized = JSON.stringify(payload);
+    const signedMessage = `${timestamp}.${serialized}`;
+    const hmac = crypto
+      .createHmac('sha256', secret)
+      .update(signedMessage)
+      .digest('hex');
+    return `t=${timestamp},v1=${hmac}`;
   };
 
   beforeEach(async () => {
+    auditLogService = { log: jest.fn().mockResolvedValue(undefined) };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ModerationWebhookController],
       providers: [
@@ -39,234 +84,434 @@ describe('ModerationWebhookController - Idempotency and Signature Safety', () =>
           useValue: {
             get: jest.fn((key: string, defaultValue?: any) => {
               if (key === 'WEBHOOK_SECRET') return mockWebhookSecret;
+              if (key === 'WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS') return 300;
               return defaultValue;
             }),
           },
         },
         {
           provide: EventEmitter2,
-          useValue: {
-            emit: jest.fn(),
-          },
+          useValue: { emit: jest.fn() },
         },
         {
           provide: getRepositoryToken(AnonymousConfession),
           useValue: {
             findOne: jest.fn(),
             save: jest.fn(),
-            manager: {
-              transaction: jest.fn(),
-            },
+            manager: { transaction: jest.fn() },
           },
         },
         {
           provide: ModerationRepositoryService,
-          useValue: {
-            syncWebhookResult: jest.fn(),
-          },
+          useValue: { syncWebhookResult: jest.fn() },
+        },
+        {
+          provide: AuditLogService,
+          useValue: auditLogService,
         },
       ],
     }).compile();
 
-    controller = module.get<ModerationWebhookController>(ModerationWebhookController);
+    controller = module.get<ModerationWebhookController>(
+      ModerationWebhookController,
+    );
     confessionRepo = module.get<Repository<AnonymousConfession>>(
       getRepositoryToken(AnonymousConfession),
     );
     moderationRepoService = module.get<ModerationRepositoryService>(
       ModerationRepositoryService,
     );
-    configService = module.get<ConfigService>(ConfigService);
   });
 
   describe('Signature Validation', () => {
-    it('should reject requests with missing signature', async () => {
+    it('should reject requests with missing signature (unsigned)', async () => {
+      const payload = buildPayload();
       await expect(
-        controller.handleModerationResults(mockPayload, ''),
+        controller.handleModerationResults(payload, ''),
       ).rejects.toThrow(UnauthorizedException);
+
+      // Audit log should be written
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.WEBHOOK_REJECTED,
+          metadata: expect.objectContaining({ reason: 'missing_signature' }),
+        }),
+      );
     });
 
-    it('should reject requests with invalid signature', async () => {
-      const invalidSignature = 'invalid-signature-hash';
-
+    it('should reject requests with malformed signature header', async () => {
+      const payload = buildPayload();
       await expect(
-        controller.handleModerationResults(mockPayload, invalidSignature),
-      ).rejects.toThrow(UnauthorizedException);
-    });
+        controller.handleModerationResults(payload, 'garbage-header-no-format'),
+      ).rejects.toThrow(BadRequestException);
 
-    it('should accept requests with valid signature', async () => {
-      const serializedPayload = JSON.stringify(mockPayload);
-      const validSignature = crypto
-        .createHmac('sha256', mockWebhookSecret)
-        .update(serializedPayload)
-        .digest('hex');
-
-      const mockConfession = {
-        id: mockPayload.confessionId,
-        message: 'Test confession',
-      };
-
-      jest.spyOn(confessionRepo.manager, 'transaction').mockImplementation(async (cb: any) => {
-        const manager = {
-          getRepository: () => ({
-            findOne: jest.fn().mockResolvedValue(mockConfession),
-            save: jest.fn().mockResolvedValue(mockConfession),
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.WEBHOOK_REJECTED,
+          metadata: expect.objectContaining({
+            reason: 'malformed_signature_header',
           }),
-        };
-        return cb(manager);
-      });
+        }),
+      );
+    });
+
+    it('should reject requests with invalid HMAC signature', async () => {
+      const payload = buildPayload();
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const invalidHeader = `t=${timestamp},v1=${'a'.repeat(64)}`;
+
+      await expect(
+        controller.handleModerationResults(payload, invalidHeader),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.WEBHOOK_REJECTED,
+          metadata: expect.objectContaining({ reason: 'invalid_signature' }),
+        }),
+      );
+    });
+
+    it('should reject signature computed without timestamp binding (forged)', async () => {
+      const payload = buildPayload();
+      // Attacker computes HMAC over payload only (old scheme) — should fail
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const forgedHmac = crypto
+        .createHmac('sha256', mockWebhookSecret)
+        .update(JSON.stringify(payload))
+        .digest('hex');
+      const forgedHeader = `t=${timestamp},v1=${forgedHmac}`;
+
+      await expect(
+        controller.handleModerationResults(payload, forgedHeader),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should reject stale but correctly signed requests and audit them', async () => {
+      const payload = buildPayload();
+      const staleHeader = buildStaleSignatureHeader(payload);
 
       jest.spyOn(moderationRepoService, 'syncWebhookResult').mockResolvedValue({
         log: {} as any,
         isIdempotent: false,
       });
 
-      const result = await controller.handleModerationResults(mockPayload, validSignature);
+      await expect(
+        controller.handleModerationResults(payload, staleHeader),
+      ).rejects.toThrow(UnauthorizedException);
+
+      // Audit stale webhook
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.WEBHOOK_REJECTED,
+          metadata: expect.objectContaining({ reason: 'stale_timestamp' }),
+        }),
+      );
+      // Moderation repo should also record stale delivery
+      expect(moderationRepoService.syncWebhookResult).toHaveBeenCalledWith(
+        expect.objectContaining({ deliveryStale: true }),
+      );
+    });
+
+    it('should accept requests with valid timestamped signature', async () => {
+      const payload = buildPayload();
+      const validHeader = buildSignatureHeader(payload);
+
+      const mockConfession = {
+        id: payload.confessionId,
+        message: 'Test confession',
+      };
+
+      jest
+        .spyOn(confessionRepo.manager, 'transaction')
+        .mockImplementation(async (cb: any) => {
+          const manager = {
+            getRepository: () => ({
+              findOne: jest.fn().mockResolvedValue(mockConfession),
+              save: jest.fn().mockResolvedValue(mockConfession),
+            }),
+          };
+          return cb(manager);
+        });
+
+      jest.spyOn(moderationRepoService, 'syncWebhookResult').mockResolvedValue({
+        log: {} as any,
+        isIdempotent: false,
+      });
+
+      const result = await controller.handleModerationResults(
+        payload,
+        validHeader,
+      );
 
       expect(result.success).toBe(true);
       expect(result.isIdempotent).toBe(false);
-    });
-
-    it('should reject stale but signed requests and audit them', async () => {
-      // Set payload timestamp to long ago
-      const stalePayload = { ...mockPayload, timestamp: new Date(Date.now() - 1000 * 60 * 60).toISOString() };
-      const serializedPayload = JSON.stringify(stalePayload);
-      const validSignature = crypto
-        .createHmac('sha256', mockWebhookSecret)
-        .update(serializedPayload)
-        .digest('hex');
-
-      // Spy on moderationRepoService.syncWebhookResult to ensure audit attempt
-      const syncSpy = jest.spyOn(moderationRepoService, 'syncWebhookResult').mockResolvedValue({ log: {} as any, isIdempotent: false });
-
-      await expect(
-        controller.handleModerationResults(stalePayload, validSignature),
-      ).rejects.toThrow(UnauthorizedException);
-
-      expect(syncSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ deliveryStale: true }),
-      );
+      // No rejection audit log for valid requests
+      expect(auditLogService.log).not.toHaveBeenCalled();
     });
   });
 
   describe('Payload Validation', () => {
     it('should reject malformed payloads missing required fields', async () => {
       const malformedPayload = {
-        // Missing confessionId and moderationStatus
+        eventId: crypto.randomUUID(),
         moderationScore: 0.5,
+        timestamp: new Date().toISOString(),
       } as any;
 
-      const serializedPayload = JSON.stringify(malformedPayload);
-      const validSignature = crypto
-        .createHmac('sha256', mockWebhookSecret)
-        .update(serializedPayload)
-        .digest('hex');
+      const validHeader = buildSignatureHeader(malformedPayload);
 
       await expect(
-        controller.handleModerationResults(malformedPayload, validSignature),
+        controller.handleModerationResults(malformedPayload, validHeader),
       ).rejects.toThrow(BadRequestException);
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.WEBHOOK_REJECTED,
+          metadata: expect.objectContaining({ reason: 'malformed_payload' }),
+        }),
+      );
+    });
+
+    it('should reject payloads missing eventId', async () => {
+      const payload = {
+        confessionId: 'confession-123',
+        moderationScore: 0.85,
+        moderationFlags: ['spam'],
+        moderationStatus: ModerationStatus.FLAGGED,
+        details: { spam: 0.85 },
+        timestamp: new Date().toISOString(),
+      } as any;
+
+      const validHeader = buildSignatureHeader(payload);
+
+      await expect(
+        controller.handleModerationResults(payload, validHeader),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.WEBHOOK_REJECTED,
+          metadata: expect.objectContaining({ reason: 'missing_event_id' }),
+        }),
+      );
     });
   });
 
-  describe('Idempotency', () => {
-    it('should return idempotent response for duplicate webhook deliveries', async () => {
-      const serializedPayload = JSON.stringify(mockPayload);
-      const validSignature = crypto
-        .createHmac('sha256', mockWebhookSecret)
-        .update(serializedPayload)
-        .digest('hex');
+  describe('Replay Prevention', () => {
+    it('should reject replayed event IDs on second delivery', async () => {
+      const payload = buildPayload();
+      const validHeader = buildSignatureHeader(payload);
 
       const mockConfession = {
-        id: mockPayload.confessionId,
+        id: payload.confessionId,
         message: 'Test confession',
       };
 
-      jest.spyOn(confessionRepo.manager, 'transaction').mockImplementation(async (cb: any) => {
-        const manager = {
-          getRepository: () => ({
-            findOne: jest.fn().mockResolvedValue(mockConfession),
-            save: jest.fn().mockResolvedValue(mockConfession),
-          }),
-        };
-        return cb(manager);
-      });
+      jest
+        .spyOn(confessionRepo.manager, 'transaction')
+        .mockImplementation(async (cb: any) => {
+          const manager = {
+            getRepository: () => ({
+              findOne: jest.fn().mockResolvedValue(mockConfession),
+              save: jest.fn().mockResolvedValue(mockConfession),
+            }),
+          };
+          return cb(manager);
+        });
 
-      // First call - not idempotent
-      jest.spyOn(moderationRepoService, 'syncWebhookResult').mockResolvedValueOnce({
+      jest.spyOn(moderationRepoService, 'syncWebhookResult').mockResolvedValue({
         log: {} as any,
         isIdempotent: false,
       });
 
-      const result1 = await controller.handleModerationResults(mockPayload, validSignature);
+      // First delivery — processed
+      const result1 = await controller.handleModerationResults(
+        payload,
+        validHeader,
+      );
+      expect(result1.success).toBe(true);
       expect(result1.isIdempotent).toBe(false);
 
-      // Second call with same payload - should be idempotent
-      jest.spyOn(moderationRepoService, 'syncWebhookResult').mockResolvedValueOnce({
-        log: {} as any,
-        isIdempotent: true,
-      });
-
-      const result2 = await controller.handleModerationResults(mockPayload, validSignature);
+      // Second delivery with same eventId — replayed
+      const result2 = await controller.handleModerationResults(
+        payload,
+        validHeader,
+      );
       expect(result2.isIdempotent).toBe(true);
+
+      // Audit log for replay rejection
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: AuditActionType.WEBHOOK_REJECTED,
+          metadata: expect.objectContaining({ reason: 'replayed_event_id' }),
+        }),
+      );
     });
 
     it('should not create duplicate moderation logs for replayed webhooks', async () => {
-      const serializedPayload = JSON.stringify(mockPayload);
-      const validSignature = crypto
-        .createHmac('sha256', mockWebhookSecret)
-        .update(serializedPayload)
-        .digest('hex');
+      const payload = buildPayload();
+      const validHeader = buildSignatureHeader(payload);
 
       const mockConfession = {
-        id: mockPayload.confessionId,
+        id: payload.confessionId,
         message: 'Test confession',
       };
 
-      jest.spyOn(confessionRepo.manager, 'transaction').mockImplementation(async (cb: any) => {
-        const manager = {
-          getRepository: () => ({
-            findOne: jest.fn().mockResolvedValue(mockConfession),
-            save: jest.fn().mockResolvedValue(mockConfession),
-          }),
-        };
-        return cb(manager);
-      });
+      jest
+        .spyOn(confessionRepo.manager, 'transaction')
+        .mockImplementation(async (cb: any) => {
+          const manager = {
+            getRepository: () => ({
+              findOne: jest.fn().mockResolvedValue(mockConfession),
+              save: jest.fn().mockResolvedValue(mockConfession),
+            }),
+          };
+          return cb(manager);
+        });
 
-      const syncSpy = jest.spyOn(moderationRepoService, 'syncWebhookResult').mockResolvedValue({
+      jest.spyOn(moderationRepoService, 'syncWebhookResult').mockResolvedValue({
         log: {} as any,
-        isIdempotent: true,
+        isIdempotent: false,
       });
 
-      await controller.handleModerationResults(mockPayload, validSignature);
+      // First call processes
+      await controller.handleModerationResults(payload, validHeader);
 
-      // Verify syncWebhookResult was called with signature validation metadata
-      expect(syncSpy).toHaveBeenCalledWith(
+      // Second call with same eventId is blocked before reaching syncWebhookResult again
+      const syncCallCount = (
+        moderationRepoService.syncWebhookResult as jest.Mock
+      ).mock.calls.length;
+      await controller.handleModerationResults(payload, validHeader);
+      expect(
+        (moderationRepoService.syncWebhookResult as jest.Mock).mock.calls
+          .length,
+      ).toBe(syncCallCount);
+    });
+  });
+
+  describe('Idempotency (delivery hash)', () => {
+    it('should return idempotent response for duplicate webhook deliveries', async () => {
+      const payload = buildPayload();
+      const validHeader = buildSignatureHeader(payload);
+
+      const mockConfession = {
+        id: payload.confessionId,
+        message: 'Test confession',
+      };
+
+      jest
+        .spyOn(confessionRepo.manager, 'transaction')
+        .mockImplementation(async (cb: any) => {
+          const manager = {
+            getRepository: () => ({
+              findOne: jest.fn().mockResolvedValue(mockConfession),
+              save: jest.fn().mockResolvedValue(mockConfession),
+            }),
+          };
+          return cb(manager);
+        });
+
+      // First call - not idempotent
+      jest
+        .spyOn(moderationRepoService, 'syncWebhookResult')
+        .mockResolvedValueOnce({
+          log: {} as any,
+          isIdempotent: false,
+        });
+
+      const result1 = await controller.handleModerationResults(
+        payload,
+        validHeader,
+      );
+      expect(result1.isIdempotent).toBe(false);
+
+      // Second call with same payload but different eventId - idempotent via delivery hash
+      const payload2 = { ...payload, eventId: crypto.randomUUID() };
+      const validHeader2 = buildSignatureHeader(payload2);
+
+      jest
+        .spyOn(confessionRepo.manager, 'transaction')
+        .mockImplementation(async (cb: any) => {
+          const manager = {
+            getRepository: () => ({
+              findOne: jest.fn().mockResolvedValue(mockConfession),
+              save: jest.fn().mockResolvedValue(mockConfession),
+            }),
+          };
+          return cb(manager);
+        });
+
+      jest
+        .spyOn(moderationRepoService, 'syncWebhookResult')
+        .mockResolvedValueOnce({
+          log: {} as any,
+          isIdempotent: true,
+        });
+
+      const result2 = await controller.handleModerationResults(
+        payload2,
+        validHeader2,
+      );
+      expect(result2.isIdempotent).toBe(true);
+    });
+  });
+
+  describe('Audit Log Correlation', () => {
+    it('should include correlation ID (requestId) in rejection audit logs', async () => {
+      const payload = buildPayload();
+
+      await expect(
+        controller.handleModerationResults(payload, ''),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
         expect.objectContaining({
-          signatureValid: true,
-          payloadMalformed: false,
+          context: expect.objectContaining({
+            requestId: expect.any(String),
+          }),
         }),
-        expect.anything(),
+      );
+    });
+
+    it('should include webhook actor metadata in rejection audit logs', async () => {
+      const payload = buildPayload();
+
+      await expect(
+        controller.handleModerationResults(payload, ''),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            actorType: 'webhook',
+            actorId: 'moderation-provider',
+          }),
+        }),
       );
     });
   });
 
   describe('Confession Not Found', () => {
     it('should handle missing confession gracefully', async () => {
-      const serializedPayload = JSON.stringify(mockPayload);
-      const validSignature = crypto
-        .createHmac('sha256', mockWebhookSecret)
-        .update(serializedPayload)
-        .digest('hex');
+      const payload = buildPayload();
+      const validHeader = buildSignatureHeader(payload);
 
-      jest.spyOn(confessionRepo.manager, 'transaction').mockImplementation(async (cb: any) => {
-        const manager = {
-          getRepository: () => ({
-            findOne: jest.fn().mockResolvedValue(null),
-          }),
-        };
-        return cb(manager);
-      });
+      jest
+        .spyOn(confessionRepo.manager, 'transaction')
+        .mockImplementation(async (cb: any) => {
+          const manager = {
+            getRepository: () => ({
+              findOne: jest.fn().mockResolvedValue(null),
+            }),
+          };
+          return cb(manager);
+        });
 
-      const result = await controller.handleModerationResults(mockPayload, validSignature);
+      const result = await controller.handleModerationResults(
+        payload,
+        validHeader,
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Confession not found');

--- a/xconfess-backend/src/moderation/moderation-webhook.controller.spec.ts
+++ b/xconfess-backend/src/moderation/moderation-webhook.controller.spec.ts
@@ -1,5 +1,6 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import * as crypto from 'crypto';
 import { ModerationStatus } from './ai-moderation.service';
 import { ModerationWebhookController } from './moderation-webhook.controller';
 
@@ -19,6 +20,9 @@ describe('ModerationWebhookController', () => {
   let eventEmitter: {
     emit: jest.Mock;
   };
+  let auditLogService: {
+    log: jest.Mock;
+  };
 
   const confession = {
     id: 'conf-123',
@@ -31,12 +35,19 @@ describe('ModerationWebhookController', () => {
     isHidden: false,
   } as any;
 
-  const buildSignature = (payload: unknown) => {
-    const crypto = require('crypto') as typeof import('crypto');
-    return crypto
-      .createHmac('sha256', webhookSecret)
-      .update(JSON.stringify(payload))
+  /**
+   * Builds a timestamped signature header: "t=<unix_ts>,v1=<hmac>"
+   * HMAC computed over "<timestamp>.<serialized_payload>"
+   */
+  const buildSignature = (payload: unknown, secret = webhookSecret) => {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const serialized = JSON.stringify(payload);
+    const signedMessage = `${timestamp}.${serialized}`;
+    const hmac = crypto
+      .createHmac('sha256', secret)
+      .update(signedMessage)
       .digest('hex');
+    return `t=${timestamp},v1=${hmac}`;
   };
 
   beforeEach(() => {
@@ -65,23 +76,34 @@ describe('ModerationWebhookController', () => {
     eventEmitter = {
       emit: jest.fn(),
     };
+    auditLogService = {
+      log: jest.fn().mockResolvedValue(undefined),
+    };
 
     controller = new ModerationWebhookController(
-      { get: jest.fn().mockReturnValue(webhookSecret) } as any,
+      {
+        get: jest.fn((key: string, def?: any) => {
+          if (key === 'WEBHOOK_SECRET') return webhookSecret;
+          if (key === 'WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS') return 300;
+          return def;
+        }),
+      } as any,
       eventEmitter as unknown as EventEmitter2,
       confessionRepo as any,
       moderationRepoService as any,
+      auditLogService as any,
     );
   });
 
   it('updates the confession and emits requires-review for flagged results', async () => {
     const payload = {
+      eventId: crypto.randomUUID(),
       confessionId: 'conf-123',
       moderationScore: 0.71,
       moderationFlags: ['harassment'],
       moderationStatus: ModerationStatus.FLAGGED,
       details: { harassment: 0.71 },
-      timestamp: '2026-03-25T10:00:00.000Z',
+      timestamp: new Date().toISOString(),
     };
 
     const result = await controller.handleModerationResults(
@@ -124,12 +146,13 @@ describe('ModerationWebhookController', () => {
 
   it('emits high-severity for rejected results', async () => {
     const payload = {
+      eventId: crypto.randomUUID(),
       confessionId: 'conf-123',
       moderationScore: 0.99,
       moderationFlags: ['violence'],
       moderationStatus: ModerationStatus.REJECTED,
       details: { violence: 0.99 },
-      timestamp: '2026-03-25T10:05:00.000Z',
+      timestamp: new Date().toISOString(),
     };
 
     await controller.handleModerationResults(payload, buildSignature(payload));
@@ -147,43 +170,44 @@ describe('ModerationWebhookController', () => {
     );
   });
 
-  it('treats a duplicate delivery as idempotent and skips side effects', async () => {
+  it('treats a duplicate delivery (same eventId) as idempotent and skips side effects', async () => {
     const payload = {
+      eventId: crypto.randomUUID(),
       confessionId: 'conf-123',
       moderationScore: 0.71,
       moderationFlags: ['harassment'],
       moderationStatus: ModerationStatus.FLAGGED,
       details: { harassment: 0.71 },
-      timestamp: '2026-03-25T10:00:00.000Z',
+      timestamp: new Date().toISOString(),
     };
-    moderationRepoService.syncWebhookResult.mockResolvedValueOnce({
-      log: { id: 'log-1' },
-      isIdempotent: true,
-    });
 
-    const result = await controller.handleModerationResults(
+    // First call processes normally
+    const result1 = await controller.handleModerationResults(
       payload,
       buildSignature(payload),
     );
+    expect(result1.isIdempotent).toBe(false);
 
-    expect(confessionRepo.save).not.toHaveBeenCalled();
-    expect(eventEmitter.emit).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      success: true,
-      confessionId: 'conf-123',
-      status: ModerationStatus.FLAGGED,
-      isIdempotent: true,
-    });
+    // Second call with same eventId — replayed
+    const result2 = await controller.handleModerationResults(
+      payload,
+      buildSignature(payload),
+    );
+    expect(result2.isIdempotent).toBe(true);
+
+    // Confession save should only happen once (first call)
+    expect(confessionRepo.save).toHaveBeenCalledTimes(1);
   });
 
   it('rolls back staged webhook log updates when confession save fails', async () => {
     const payload = {
+      eventId: crypto.randomUUID(),
       confessionId: 'conf-123',
       moderationScore: 0.85,
       moderationFlags: ['harassment'],
       moderationStatus: ModerationStatus.FLAGGED,
       details: { harassment: 0.85 },
-      timestamp: '2026-03-25T10:00:00.000Z',
+      timestamp: new Date().toISOString(),
     };
 
     const committed = {
@@ -227,16 +251,36 @@ describe('ModerationWebhookController', () => {
 
   it('rejects webhook requests with an invalid signature', async () => {
     const payload = {
+      eventId: crypto.randomUUID(),
       confessionId: 'conf-123',
       moderationScore: 0.71,
       moderationFlags: ['harassment'],
       moderationStatus: ModerationStatus.FLAGGED,
       details: { harassment: 0.71 },
-      timestamp: '2026-03-25T10:00:00.000Z',
+      timestamp: new Date().toISOString(),
+    };
+
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const invalidHeader = `t=${timestamp},v1=${'f'.repeat(64)}`;
+
+    await expect(
+      controller.handleModerationResults(payload, invalidHeader),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('rejects webhook requests with missing signature header', async () => {
+    const payload = {
+      eventId: crypto.randomUUID(),
+      confessionId: 'conf-123',
+      moderationScore: 0.71,
+      moderationFlags: ['harassment'],
+      moderationStatus: ModerationStatus.FLAGGED,
+      details: { harassment: 0.71 },
+      timestamp: new Date().toISOString(),
     };
 
     await expect(
-      controller.handleModerationResults(payload, 'invalid-signature'),
+      controller.handleModerationResults(payload, ''),
     ).rejects.toThrow(UnauthorizedException);
   });
 });

--- a/xconfess-backend/src/moderation/moderation-webhook.controller.ts
+++ b/xconfess-backend/src/moderation/moderation-webhook.controller.ts
@@ -21,8 +21,11 @@ import {
   ModerationStatus,
 } from './ai-moderation.service';
 import { ModerationRepositoryService } from './moderation-repository.service';
+import { AuditLogService } from '../audit-log/audit-log.service';
+import { AuditActionType } from '../audit-log/audit-log.entity';
 
 interface WebhookPayload {
+  eventId: string;
   confessionId: string;
   moderationScore: number;
   moderationFlags: string[];
@@ -31,11 +34,45 @@ interface WebhookPayload {
   timestamp: string;
 }
 
+/**
+ * Parses a timestamped HMAC signature header.
+ * Expected format: "t=<unix_timestamp>,v1=<hmac_hex>"
+ * The HMAC is computed over "<timestamp>.<serialized_payload>".
+ */
+function parseSignatureHeader(
+  header: string,
+): { timestamp: string; signature: string } | null {
+  if (!header) return null;
+
+  const parts = header.split(',');
+  let timestamp = '';
+  let signature = '';
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith('t=')) {
+      timestamp = trimmed.substring(2);
+    } else if (trimmed.startsWith('v1=')) {
+      signature = trimmed.substring(3);
+    }
+  }
+
+  if (!timestamp || !signature) return null;
+  return { timestamp, signature };
+}
+
 @Controller('webhooks/moderation')
 export class ModerationWebhookController {
   private readonly logger = new Logger(ModerationWebhookController.name);
   private readonly webhookSecret: string;
   private readonly timestampToleranceSeconds: number;
+
+  /**
+   * In-memory set of recently processed event IDs for fast replay rejection.
+   * Entries are TTL-evicted after the timestamp tolerance window.
+   */
+  private readonly processedEventIds = new Map<string, number>();
+  private readonly eventIdTtlMs: number;
 
   constructor(
     private readonly configService: ConfigService,
@@ -43,86 +80,157 @@ export class ModerationWebhookController {
     @InjectRepository(AnonymousConfession)
     private readonly confessionRepo: Repository<AnonymousConfession>,
     private readonly moderationRepoService: ModerationRepositoryService,
+    private readonly auditLogService: AuditLogService,
   ) {
     this.webhookSecret = this.configService.get<string>('WEBHOOK_SECRET', '');
     this.timestampToleranceSeconds = this.configService.get<number>(
       'WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS',
       300,
     );
+    this.eventIdTtlMs = this.timestampToleranceSeconds * 2 * 1000;
   }
 
   @Post('results')
   @HttpCode(HttpStatus.OK)
   async handleModerationResults(
     @Body() payload: WebhookPayload,
-    @Headers('x-webhook-signature') signature: string,
+    @Headers('x-webhook-signature') signatureHeader: string,
   ) {
-    // Issue #782: Enhanced signature validation and malformed payload handling
+    const correlationId = crypto.randomUUID();
     const serializedPayload = JSON.stringify(payload);
 
-    // Validate signature presence first
-    if (!signature) {
-      this.logger.warn('Missing moderation webhook signature');
+    // ─── 1. Reject unsigned requests ────────────────────────────────────
+    if (!signatureHeader) {
+      this.auditReject(
+        correlationId,
+        payload,
+        'missing_signature',
+        'Missing webhook signature header',
+      );
       throw new UnauthorizedException('Missing signature');
     }
 
-    // Validate timestamp freshness before processing to prevent replay.
-    // If timestamp is missing or malformed, we treat as bad request.
-    let timestamp: Date | null = null;
-    try {
-      timestamp = payload.timestamp ? new Date(payload.timestamp) : null;
-      if (!timestamp || isNaN(timestamp.getTime())) {
-        this.logger.warn('Malformed or missing timestamp in webhook payload');
-        throw new BadRequestException('Malformed payload: invalid timestamp');
-      }
-    } catch (err) {
-      this.logger.warn('Malformed timestamp in moderation webhook payload');
+    // ─── 2. Parse and validate timestamped signature header ─────────────
+    const parsed = parseSignatureHeader(signatureHeader);
+    if (!parsed) {
+      this.auditReject(
+        correlationId,
+        payload,
+        'malformed_signature_header',
+        'Malformed signature header format',
+      );
+      throw new BadRequestException('Malformed signature header');
+    }
+
+    // ─── 3. Validate timestamp freshness ────────────────────────────────
+    const sigTimestamp = Number(parsed.timestamp);
+    if (isNaN(sigTimestamp) || sigTimestamp <= 0) {
+      this.auditReject(
+        correlationId,
+        payload,
+        'invalid_timestamp',
+        'Invalid timestamp in signature header',
+      );
       throw new BadRequestException('Malformed payload: invalid timestamp');
     }
 
-    const now = new Date();
-    const ageSeconds = Math.abs((now.getTime() - timestamp.getTime()) / 1000);
+    const nowMs = Date.now();
+    const ageSeconds = Math.abs(nowMs - sigTimestamp * 1000) / 1000;
     if (ageSeconds > this.timestampToleranceSeconds) {
-      // Audit stale but signed request and reject
+      // Audit stale webhook attempt
+      this.auditReject(
+        correlationId,
+        payload,
+        'stale_timestamp',
+        `Webhook timestamp too old (${Math.round(ageSeconds)}s)`,
+      );
+
       try {
-        await this.moderationRepoService.syncWebhookResult(
-          {
-            confessionId: payload.confessionId ?? '',
-            content: serializedPayload,
-            result: {
-              score: payload.moderationScore ?? 0,
-              flags: (payload.moderationFlags ?? []) as ModerationCategory[],
-              status: payload.moderationStatus ?? ModerationStatus.PENDING,
-              details: payload.details ?? {},
-              requiresReview: false,
-            },
-            deliveryHash: this.buildDeliveryHash(serializedPayload),
-            deliveryTimestamp: payload.timestamp,
-            signatureValid: this.verifySignature(serializedPayload, signature),
-            payloadMalformed: false,
-            deliveryStale: true,
+        await this.moderationRepoService.syncWebhookResult({
+          confessionId: payload.confessionId ?? '',
+          content: serializedPayload,
+          result: {
+            score: payload.moderationScore ?? 0,
+            flags: (payload.moderationFlags ?? []) as ModerationCategory[],
+            status: payload.moderationStatus ?? ModerationStatus.PENDING,
+            details: payload.details ?? {},
+            requiresReview: false,
           },
-        );
+          deliveryHash: this.buildDeliveryHash(serializedPayload),
+          deliveryTimestamp: payload.timestamp,
+          signatureValid: false,
+          payloadMalformed: false,
+          deliveryStale: true,
+        });
       } catch (e) {
         this.logger.error('Failed to audit stale webhook', e as any);
       }
 
-      this.logger.warn('Rejected stale moderation webhook delivery');
       throw new UnauthorizedException('Stale webhook delivery');
     }
 
-    // Now validate signature
-    if (!this.verifySignature(serializedPayload, signature)) {
-      this.logger.warn('Invalid moderation webhook signature');
+    // ─── 4. Verify timestamped HMAC signature ──────────────────────────
+    // The HMAC is computed over "<timestamp>.<payload>" binding timestamp to body
+    if (
+      !this.verifyTimestampedSignature(
+        parsed.timestamp,
+        serializedPayload,
+        parsed.signature,
+      )
+    ) {
+      this.auditReject(
+        correlationId,
+        payload,
+        'invalid_signature',
+        'HMAC signature verification failed',
+      );
       throw new UnauthorizedException('Invalid signature');
     }
 
-    // Validate payload structure
+    // ─── 5. Validate payload structure ─────────────────────────────────
     if (!payload.confessionId || !payload.moderationStatus) {
-      this.logger.error('Malformed moderation webhook payload', { payload });
-      throw new BadRequestException('Malformed payload: missing required fields');
+      this.auditReject(
+        correlationId,
+        payload,
+        'malformed_payload',
+        'Missing required fields: confessionId or moderationStatus',
+      );
+      throw new BadRequestException(
+        'Malformed payload: missing required fields',
+      );
     }
 
+    // ─── 6. Reject replayed event IDs ──────────────────────────────────
+    if (!payload.eventId) {
+      this.auditReject(
+        correlationId,
+        payload,
+        'missing_event_id',
+        'Missing eventId in payload',
+      );
+      throw new BadRequestException('Malformed payload: missing eventId');
+    }
+
+    this.evictStaleEventIds();
+    if (this.processedEventIds.has(payload.eventId)) {
+      this.auditReject(
+        correlationId,
+        payload,
+        'replayed_event_id',
+        `Event ${payload.eventId} already processed`,
+      );
+      this.logger.warn(
+        `Rejected replayed moderation webhook event ${payload.eventId}`,
+      );
+      return {
+        success: true,
+        confessionId: payload.confessionId,
+        status: payload.moderationStatus,
+        isIdempotent: true,
+      };
+    }
+
+    // ─── 7. Process the webhook ────────────────────────────────────────
     const requiresReview =
       payload.moderationStatus === ModerationStatus.FLAGGED;
     const shouldHide = payload.moderationStatus === ModerationStatus.REJECTED;
@@ -146,7 +254,6 @@ export class ModerationWebhookController {
           return { status: 'not_found' as const };
         }
 
-        // Issue #782: Idempotent webhook processing with delivery hash
         const { isIdempotent } =
           await this.moderationRepoService.syncWebhookResult(
             {
@@ -187,7 +294,6 @@ export class ModerationWebhookController {
       this.logger.log(
         `Ignoring duplicate moderation webhook for confession ${payload.confessionId}`,
       );
-
       return {
         success: true,
         confessionId: result.confessionId,
@@ -195,6 +301,9 @@ export class ModerationWebhookController {
         isIdempotent: true,
       };
     }
+
+    // Mark event ID as processed
+    this.processedEventIds.set(payload.eventId, Date.now());
 
     if (payload.moderationStatus === ModerationStatus.REJECTED) {
       this.eventEmitter.emit('moderation.high-severity', {
@@ -224,18 +333,31 @@ export class ModerationWebhookController {
     };
   }
 
+  /**
+   * Builds a SHA-256 delivery hash for idempotency tracking.
+   */
   private buildDeliveryHash(payload: string): string {
     return crypto.createHash('sha256').update(payload).digest('hex');
   }
 
-  private verifySignature(payload: string, signature: string): boolean {
+  /**
+   * Verifies a timestamped HMAC signature.
+   * The signed message is "<timestamp>.<payload>" to bind the timestamp
+   * cryptographically to the request body, preventing timestamp tampering.
+   */
+  private verifyTimestampedSignature(
+    timestamp: string,
+    payload: string,
+    signature: string,
+  ): boolean {
     if (!this.webhookSecret || !signature) {
       return false;
     }
 
+    const signedMessage = `${timestamp}.${payload}`;
     const expectedSignature = crypto
       .createHmac('sha256', this.webhookSecret)
-      .update(payload)
+      .update(signedMessage)
       .digest('hex');
 
     if (signature.length !== expectedSignature.length) {
@@ -246,5 +368,63 @@ export class ModerationWebhookController {
       Buffer.from(signature),
       Buffer.from(expectedSignature),
     );
+  }
+
+  /**
+   * Evicts event IDs older than the TTL window to prevent unbounded memory growth.
+   */
+  private evictStaleEventIds(): void {
+    const cutoff = Date.now() - this.eventIdTtlMs;
+    for (const [eventId, ts] of this.processedEventIds) {
+      if (ts < cutoff) {
+        this.processedEventIds.delete(eventId);
+      }
+    }
+  }
+
+  /**
+   * Logs a rejected webhook to the audit trail with redacted metadata.
+   * Fire-and-forget: failures here must not break the rejection response.
+   */
+  private auditReject(
+    correlationId: string,
+    payload: WebhookPayload,
+    reason: string,
+    detail: string,
+  ): void {
+    this.logger.warn({
+      event: 'moderation_webhook_rejected',
+      correlationId,
+      reason,
+      confessionId: payload?.confessionId ?? 'unknown',
+      eventId: payload?.eventId ?? 'unknown',
+    });
+
+    // Fire-and-forget audit log (redaction handled by AuditLogRedactionService)
+    this.auditLogService
+      .log({
+        actionType: AuditActionType.WEBHOOK_REJECTED,
+        metadata: {
+          entityType: 'moderation_webhook',
+          entityId: payload?.confessionId ?? 'unknown',
+          confessionId: payload?.confessionId ?? 'unknown',
+          eventId: payload?.eventId ?? 'unknown',
+          reason,
+          detail,
+          actorType: 'webhook' as const,
+          actorId: 'moderation-provider',
+        },
+        context: {
+          requestId: correlationId,
+          actor: {
+            type: 'webhook' as const,
+            id: 'moderation-provider',
+            source: 'moderation-webhook',
+          },
+        },
+      })
+      .catch((err) => {
+        this.logger.error('Failed to write webhook rejection audit log', err);
+      });
   }
 }


### PR DESCRIPTION
FIX

Closes #1455 

---

WHAT CHANGED

Secured the moderation webhook endpoint (POST /webhooks/moderation/results) by
enforcing timestamped HMAC signatures using a Stripe-style header format
(t=<unix_ts>,v1=<hmac>) where the HMAC is computed over "<timestamp>.<payload>",
adding explicit eventId-based replay rejection with a TTL-evicted in-memory store,
and writing correlated, redacted audit logs via AuditLogService for every rejected
webhook (unsigned, stale, malformed, invalid signature, replayed). A new
WEBHOOK_REJECTED action type was added to the AuditActionType enum.


WHY

Forged or replayed moderation callbacks could suppress or approve unsafe content
because the previous HMAC did not bind the timestamp to the payload, there was no
event-level replay tracking, and rejected webhooks left no audit trail for forensic
investigation.


HOW TO TEST

1. From a fresh checkout, install dependencies:
   npm install

2. Set env vars (or rely on jest.setup.ts defaults):
   WEBHOOK_SECRET=test-webhook-secret
   WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS=300

3. Run the targeted test suite:
   npm run backend:test -- --runTestsByPath src/moderation/moderation-webhook-idempotency.spec.ts src/moderation/moderation-webhook.controller.spec.ts

   Expected: 20 tests passing, 2 suites green

4. (Optional) Run the full moderation suite to confirm no regressions:
   cd xconfess-backend && npx jest --config jest.config.js --testPathPatterns "src/moderation/" --forceExit

   Expected: 24 tests passing, 4 suites green

5. (Optional) Verify TypeScript compilation of changed files:
   cd xconfess-backend && npx tsc --noEmit 2>&1 | grep -E "moderation-webhook|audit-log.entity"

   Expected: no output (no errors in modified files)

---

SCOPE CHECK

[x] This PR touches only the files needed to resolve the linked issue
[x] I have not included unrelated refactors, style fixes, or dependency upgrades
[x] Changed lines <= 400 and files touched <= 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

N/A - 4 files changed, 506 insertions / 152 deletions. The test rewrites are
substantial because every test had to be updated for the new signature format
(t=<ts>,v1=<hmac>) and eventId requirement, plus new test cases were added for
each acceptance criterion.

---

EVIDENCE

Tests

[x] Added or updated unit tests
[ ] Added or updated integration / e2e tests
[ ] Change is not testable - manual steps provided above
[ ] No runtime behaviour changed (docs / config only)

Test run output:

  $ npm run backend:test -- --runTestsByPath src/moderation/moderation-webhook-idempotency.spec.ts src/moderation/moderation-webhook.controller.spec.ts --forceExit

  PASS src/moderation/moderation-webhook.controller.spec.ts
  PASS src/moderation/moderation-webhook-idempotency.spec.ts

  Test Suites: 2 passed, 2 total
  Tests:       20 passed, 20 total
  Snapshots:   0 total
  Time:        7.486 s
  Ran all test suites matching src/moderation/moderation-webhook-idempotency.spec.ts|src/moderation/moderation-webhook.controller.spec.ts.

Screenshots (UI changes only)

N/A - Backend-only change, no UI modifications.

---

CHECKLIST

[x] Branch is up to date with main
[x] All CI checks pass
[x] PR description is complete (no empty sections)
[x] I have read the small PR policy (docs/SMALL_PR_POLICY.md)

---

FILES CHANGED

1. xconfess-backend/src/moderation/moderation-webhook.controller.ts
   Core fix: timestamped HMAC verification, eventId replay store, auditReject() helper

2. xconfess-backend/src/moderation/moderation-webhook-idempotency.spec.ts
   Rewritten: 14 tests covering unsigned, stale, malformed, forged, replayed,
   valid, and audit correlation scenarios

3. xconfess-backend/src/moderation/moderation-webhook.controller.spec.ts
   Updated: adapted to new t=<ts>,v1=<hmac> signature format and eventId field

4. xconfess-backend/src/audit-log/audit-log.entity.ts
   Added WEBHOOK_REJECTED = 'webhook_rejected' to AuditActionType enum

Closes #1455 