### PR TITLE
fix(frontend): sanitize markdown rendering consistently #1513

### DIFF
--- a/xconfess-frontend/app/(dashboard)/confessions/[id]/ConfessionDetailClient.tsx
+++ b/xconfess-frontend/app/(dashboard)/confessions/[id]/ConfessionDetailClient.tsx
@@ -27,6 +27,7 @@ import { ShareButton } from "@/app/components/confession/ShareButton";
 import { CommentSection } from "@/app/components/confession/CommentSection";
 import { RelatedConfessions } from "@/app/components/confession/RelatedConfessions";
 import { formatDate } from "@/app/lib/utils/formatDate";
+import { sanitizeMarkdown } from "@/app/lib/utils/markdown";
 import { queryKeys } from "@/app/lib/api/queryKeys";
 import { useAuth } from "@/app/lib/hooks/useAuth";
 import { getConfessionById } from "@/app/lib/api/confessions";
@@ -315,7 +316,7 @@ export function ConfessionDetailClient({
           <CardContent className="pt-0">
             <div className="prose prose-zinc max-w-none text-zinc-900 dark:prose-invert dark:text-white prose-p:text-lg prose-p:leading-relaxed prose-a:break-all">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {confession.content}
+                {sanitizeMarkdown(confession.content)}
               </ReactMarkdown>
             </div>
 

--- a/xconfess-frontend/app/components/confession/PreviewPanel.tsx
+++ b/xconfess-frontend/app/components/confession/PreviewPanel.tsx
@@ -3,6 +3,7 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "@/app/lib/utils/cn";
+import { sanitizeMarkdown } from "@/app/lib/utils/markdown";
 
 interface PreviewPanelProps {
   title?: string;
@@ -94,7 +95,7 @@ export const PreviewPanel: React.FC<PreviewPanelProps> = ({
             ),
           }}
         >
-          {body || "*No content to preview*"}
+          {sanitizeMarkdown(body) || "*No content to preview*"}
         </ReactMarkdown>
       </div>
     </div>

--- a/xconfess-frontend/app/lib/utils/__tests__/markdown.test.ts
+++ b/xconfess-frontend/app/lib/utils/__tests__/markdown.test.ts
@@ -3,6 +3,7 @@ import {
   insertItalic,
   insertLink,
   insertEmoji,
+  sanitizeMarkdown,
 } from "../markdown";
 
 // Mock textarea element
@@ -56,6 +57,33 @@ describe("markdown utilities", () => {
       const textarea = createMockTextarea("Hello world", 6, 6);
       insertEmoji(textarea, "😀");
       expect(textarea.value).toBe("Hello 😀world");
+    });
+  });
+
+  describe("sanitizeMarkdown", () => {
+    it("should block script tags", () => {
+      const input = "Hello <script>alert(1)</script> World";
+      expect(sanitizeMarkdown(input)).toBe("Hello  World");
+    });
+
+    it("should block iframe tags", () => {
+      const input = "Video <iframe src='http://evil.com'></iframe>";
+      expect(sanitizeMarkdown(input)).toBe("Video ");
+    });
+
+    it("should block inline event handlers", () => {
+      const input = "Click <a href='#' onclick='alert(1)'>here</a>";
+      expect(sanitizeMarkdown(input)).toBe("Click <a href='#' >here</a>");
+    });
+
+    it("should block unsafe URL protocols", () => {
+      const input = "[link](javascript:alert(1))";
+      expect(sanitizeMarkdown(input)).toBe("[link](javascript_blocked:alert(1))");
+    });
+
+    it("should allow safe markdown formatting", () => {
+      const input = "**bold** and *italic* and [link](https://example.com)";
+      expect(sanitizeMarkdown(input)).toBe("**bold** and *italic* and [link](https://example.com)");
     });
   });
 });

--- a/xconfess-frontend/app/lib/utils/markdown.ts
+++ b/xconfess-frontend/app/lib/utils/markdown.ts
@@ -49,3 +49,23 @@ export function insertLink(textarea: HTMLTextAreaElement, url?: string): { newTe
 export function insertEmoji(textarea: HTMLTextAreaElement, emoji: string): { newText: string; cursorPos: number } {
   return insertMarkdown(textarea, emoji, "");
 }
+
+export function sanitizeMarkdown(content: string): string {
+  if (!content) return "";
+
+  let sanitized = content;
+
+  // 1. Remove script tags completely
+  sanitized = sanitized.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+
+  // 2. Remove iframe tags completely
+  sanitized = sanitized.replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, "");
+
+  // 3. Remove inline event handlers (e.g., onclick="...", onmouseover=...)
+  sanitized = sanitized.replace(/\bon[a-z]+\s*=\s*(?:(['"]?)[\s\S]*?\1|[^\s>]+)/gi, "");
+
+  // 4. Neutralize unsafe URL protocols
+  sanitized = sanitized.replace(/(javascript|vbscript|data):/gi, "$1_blocked:");
+
+  return sanitized;
+}

--- a/xconfess-frontend/test_markdown.js
+++ b/xconfess-frontend/test_markdown.js
@@ -1,0 +1,7 @@
+const markdown = "<script>alert(1)</script> [click](javascript:alert(1)) <iframe src='blah'></iframe> <div onclick='alert(2)'></div>";
+let sanitized = markdown;
+sanitized = sanitized.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+sanitized = sanitized.replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, "");
+sanitized = sanitized.replace(/\bon[a-z]+\s*=\s*(?:(['"]?)[\s\S]*?\1|[^\s>]+)/gi, "");
+sanitized = sanitized.replace(/(javascript|vbscript|data):/gi, "$1_blocked:");
+console.log(sanitized);


### PR DESCRIPTION
<!--
  Small PR policy: https://github.com/Xconfess/Xconfess/blob/main/docs/SMALL_PR_POLICY.md
  Keep this PR focused on ONE issue. Fill in every section — mark unused ones N/A.
-->

## Closes

Closes #1513 
---

## What changed

Added a centralized `sanitizeMarkdown` utility function that intercepts and strips out potentially malicious HTML elements. I then audited and integrated this utility into all markdown rendering paths (specifically `PreviewPanel.tsx` and `ConfessionDetailClient.tsx`) so that content is sanitized before it hits `react-markdown`. I also added comprehensive test coverage for the sanitization cases.

## Why

This prevents Cross-Site Scripting (XSS) vulnerabilities by safely blocking script tags, iframes, inline event handlers, and unsafe URL protocols (like `javascript:`) before they can be rendered in the DOM, while ensuring standard markdown formatting remains functional.

## How to test

1. Checkout the branch locally and `cd xconfess-frontend`
2. Run `npm install` to ensure testing dependencies like `ts-jest` are present.
3. Run `npm run test -- app/lib/utils/__tests__/markdown.test.ts` to verify that all malicious payload tests pass successfully.

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:
N/A
---

## Evidence

### Tests

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output (paste or screenshot):

```text
 PASS  app/lib/utils/__tests__/markdown.test.ts
  markdown utilities
    insertBold
      ✓ should insert bold markdown around selected text (1 ms)
      ✓ should insert bold markdown at cursor when no selection
    insertItalic
      ✓ should insert italic markdown around selected text
    insertLink
      ✓ should insert link markdown with selected text
      ✓ should use default text when no selection
    insertEmoji
      ✓ should insert emoji at cursor position
    sanitizeMarkdown
      ✓ should block script tags (1 ms)
      ✓ should block iframe tags
      ✓ should block inline event handlers
      ✓ should block unsafe URL protocols
      ✓ should allow safe markdown formatting

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
