### PR TITLE
fix(backend): add database indexes for admin audit and report filters

### DIFF
--- a/xconfess-backend/scripts/explain-queries.js
+++ b/xconfess-backend/scripts/explain-queries.js
@@ -10,6 +10,8 @@ const queries = {
   confession_list: `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT id FROM anonymous_confessions WHERE is_deleted = false AND is_hidden = false AND moderation_status IN ('approved','pending') ORDER BY created_at DESC LIMIT $1;`,
   confession_by_tag: `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT c.id FROM anonymous_confessions c INNER JOIN confession_tags ct ON ct.confession_id = c.id INNER JOIN tags t ON t.id = ct.tag_id WHERE t.name = $1 AND c.is_deleted = false ORDER BY c.created_at DESC LIMIT $2;`,
   reports_list: `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT id FROM reports WHERE status = $1 ORDER BY created_at DESC LIMIT $2;`,
+  audit_logs_by_admin_daterange: `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT id FROM audit_logs WHERE admin_id = $1 AND created_at >= $2 AND created_at <= $3 ORDER BY created_at DESC LIMIT $4;`,
+  reports_cursor_by_status: `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT id FROM reports WHERE status = $1 AND created_at >= $2 AND created_at <= $3 ORDER BY created_at DESC, id DESC LIMIT $4;`,
 };
 
 const argv = require('minimist')(process.argv.slice(2));
@@ -36,6 +38,14 @@ const pool = new Pool({
       res = await client.query(queries[q], ['test', parseInt(argv.limit || '100', 10)]);
     } else if (q === 'reports_list') {
       res = await client.query(queries[q], ['pending', parseInt(argv.limit || '100', 10)]);
+    } else if (q === 'audit_logs_by_admin_daterange') {
+      const now = new Date();
+      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      res = await client.query(queries[q], [1, sevenDaysAgo, now, parseInt(argv.limit || '100', 10)]);
+    } else if (q === 'reports_cursor_by_status') {
+      const now = new Date();
+      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      res = await client.query(queries[q], ['pending', sevenDaysAgo, now, parseInt(argv.limit || '100', 10)]);
     } else {
       res = await client.query(queries[q], [parseInt(argv.limit || '100', 10)]);
     }

--- a/xconfess-backend/src/admin/entities/report.entity.ts
+++ b/xconfess-backend/src/admin/entities/report.entity.ts
@@ -33,6 +33,7 @@ export enum ReportStatus {
 @Index(['reporterId'])
 @Index(['status'])
 @Index(['createdAt'])
+@Index(['idempotencyKey'])
 export class Report {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -96,7 +97,6 @@ export class Report {
     length: 255,
     nullable: true,
   })
-  @Index(['idempotency_key'])
   idempotencyKey: string | null;
 
   @CreateDateColumn()

--- a/xconfess-backend/src/migrations/20260723000001-add-audit-report-composite-indexes.ts
+++ b/xconfess-backend/src/migrations/20260723000001-add-audit-report-composite-indexes.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: add composite indexes for admin audit and report filters
+ *
+ * Adds indexes optimized for real query patterns observed in:
+ *   - AuditLogService.findAll: filters by admin_id + action + entity_type, sorted by createdAt
+ *   - AdminService.getReportsCursor: keyset pagination (createdAt DESC, id DESC) with status/type filters
+ *
+ * Indexes added:
+ *   - audit_logs: (admin_id, created_at DESC)
+ *   - audit_logs: (action, created_at DESC)
+ *   - audit_logs: (entity_type, created_at DESC)
+ *   - reports: (status, created_at DESC, id DESC)
+ *   - reports: (type, created_at DESC, id DESC)
+ */
+export class AddAuditReportCompositeIndexes20260723000001
+  implements MigrationInterface
+{
+  name = 'AddAuditReportCompositeIndexes20260723000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Audit logs composite indexes
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_audit_logs_admin_created"
+        ON "audit_logs" ("admin_id", "createdAt" DESC);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_audit_logs_action_created"
+        ON "audit_logs" ("action", "createdAt" DESC);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_audit_logs_entity_type_created"
+        ON "audit_logs" ("entity_type", "createdAt" DESC);
+    `);
+
+    // Reports composite indexes for cursor pagination and filtering
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_reports_status_created_id"
+        ON "reports" ("status", "createdAt" DESC, "id" DESC);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_reports_type_created_id"
+        ON "reports" ("type", "createdAt" DESC, "id" DESC);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "idx_reports_type_created_id";
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "idx_reports_status_created_id";
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "idx_audit_logs_entity_type_created";
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "idx_audit_logs_action_created";
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "idx_audit_logs_admin_created";
+    `);
+  }
+}


### PR DESCRIPTION
## Summary
Add composite indexes for admin incident response queries against audit_logs and reports tables. These queries are performance-critical for the admin dashboard and incident investigation workflows.

## Changes
- New migration `20260723000001-add-audit-report-composite-indexes.ts`:
  - Audit logs: `(admin_id, created_at DESC)`, `(action, created_at DESC)`, `(entity_type, created_at DESC)`
  - Reports: `(status, created_at DESC, id DESC)`, `(type, created_at DESC, id DESC)` for cursor pagination
- Fix misplaced `@Index` decorator on `Report.idempotencyKey` (moved from property to class level)
- Extend `explain-queries.js` with two new regression test queries:
  - `audit_logs_by_admin_daterange`: tests admin-scoped audit log filtering
  - `reports_cursor_by_status`: tests keyset pagination with status filter

## Testing
- `npm run backend:test` (existing test suites pass)
- `node xconfess-backend/scripts/explain-queries.js --query=reports_cursor_by_status` to verify index usage (no Seq Scan)
- `node xconfess-backend/scripts/explain-queries.js --query=audit_logs_by_admin_daterange` to verify index usage

## Related Issues
Closes #1503