### PR TITLE
fix(backend): prevent IDOR in profile, activity, and user confession routes

### DIFF
--- a/xconfess-backend/src/auth/interfaces/jwt-payload.interface.ts
+++ b/xconfess-backend/src/auth/interfaces/jwt-payload.interface.ts
@@ -24,6 +24,7 @@ export interface JwtPayload {
  */
 export interface RequestUser {
   id: number; // Canonical user ID field
+  sub?: number;
   username: string;
   email: string;
   role: UserRole;

--- a/xconfess-backend/src/auth/jwt.strategy.ts
+++ b/xconfess-backend/src/auth/jwt.strategy.ts
@@ -39,6 +39,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     // Return canonical RequestUser shape
     return {
       id: payload.sub, // Canonical ID field
+      sub: payload.sub,
       username: payload.username,
       email: payload.email,
       role: user?.role || UserRole.USER,

--- a/xconfess-backend/src/common/guards/idor.spec.ts
+++ b/xconfess-backend/src/common/guards/idor.spec.ts
@@ -130,6 +130,92 @@ describe('[Backend] DELETE /users/:userId', () => {
   });
 });
 
+describe('[Backend] GET /users/:userId/activities', () => {
+  it('401 when unauthenticated', async () => {
+    await request(BACKEND).get(`/users/${USER_A.id}/activities`).expect(401);
+  });
+
+  it('200 for own activities', async () => {
+    await request(BACKEND)
+      .get(`/users/${USER_A.id}/activities`)
+      .set(authed(USER_A.token))
+      .expect(200);
+  });
+
+  it('403 IDOR — user B cannot read user A activities', async () => {
+    await request(BACKEND)
+      .get(`/users/${USER_A.id}/activities`)
+      .set(authed(USER_B.token))
+      .expect(403);
+  });
+});
+
+describe('[Backend] GET /users/:userId/confessions', () => {
+  it('401 when unauthenticated', async () => {
+    await request(BACKEND).get(`/users/${USER_A.id}/confessions`).expect(401);
+  });
+
+  it('200 for own confessions', async () => {
+    await request(BACKEND)
+      .get(`/users/${USER_A.id}/confessions`)
+      .set(authed(USER_A.token))
+      .expect(200);
+  });
+
+  it('403 IDOR — user B cannot read user A confessions', async () => {
+    await request(BACKEND)
+      .get(`/users/${USER_A.id}/confessions`)
+      .set(authed(USER_B.token))
+      .expect(403);
+  });
+});
+
+describe('[Backend] GET /users/:userId/profile/summary', () => {
+  it('401 when unauthenticated', async () => {
+    await request(BACKEND).get(`/users/${USER_A.id}/profile/summary`).expect(401);
+  });
+
+  it('200 for own profile summary', async () => {
+    await request(BACKEND)
+      .get(`/users/${USER_A.id}/profile/summary`)
+      .set(authed(USER_A.token))
+      .expect(200);
+  });
+
+  it('403 IDOR — user B cannot read user A profile summary', async () => {
+    await request(BACKEND)
+      .get(`/users/${USER_A.id}/profile/summary`)
+      .set(authed(USER_B.token))
+      .expect(403);
+  });
+});
+
+describe('[Backend] Public profile endpoints', () => {
+  it('200 public access to /users/:userId/profile without token', async () => {
+    const res = await request(BACKEND)
+      .get(`/users/${USER_A.id}/profile`)
+      .expect(200);
+    // Excludes private fields
+    expect(res.body).not.toHaveProperty('id');
+    expect(res.body).not.toHaveProperty('settings');
+    expect(res.body).not.toHaveProperty('history');
+    expect(res.body).toHaveProperty('username');
+    expect(res.body).toHaveProperty('stats');
+  });
+
+  it('200 public access to /users/:userId/public-profile without token', async () => {
+    const res = await request(BACKEND)
+      .get(`/users/${USER_A.id}/public-profile`)
+      .expect(200);
+    // Excludes private fields
+    expect(res.body).not.toHaveProperty('id');
+    expect(res.body).not.toHaveProperty('settings');
+    expect(res.body).not.toHaveProperty('history');
+    expect(res.body).toHaveProperty('username');
+    expect(res.body).toHaveProperty('stats');
+  });
+});
+
 // ── Admin endpoints ─────────────────────────────────────────────────────────
 
 describe('[Backend] Admin data endpoints', () => {
@@ -191,6 +277,57 @@ describe('[Proxy] Next.js proxy routes enforce IDOR independently', () => {
     );
     // Proxy must reject based on session, not the spoofed header.
     expect(res.status).toBe(403);
+  });
+
+  it('403 — proxy rejects cross-user activity access', async () => {
+    const res = await fetch(
+      `${FRONTEND}/api/users/${USER_A.id}/activities`,
+      { headers: { cookie: `session=${sessionB}` } },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('200 — proxy allows own activity access', async () => {
+    const res = await fetch(
+      `${FRONTEND}/api/users/${USER_A.id}/activities`,
+      { headers: { cookie: `session=${sessionA}` } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('403 — proxy rejects cross-user confessions access', async () => {
+    const res = await fetch(
+      `${FRONTEND}/api/users/${USER_A.id}/confessions`,
+      { headers: { cookie: `session=${sessionB}` } },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('200 — proxy allows own confessions access', async () => {
+    const res = await fetch(
+      `${FRONTEND}/api/users/${USER_A.id}/confessions`,
+      { headers: { cookie: `session=${sessionA}` } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('200 — proxy allows public profile access without cookie', async () => {
+    const res = await fetch(
+      `${FRONTEND}/api/users/${USER_A.id}/public-profile`,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('SECURITY — proxy strips X-User-Id header before forwarding to public profile', async () => {
+    const res = await fetch(
+      `${FRONTEND}/api/users/${USER_A.id}/public-profile`,
+      {
+        headers: {
+          'x-user-id': USER_B.id,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
   });
 });
 

--- a/xconfess-backend/src/common/guards/ownership.guard.ts
+++ b/xconfess-backend/src/common/guards/ownership.guard.ts
@@ -45,6 +45,11 @@ export class OwnershipGuard implements CanActivate {
       throw new ForbiddenException('Not authenticated');
     }
 
+    const authedUserId = authedUser.id ?? authedUser.sub;
+    if (!authedUserId) {
+      throw new ForbiddenException('Not authenticated');
+    }
+
     // Admins bypass ownership checks when meta allows it.
     if (meta.adminBypass && authedUser.role === 'admin') {
       return true;
@@ -63,10 +68,10 @@ export class OwnershipGuard implements CanActivate {
       throw new ForbiddenException('Ownership check failed: missing resource ID');
     }
 
-    const isSelf = String(authedUser.sub) === String(resourceOwnerId);
+    const isSelf = String(authedUserId) === String(resourceOwnerId);
     if (!isSelf) {
       this.logger.warn(
-        `IDOR attempt blocked: user ${authedUser.sub} tried to access resource owned by ${resourceOwnerId}`,
+        `IDOR attempt blocked: user ${authedUserId} tried to access resource owned by ${resourceOwnerId}`,
       );
       throw new ForbiddenException('Access denied: resource belongs to another user');
     }

--- a/xconfess-backend/src/user/user.controller.ts
+++ b/xconfess-backend/src/user/user.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Req,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { OwnershipGuard } from '../common/guards/ownership.guard';
@@ -19,9 +20,54 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   /** Public profile — no ownership required */
-  @Get(':userId/profile')
+  @Get([':userId/profile', ':userId/public-profile'])
   async getPublicProfile(@Param('userId') userId: string) {
     return this.userService.getPublicProfile(userId);
+  }
+
+  /** Get authenticated user's own profile summary */
+  @Get('profile/summary')
+  async getMyProfileSummary(@Req() req: any) {
+    const userId = req.user.id ?? req.user.sub;
+    return this.userService.getProfileSummary(userId);
+  }
+
+  /** Get specific user's profile summary (with ownership check) */
+  @Get(':userId/profile/summary')
+  @UseGuards(OwnershipGuard)
+  @Ownership({ paramKey: 'userId' })
+  async getProfileSummary(
+    @Param('userId') userId: string,
+  ) {
+    return this.userService.getProfileSummary(parseInt(userId, 10));
+  }
+
+  /** Get user's activities list (with ownership check) */
+  @Get(':userId/activities')
+  @UseGuards(OwnershipGuard)
+  @Ownership({ paramKey: 'userId' })
+  async getUserActivities(
+    @Param('userId') userId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const p = page ? parseInt(page, 10) : 1;
+    const l = limit ? parseInt(limit, 10) : 10;
+    return this.userService.getUserActivitiesList(parseInt(userId, 10), p, l);
+  }
+
+  /** Get user's confessions list (with ownership check) */
+  @Get(':userId/confessions')
+  @UseGuards(OwnershipGuard)
+  @Ownership({ paramKey: 'userId' })
+  async getUserConfessions(
+    @Param('userId') userId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const p = page ? parseInt(page, 10) : 1;
+    const l = limit ? parseInt(limit, 10) : 10;
+    return this.userService.getUserConfessionsList(parseInt(userId, 10), p, l);
   }
 
   /**
@@ -36,7 +82,8 @@ export class UserController {
     @Body() dto: Record<string, unknown>,
     @Req() req: any,
   ) {
-    return this.userService.updateSettings(req.user.sub, dto);
+    const authedUserId = req.user.id ?? req.user.sub;
+    return this.userService.updateSettings(authedUserId, dto);
   }
 
   /**
@@ -47,6 +94,7 @@ export class UserController {
   @UseGuards(OwnershipGuard)
   @Ownership({ paramKey: 'userId', adminBypass: true })
   async deleteAccount(@Param('userId') userId: string, @Req() req: any) {
-    return this.userService.deleteAccount(req.user.sub);
+    const authedUserId = req.user.id ?? req.user.sub;
+    return this.userService.deleteAccount(authedUserId);
   }
 }

--- a/xconfess-backend/src/user/user.service.ts
+++ b/xconfess-backend/src/user/user.service.ts
@@ -206,6 +206,12 @@ export class UserService {
     return this.userRepository.save(user);
   }
 
+  async deleteAccount(userId: number): Promise<void> {
+    const user = await this.findById(userId);
+    if (!user) throw new NotFoundException('User not found');
+    await this.userRepository.remove(user);
+  }
+
   // =========================
   // ROLE
   // =========================
@@ -733,5 +739,102 @@ export class UserService {
       this.logger.error(`Failed to aggregate user activity: ${error.message}`, error.stack);
       return { data: [], meta: { total: 0, page, limit, totalPages: 0 } };
     }
+  }
+
+  async updateSettings(
+    userId: number,
+    dto: Record<string, any>,
+  ): Promise<User> {
+    const user = await this.findById(userId);
+    if (!user) throw new NotFoundException('User not found');
+
+    if (dto.privacySettings) {
+      user.privacySettings = {
+        ...user.privacySettings,
+        ...dto.privacySettings,
+      };
+    }
+
+    if (dto.notificationPreferences) {
+      user.notificationPreferences = {
+        ...user.notificationPreferences,
+        ...dto.notificationPreferences,
+      };
+    }
+
+    for (const key of Object.keys(dto)) {
+      if (
+        key !== 'privacySettings' &&
+        key !== 'notificationPreferences' &&
+        key in user
+      ) {
+        (user as any)[key] = dto[key];
+      }
+    }
+
+    await this.userRepository.save(user);
+    await this.enforcePrivacyPolicies(user);
+    return user;
+  }
+
+  async getPublicProfile(userId: string | number): Promise<any> {
+    const numericId = typeof userId === 'string' ? parseInt(userId, 10) : userId;
+    if (isNaN(numericId)) {
+      throw new NotFoundException('User not found');
+    }
+    const user = await this.findById(numericId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const anonRows = await this.userRepository.manager.query(
+      'SELECT anonymous_user_id as id FROM user_anonymous_users WHERE user_id = $1',
+      [numericId],
+    );
+    const anonIds = anonRows.map((row: { id: string }) => row.id);
+
+    let stats = {
+      confessions: 0,
+      reactions: 0,
+      comments: 0,
+      tipsReceived: 0,
+    };
+
+    if (anonIds.length > 0) {
+      const [statsRow] = await this.userRepository.manager.query(
+        `
+        SELECT
+          (SELECT COUNT(*)::int FROM anonymous_confessions c
+            WHERE c.anonymous_user_id = ANY($1) AND c."isDeleted" = false) AS confessions,
+          (SELECT COUNT(*)::int FROM reaction r
+            JOIN anonymous_confessions c ON c.id = r.confession_id
+            WHERE c.anonymous_user_id = ANY($1) AND c."isDeleted" = false) AS reactions,
+          (SELECT COUNT(*)::int FROM comments com
+            JOIN anonymous_confessions c ON c.id = com."confessionId"
+            WHERE c.anonymous_user_id = ANY($1) AND com."isDeleted" = false) AS comments,
+          (SELECT COALESCE(SUM(t.amount), 0)::float FROM tips t
+            JOIN anonymous_confessions c ON c.id = t.confession_id
+            WHERE c.anonymous_user_id = ANY($1)) AS tips_received
+        `,
+        [anonIds],
+      );
+      stats = {
+        confessions: Number(statsRow?.confessions ?? 0),
+        reactions: Number(statsRow?.reactions ?? 0),
+        comments: Number(statsRow?.comments ?? 0),
+        tipsReceived: Number(statsRow?.tips_received ?? 0),
+      };
+    }
+
+    const badges = this.buildReputationBadges(stats.confessions);
+
+    return {
+      displayName: user.username,
+      username: user.username,
+      avatar: null,
+      createdAt: user.createdAt,
+      stats,
+      badges,
+    };
   }
 }

--- a/xconfess-frontend/app/api/users/[id]/activities/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/activities/route.ts
@@ -1,28 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
 import { internalProxyErrorResponse } from "@/app/lib/utils/proxyError";
 import { getApiBaseUrl } from "@/app/lib/config";
 
 const BASE_API_URL = getApiBaseUrl();
 
-export async function GET(request: Request, { params }: { params: { id: string } }) {
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const { id } = params;
+
+  // ── Proxy-layer auth ────────────────────────────────────────────────────────
+  const sessionUserId = getSessionUserId(req);
+  if (!sessionUserId) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  if (String(sessionUserId) !== String(id)) {
+    console.warn(`[proxy/activities] IDOR attempt blocked: session=${sessionUserId} param=${id}`);
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   try {
-    const { id } = params;
     const backendUrl = `${BASE_API_URL}/users/${id}/activities`;
-
-    const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
+    const correlationId = req.headers.get("X-Correlation-ID") || "unknown";
 
     const response = await fetch(backendUrl, {
       method: "GET",
-      headers: {
-        "X-Correlation-ID": correlationId,
-      },
+      headers: buildForwardHeaders(req, correlationId),
     });
 
     const responseBody = await response.text();
-    const status = response.status;
-
     return new Response(responseBody, {
-      status,
+      status: response.status,
       headers: {
         "Content-Type": "application/json",
       },
@@ -30,4 +39,33 @@ export async function GET(request: Request, { params }: { params: { id: string }
   } catch (error) {
     return internalProxyErrorResponse({ route: "GET /api/users/[id]/activities" }, error);
   }
+}
+
+function getSessionUserId(req: NextRequest): string | null {
+  const sessionCookie = req.cookies.get("session");
+  if (!sessionCookie) return null;
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(sessionCookie.value.split(".")[1], "base64").toString(),
+    );
+    return payload?.sub ? String(payload.sub) : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildForwardHeaders(req: NextRequest, correlationId: string): HeadersInit {
+  const headers: Record<string, string> = {
+    cookie: req.headers.get("cookie") ?? "",
+    "content-type": "application/json",
+    "X-Correlation-ID": correlationId,
+  };
+
+  const blockedHeaders = ["x-user-id", "x-forwarded-user", "x-admin-override"];
+  for (const h of blockedHeaders) {
+    delete headers[h];
+  }
+
+  return headers;
 }

--- a/xconfess-frontend/app/api/users/[id]/confessions/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/confessions/route.ts
@@ -1,27 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
 
 const BASE_API_URL = getApiBaseUrl();
 
-export async function GET(request: Request, { params }: { params: { id: string } }) {
-  const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const { id } = params;
+  const correlationId = req.headers.get("X-Correlation-ID") || "unknown";
+
+  // ── Proxy-layer auth ────────────────────────────────────────────────────────
+  const sessionUserId = getSessionUserId(req);
+  if (!sessionUserId) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+  if (String(sessionUserId) !== String(id)) {
+    console.warn(`[proxy/confessions] IDOR attempt blocked: session=${sessionUserId} param=${id}`);
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   try {
-    const { id } = params;
     const backendUrl = `${BASE_API_URL}/users/${id}/confessions`;
 
     const response = await fetch(backendUrl, {
       method: "GET",
-      headers: {
-        "X-Correlation-ID": correlationId,
-      },
+      headers: buildForwardHeaders(req, correlationId),
     });
 
     if (!response.ok) {
       const errData = await response.json().catch(() => ({}));
       return createApiErrorResponse(errData, {
         status: response.status,
-          upstreamResponse: response,
+        upstreamResponse: response,
         correlationId,
         route: "GET /api/users/[id]/confessions"
       });
@@ -43,3 +55,31 @@ export async function GET(request: Request, { params }: { params: { id: string }
   }
 }
 
+function getSessionUserId(req: NextRequest): string | null {
+  const sessionCookie = req.cookies.get("session");
+  if (!sessionCookie) return null;
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(sessionCookie.value.split(".")[1], "base64").toString(),
+    );
+    return payload?.sub ? String(payload.sub) : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildForwardHeaders(req: NextRequest, correlationId: string): HeadersInit {
+  const headers: Record<string, string> = {
+    cookie: req.headers.get("cookie") ?? "",
+    "content-type": "application/json",
+    "X-Correlation-ID": correlationId,
+  };
+
+  const blockedHeaders = ["x-user-id", "x-forwarded-user", "x-admin-override"];
+  for (const h of blockedHeaders) {
+    delete headers[h];
+  }
+
+  return headers;
+}

--- a/xconfess-frontend/app/api/users/[id]/public-profile/route.ts
+++ b/xconfess-frontend/app/api/users/[id]/public-profile/route.ts
@@ -1,10 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
 
 const BASE_API_URL = getApiBaseUrl();
 
-export async function GET(request: Request, { params }: { params: { id: string } }) {
-  const correlationId = request.headers.get("X-Correlation-ID") || "unknown";
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const correlationId = req.headers.get("X-Correlation-ID") || "unknown";
 
   try {
     const { id } = params;
@@ -12,16 +16,14 @@ export async function GET(request: Request, { params }: { params: { id: string }
 
     const response = await fetch(backendUrl, {
       method: "GET",
-      headers: {
-        "X-Correlation-ID": correlationId,
-      },
+      headers: buildForwardHeaders(req, correlationId),
     });
 
     if (!response.ok) {
       const errData = await response.json().catch(() => ({}));
       return createApiErrorResponse(errData, {
         status: response.status,
-          upstreamResponse: response,
+        upstreamResponse: response,
         correlationId,
         route: "GET /api/users/[id]/public-profile"
       });
@@ -43,3 +45,17 @@ export async function GET(request: Request, { params }: { params: { id: string }
   }
 }
 
+function buildForwardHeaders(req: NextRequest, correlationId: string): HeadersInit {
+  const headers: Record<string, string> = {
+    cookie: req.headers.get("cookie") ?? "",
+    "content-type": "application/json",
+    "X-Correlation-ID": correlationId,
+  };
+
+  const blockedHeaders = ["x-user-id", "x-forwarded-user", "x-admin-override"];
+  for (const h of blockedHeaders) {
+    delete headers[h];
+  }
+
+  return headers;
+}


### PR DESCRIPTION
# Summary

This PR fixes multiple potential Insecure Direct Object Reference (IDOR) vulnerabilities by enforcing ownership validation across user-related endpoints, limiting public profile exposure, and adding regression tests for unauthorized access attempts.

**Closes #1450**

---

# Overview

Several profile, activity, and confession endpoints relied on user identifiers supplied in requests without consistently verifying that the authenticated user was authorized to access the requested resource.

This PR hardens those endpoints by introducing strict ownership validation and reducing the amount of information returned from public profile APIs.

---

# Changes

## Backend Ownership Validation

Audited and updated user-related endpoints to ensure that private resources can only be accessed by their owners.

Applied ownership validation across:

- profile endpoints
- activity endpoints
- user confession endpoints
- related services using authenticated user context

---

## Ownership Guard Improvements

Updated the ownership guard to:

- verify authenticated user identity
- reject cross-user access attempts
- return appropriate authorization errors
- centralize ownership validation logic

---

## Public Profile Hardening

Restricted public profile responses to intentionally exposed fields only.

Examples include:

- display name
- avatar
- public statistics
- reputation (if public)

Private information such as settings, internal identifiers, preferences, or personal activity is no longer exposed through public profile routes.

---

## Frontend API Proxy

Updated the frontend API proxy routes to align with the stricter backend authorization rules and prevent forwarding unauthorized requests.

---

## Regression Tests

Added negative security tests covering:

- user attempting to access another user's profile
- user attempting to access another user's activity
- user attempting to access another user's confessions
- unauthorized public profile field exposure

Added positive tests verifying:

- owner can access own resources
- public profile still returns approved fields

---

# Files Updated

Primary files include:

```text
xconfess-backend/src/user/**

xconfess-backend/src/common/guards/ownership.guard.ts

xconfess-frontend/app/api/users/**/route.ts

xconfess-backend/src/common/guards/idor.spec.ts
```

---

# Validation

Executed locally:

```bash
npm run backend:test -- --runTestsByPath src/common/guards/idor.spec.ts
```

Also verified:

- authenticated users can access their own profile
- authenticated users cannot access another user's private profile
- activity endpoints reject cross-user access
- confession endpoints reject unauthorized access
- public profile exposes only approved fields
- regression tests pass successfully

---

# Result

This PR eliminates IDOR vulnerabilities in user-facing endpoints by enforcing ownership validation, minimizing public data exposure, and adding regression tests to prevent future authorization regressions.