### PR TITLE
fix(backend): add notification preference enforcement at dispatch time

### DIFF
--- a/xconfess-backend/src/notifications/gateways/notification.gateway.ts
+++ b/xconfess-backend/src/notifications/gateways/notification.gateway.ts
@@ -237,6 +237,17 @@ export class NotificationGateway
   // namespace, ensuring strict per-user isolation.
 
   async sendNotificationToUser(userId: string, notification: any) {
+    const shouldDeliver = await this.notificationService.shouldDeliverRealtime(
+      userId,
+      notification.type,
+    );
+    if (!shouldDeliver) {
+      this.logger.log(
+        `Realtime notification suppressed for user ${userId} (preference check)`,
+      );
+      return;
+    }
+
     const userRoom = `${USER_ROOM_PREFIX}${userId}`;
     this.server.to(userRoom).emit('new-notification', notification);
 

--- a/xconfess-backend/src/notifications/services/notification.service.ts
+++ b/xconfess-backend/src/notifications/services/notification.service.ts
@@ -48,6 +48,18 @@ export class NotificationService {
       return;
     }
 
+    const userId = payload?.userId || payload?.recipientId;
+    if (userId) {
+      const canDeliver = await this.shouldDeliverEmail(userId, type);
+      if (!canDeliver) {
+        this.appLogger.warn(
+          `enqueueNotification skipped (email preference disabled): type=${type} userId=${userId}`,
+          'NotificationService',
+        );
+        return;
+      }
+    }
+
     await this.notificationQueue.add(
       'send-notification',
       {
@@ -62,6 +74,66 @@ export class NotificationService {
       jobName: 'send-notification',
       notificationType: type,
     });
+  }
+
+  /**
+   * Check whether a user should receive a realtime (in-app/WebSocket) notification.
+   * Pulls fresh preferences from DB to avoid stale cached decisions.
+   */
+  async shouldDeliverRealtime(userId: string, type: string): Promise<boolean> {
+    try {
+      const preference = await this.getUserPreference(userId);
+      if (!preference.enableInAppNotifications) return false;
+
+      const channelPrefs = await this.getUserChannelPreferences(
+        userId,
+        type as NotificationType,
+      );
+      if (channelPrefs && !channelPrefs.inApp) return false;
+
+      if (this.isQuietHours(preference)) return false;
+      if (await this.isQuietHoursForUser(userId)) return false;
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Check whether a user should receive an email notification.
+   * Pulls fresh preferences from DB to avoid stale cached decisions.
+   */
+  async shouldDeliverEmail(userId: string, type: string): Promise<boolean> {
+    try {
+      const preference = await this.getUserPreference(userId);
+      if (!preference.enableEmailNotifications || !preference.emailAddress) {
+        return false;
+      }
+
+      if (
+        type === NotificationType.NEW_MESSAGE &&
+        !preference.emailNewMessage
+      ) {
+        return false;
+      }
+      if (
+        type === NotificationType.MESSAGE_BATCH &&
+        !preference.emailMessageBatch
+      ) {
+        return false;
+      }
+
+      const channelPrefs = await this.getUserChannelPreferences(
+        userId,
+        type as NotificationType,
+      );
+      if (channelPrefs && !channelPrefs.email) return false;
+
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async createNotification(


### PR DESCRIPTION
## Summary

Adds preference enforcement at notification dispatch time to prevent users who have opted out from receiving unwanted notifications.

### Changes

- **\NotificationService.shouldDeliverRealtime()\**: Checks fresh preferences from DB before WebSocket emission — covers in-app notification toggles, quiet hours, and category-level channel preferences
- **\NotificationService.shouldDeliverEmail()\**: Same fresh check before email queue insertion
- **\enqueueNotification()\**: Now skips BullMQ enqueue if user has email notifications disabled
- **\NotificationGateway.sendNotificationToUser()\**: Checks realtime preferences before emitting to user room via WebSocket

### Acceptance Criteria

- [x] Disabled channels receive no sends
- [x] Preference changes are checked at dispatch time (no stale cache)
- [x] Covers email, realtime (WebSocket), and in-app channels

Closes #1465