### PR TITLE
fix(backend): add soft-delete consistency across confessions, comment…

### DIFF
--- a/xconfess-backend/src/analytics/analytics.service.spec.ts
+++ b/xconfess-backend/src/analytics/analytics.service.spec.ts
@@ -22,11 +22,38 @@ const makeCacheServiceMock = () => ({
   invalidateSegment: jest.fn().mockResolvedValue(1),
 });
 
+// A chainable query-builder mock: every fluent method returns `this` except
+// the terminal getters, which resolve to whatever the test configures.
+const makeQueryBuilderMock = () => {
+  const qb: any = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    loadRelationCountAndMap: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([]),
+    getRawMany: jest.fn().mockResolvedValue([]),
+    getRawOne: jest.fn().mockResolvedValue(null),
+    getCount: jest.fn().mockResolvedValue(0),
+  };
+  return qb;
+};
+
 // ─── Suite ────────────────────────────────────────────────────────────────────
 
 describe('AnalyticsService', () => {
   let service: AnalyticsService;
   let cacheService: ReturnType<typeof makeCacheServiceMock>;
+  let confessionRepo: ReturnType<typeof repoMock>;
+  let reactionRepo: ReturnType<typeof repoMock>;
 
   beforeEach(async () => {
     cacheService = makeCacheServiceMock();
@@ -45,9 +72,63 @@ describe('AnalyticsService', () => {
     }).compile();
 
     service = module.get<AnalyticsService>(AnalyticsService);
+    confessionRepo = module.get(getRepositoryToken(AnonymousConfession));
+    reactionRepo = module.get(getRepositoryToken(Reaction));
   });
 
   afterEach(() => jest.clearAllMocks());
+
+  // ── Soft-delete consistency (#1449) ────────────────────────────────────────
+
+  describe('soft-delete consistency', () => {
+    it('getTrendingConfessions() excludes soft-deleted confessions', async () => {
+      const qb = makeQueryBuilderMock();
+      confessionRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getTrendingConfessions(7);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('confession.isDeleted = false');
+    });
+
+    it('getGrowthMetricsForWindow (via getConfessionGrowth) excludes soft-deleted confessions', async () => {
+      const qb = makeQueryBuilderMock();
+      confessionRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getConfessionGrowth(7);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('confession.isDeleted = false');
+    });
+
+    it('getReactionDistribution() excludes reactions on soft-deleted confessions', async () => {
+      const qb = makeQueryBuilderMock();
+      reactionRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getReactionDistribution(7);
+
+      expect(qb.innerJoin).toHaveBeenCalledWith('reaction.confession', 'confession');
+      expect(qb.andWhere).toHaveBeenCalledWith('confession.isDeleted = false');
+    });
+
+    it('getPlatformStats() counts only reactions on non-deleted confessions', async () => {
+      confessionRepo.count.mockResolvedValue(100);
+      const reactionQb = makeQueryBuilderMock();
+      reactionQb.getCount.mockResolvedValue(42);
+      reactionRepo.createQueryBuilder.mockReturnValue(reactionQb);
+
+      const categoryQb = makeQueryBuilderMock();
+      confessionRepo.createQueryBuilder.mockReturnValue(categoryQb);
+
+      const result: any = await service.getPlatformStats();
+
+      expect(reactionQb.innerJoin).toHaveBeenCalledWith(
+        'reaction.confession',
+        'confession',
+      );
+      expect(reactionQb.where).toHaveBeenCalledWith('confession.isDeleted = false');
+      expect(result.totalReactions).toBe(42);
+      expect(categoryQb.where).toHaveBeenCalledWith('confession.isDeleted = false');
+    });
+  });
 
   it('should be defined', () => {
     expect(service).toBeDefined();

--- a/xconfess-backend/src/analytics/analytics.service.ts
+++ b/xconfess-backend/src/analytics/analytics.service.ts
@@ -120,9 +120,9 @@ export class AnalyticsService {
     const trending = await this.confessionRepository
       .createQueryBuilder('confession')
       .leftJoinAndSelect('confession.reactions', 'reaction')
-      .where('confession.createdAt >= :startAt', { startAt })
-      .andWhere('confession.createdAt < :endAt', { endAt })
-      .andWhere('confession.isPublished = :isPublished', { isPublished: true })
+      .where('confession.created_at >= :startAt', { startAt })
+      .andWhere('confession.created_at < :endAt', { endAt })
+      .andWhere('confession.isDeleted = false')
       .loadRelationCountAndMap(
         'confession.reactionCount',
         'confession.reactions',
@@ -197,21 +197,27 @@ export class AnalyticsService {
       return cached;
     }
 
+    // totalConfessions intentionally includes soft-deleted rows to track total
+    // platform volume (mirrors the admin analytics overview); publishedConfessions
+    // and totalReactions are the live-content figures and exclude deleted confessions.
     const [totalUsers, totalConfessions, totalReactions, publishedConfessions] =
       await Promise.all([
         this.userRepository.count(),
         this.confessionRepository.count(),
-        this.reactionRepository.count(),
-        // Note: isPublished field doesn't exist, using total count instead
+        this.reactionRepository
+          .createQueryBuilder('reaction')
+          .innerJoin('reaction.confession', 'confession')
+          .where('confession.isDeleted = false')
+          .getCount(),
         this.confessionRepository.count({ where: { isDeleted: false } }),
       ]);
 
-    // Get most popular category
+    // Get most popular category (excluding soft-deleted confessions)
     const categoryStats = (await this.confessionRepository
       .createQueryBuilder('confession')
       .select('confession.category', 'category')
       .addSelect('COUNT(*)', 'count')
-      .where('confession.isPublished = :isPublished', { isPublished: true })
+      .where('confession.isDeleted = false')
       .groupBy('confession.category')
       .orderBy('count', 'DESC')
       .limit(1)
@@ -408,6 +414,7 @@ export class AnalyticsService {
       .addSelect('COUNT(*)', 'count')
       .where('confession.created_at >= :startAt', { startAt: range.startAt })
       .andWhere('confession.created_at < :endAt', { endAt: range.endAt })
+      .andWhere('confession.isDeleted = false')
       .groupBy("DATE(confession.created_at AT TIME ZONE 'UTC')")
       .orderBy('date', 'ASC')
       .getRawMany<BucketCountRow>();
@@ -491,10 +498,12 @@ export class AnalyticsService {
   ): Promise<ReactionDistributionMetrics> {
     const distribution = await this.reactionRepository
       .createQueryBuilder('reaction')
+      .innerJoin('reaction.confession', 'confession')
       .select('reaction.emoji', 'type')
       .addSelect('COUNT(*)', 'count')
       .where('reaction.createdAt >= :startAt', { startAt: range.startAt })
       .andWhere('reaction.createdAt < :endAt', { endAt: range.endAt })
+      .andWhere('confession.isDeleted = false')
       .groupBy('reaction.emoji')
       .orderBy('type', 'ASC')
       .getRawMany<ReactionDistributionRow>();

--- a/xconfess-backend/src/comment/comment.service.spec.ts
+++ b/xconfess-backend/src/comment/comment.service.spec.ts
@@ -121,6 +121,36 @@ describe('CommentService (soft‑delete)', () => {
         'comment',
       );
     });
+
+    // ── Soft-delete consistency (#1449) ─────────────────────────────────────
+
+    it(`excludes comments belonging to a soft-deleted confession`, async () => {
+      const fakeQB: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      (commentRepo as any).createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(fakeQB);
+      const queryDto: GetCommentsQueryDto = {
+        sortField: CommentSortField.CREATED_AT,
+        sortOrder: SortOrder.DESC,
+        limit: 20,
+      };
+
+      await service.findByConfessionId('conf1', queryDto);
+
+      expect(fakeQB.where).toHaveBeenCalledWith(
+        expect.stringContaining('confession.isDeleted = false'),
+        expect.objectContaining({ confessionId: 'conf1' }),
+      );
+    });
   });
 
   describe(`delete()`, () => {

--- a/xconfess-backend/src/comment/comment.service.ts
+++ b/xconfess-backend/src/comment/comment.service.ts
@@ -339,7 +339,9 @@ export class CommentService {
         "moderation",
         "moderation.commentId = comment.id",
       )
-      .where("comment.confession = :confessionId", { confessionId })
+      .where("comment.confession = :confessionId AND confession.isDeleted = false", {
+        confessionId,
+      })
       .andWhere("moderation.status = :status", {
         status: ModerationStatus.APPROVED,
       });

--- a/xconfess-backend/src/confession/confession.pagination.spec.ts
+++ b/xconfess-backend/src/confession/confession.pagination.spec.ts
@@ -15,6 +15,23 @@ import { TagService } from './tag.service';
 import { SortOrder } from './dto/get-confessions.dto';
 import { encryptConfession } from '../utils/confession-encryption';
 import { encodeCursor } from '../common/pagination';
+import { AnomalyDetectionService } from '../anomaly/anomaly-detection.service';
+import { ConfessionIdempotencyService } from './confession-idempotency.service';
+
+const anomalyDetectionProvider = {
+  provide: AnomalyDetectionService,
+  useValue: { getAdjustmentFactor: jest.fn().mockResolvedValue(1) },
+};
+
+const idempotencyServiceProvider = {
+  provide: ConfessionIdempotencyService,
+  useValue: {
+    computePayloadHash: jest.fn(),
+    check: jest.fn(),
+    commitSuccess: jest.fn(),
+    commitFailure: jest.fn(),
+  },
+};
 
 const AES_KEY = '12345678901234567890123456789012';
 
@@ -61,6 +78,8 @@ function buildProviders(qb: any, cacheService: any) {
     },
     { provide: CacheService, useValue: cacheService },
     { provide: TagService, useValue: { validateTags: jest.fn() } },
+    anomalyDetectionProvider,
+    idempotencyServiceProvider,
   ];
 }
 
@@ -74,6 +93,7 @@ describe('ConfessionService — feed pagination', () => {
     qb = {
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
@@ -254,6 +274,8 @@ function buildSearchProviders(repoValue: any) {
       },
     },
     { provide: TagService, useValue: { validateTags: jest.fn() } },
+    anomalyDetectionProvider,
+    idempotencyServiceProvider,
   ];
 }
 

--- a/xconfess-backend/src/confession/confession.search.spec.ts
+++ b/xconfess-backend/src/confession/confession.search.spec.ts
@@ -13,6 +13,11 @@ import { EncryptionService } from '../encryption/encryption.service';
 import { StellarService } from '../stellar/stellar.service';
 import { CacheService } from '../cache/cache.service';
 import { TagService } from './tag.service';
+import { AnomalyDetectionService } from '../anomaly/anomaly-detection.service';
+import { ConfessionIdempotencyService } from './confession-idempotency.service';
+import { encryptConfession } from '../utils/confession-encryption';
+
+const AES_KEY = '12345678901234567890123456789012';
 
 describe('ConfessionService - Search Functionality', () => {
   let service: ConfessionService;
@@ -72,7 +77,7 @@ describe('ConfessionService - Search Functionality', () => {
             get: jest.fn((key: string, defaultVal?: unknown) => {
               if (key === 'app.searchSlowQueryThresholdMs') return 500;
               if (key === 'app.searchSampleRate') return 1; // always sample in tests
-              if (key === 'app.confessionAesKey') return '';
+              if (key === 'app.confessionAesKey') return AES_KEY;
               return defaultVal;
             }),
           },
@@ -101,6 +106,19 @@ describe('ConfessionService - Search Functionality', () => {
         {
           provide: TagService,
           useValue: { validateTags: jest.fn(), getTagByName: jest.fn() },
+        },
+        {
+          provide: AnomalyDetectionService,
+          useValue: { getAdjustmentFactor: jest.fn().mockResolvedValue(1) },
+        },
+        {
+          provide: ConfessionIdempotencyService,
+          useValue: {
+            computePayloadHash: jest.fn(),
+            check: jest.fn(),
+            commitSuccess: jest.fn(),
+            commitFailure: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/xconfess-backend/src/confession/confession.service.spec.ts
+++ b/xconfess-backend/src/confession/confession.service.spec.ts
@@ -17,6 +17,8 @@ import { StellarService } from '../stellar/stellar.service';
 import { CacheService, CACHE_TTL } from '../cache/cache.service';
 import { TagService } from './tag.service';
 import { encryptConfession } from '../utils/confession-encryption';
+import { AnomalyDetectionService } from '../anomaly/anomaly-detection.service';
+import { ConfessionIdempotencyService } from './confession-idempotency.service';
 
 describe('ConfessionService', () => {
   let service: ConfessionService;
@@ -29,6 +31,7 @@ describe('ConfessionService', () => {
     qb = {
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       select: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
@@ -101,6 +104,19 @@ describe('ConfessionService', () => {
           },
         },
         { provide: TagService, useValue: { validateTags: jest.fn() } },
+        {
+          provide: AnomalyDetectionService,
+          useValue: { getAdjustmentFactor: jest.fn().mockResolvedValue(1) },
+        },
+        {
+          provide: ConfessionIdempotencyService,
+          useValue: {
+            computePayloadHash: jest.fn(),
+            check: jest.fn(),
+            commitSuccess: jest.fn(),
+            commitFailure: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -160,6 +176,44 @@ describe('ConfessionService', () => {
       console.error('ERROR', e);
       throw e;
     }
+  });
+
+  describe('Soft-delete consistency (#1449)', () => {
+    it('findAll() excludes soft-deleted confessions', async () => {
+      repo.find = jest.fn().mockResolvedValue([]);
+
+      await service.findAll();
+
+      expect(repo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { isDeleted: false } }),
+      );
+    });
+
+    it('findOne() excludes soft-deleted confessions', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('deleted-id')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(repo.findOne).toHaveBeenCalledWith({
+        where: { id: 'deleted-id', isDeleted: false },
+      });
+    });
+
+    it('getFlaggedConfessions() excludes soft-deleted confessions from both branches', async () => {
+      repo.findAndCount = jest.fn().mockResolvedValue([[], 0]);
+
+      await service.getFlaggedConfessions();
+
+      expect(repo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: [
+            { requiresReview: true, isDeleted: false },
+            expect.objectContaining({ isDeleted: false }),
+          ],
+        }),
+      );
+    });
   });
 
   describe('Cache TTL values (#1247)', () => {
@@ -251,10 +305,24 @@ describe('ConfessionService — anchor pending-state guard (#776)', () => {
             buildKey: jest.fn((...parts: string[]) => parts.join(':')),
             get: jest.fn().mockResolvedValue(null),
             set: jest.fn(),
+            del: jest.fn(),
             delPattern: jest.fn(),
           },
         },
         { provide: TagService, useValue: { validateTags: jest.fn() } },
+        {
+          provide: AnomalyDetectionService,
+          useValue: { getAdjustmentFactor: jest.fn().mockResolvedValue(1) },
+        },
+        {
+          provide: ConfessionIdempotencyService,
+          useValue: {
+            computePayloadHash: jest.fn(),
+            check: jest.fn(),
+            commitSuccess: jest.fn(),
+            commitFailure: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/xconfess-backend/src/confession/confession.service.ts
+++ b/xconfess-backend/src/confession/confession.service.ts
@@ -808,8 +808,8 @@ export class ConfessionService {
     const skip = (page - 1) * limit;
     const [data, total] = await this.confessionRepo.findAndCount({
       where: [
-        { requiresReview: true },
-        { moderationStatus: ModerationStatus.FLAGGED as any },
+        { requiresReview: true, isDeleted: false },
+        { moderationStatus: ModerationStatus.FLAGGED as any, isDeleted: false },
       ],
       order: { created_at: 'DESC' },
       skip,
@@ -960,6 +960,7 @@ export class ConfessionService {
   async findAll(): Promise<ConfessionResponseDto[]> {
     try {
       const confessions = await this.confessionRepo.find({
+        where: { isDeleted: false },
         order: { created_at: 'DESC' },
       });
 
@@ -978,7 +979,7 @@ export class ConfessionService {
   async findOne(id: string): Promise<ConfessionResponseDto> {
     try {
       const confession = await this.confessionRepo.findOne({
-        where: { id },
+        where: { id, isDeleted: false },
       });
 
       if (!confession) {

--- a/xconfess-backend/src/confession/repository/confession.repository.ts
+++ b/xconfess-backend/src/confession/repository/confession.repository.ts
@@ -1,4 +1,10 @@
-import { DataSource, Repository, FindOptionsWhere, ILike } from 'typeorm';
+import {
+  DataSource,
+  Repository,
+  FindOptionsWhere,
+  ILike,
+  SelectQueryBuilder,
+} from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { AnonymousConfession } from '../entities/confession.entity';
 import { SearchConfessionDto } from '../dto/search-confession.dto';
@@ -15,25 +21,39 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
   }
 
   /**
+   * Central soft-delete filter. Every read path that surfaces confessions to
+   * end users (public or authenticated, non-admin) must apply this so
+   * soft-deleted rows never leak through search, listings, or detail lookups.
+   * Admin-only surfaces (e.g. getDeletedConfessions) intentionally bypass this.
+   */
+  private excludeDeleted(
+    qb: SelectQueryBuilder<AnonymousConfession>,
+    alias = 'confession',
+  ): SelectQueryBuilder<AnonymousConfession> {
+    return qb.andWhere(`${alias}.isDeleted = false`);
+  }
+
+  /**
    * Find a confession by its ID with its reactions.
+   * Excludes soft-deleted confessions.
    * @param id The UUID of the confession
    * @returns The confession with its reactions, or null if not found
    */
   async findByIdWithReactions(id: string): Promise<AnonymousConfession | null> {
     return this.findOne({
-      where: { id },
+      where: { id, isDeleted: false },
       relations: ['reactions'],
     });
   }
 
   /**
    * Find confessions by a search term in the message using basic ILIKE.
-   * Filters out confessions from non-discoverable users.
+   * Filters out confessions from non-discoverable users and soft-deleted confessions.
    * @param searchTerm The term to search for in confession messages
    * @returns Array of confessions matching the search term
    */
   async findBySearchTerm(searchTerm: string): Promise<AnonymousConfession[]> {
-    return this.createQueryBuilder('confession')
+    const qb = this.createQueryBuilder('confession')
       .leftJoinAndSelect('confession.anonymousUser', 'anonymousUser')
       .leftJoinAndSelect('anonymousUser.userLinks', 'userLinks')
       .leftJoinAndSelect('userLinks.user', 'user')
@@ -42,9 +62,8 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
       })
       .andWhere(
         "(anonymousUser.userLinks IS NULL OR anonymousUser.userLinks = '{}' OR user.privacy_settings IS NULL OR user.privacy_settings->>'isDiscoverable' = 'true' OR JSON_TYPE(user.privacy_settings, '$.isDiscoverable') IS NULL)",
-      )
-      .orderBy('confession.created_at', 'DESC')
-      .getMany();
+      );
+    return this.excludeDeleted(qb).orderBy('confession.created_at', 'DESC').getMany();
   }
 
   /**
@@ -273,7 +292,7 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
   }
 
   /**
-   * Find recent confessions with pagination.
+   * Find recent confessions with pagination. Excludes soft-deleted confessions.
    * @param page The page number (1-based)
    * @param limit The number of items per page
    * @returns Array of confessions for the specified page
@@ -283,6 +302,7 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
     limit: number = 10,
   ): Promise<AnonymousConfession[]> {
     return this.find({
+      where: { isDeleted: false },
       order: {
         created_at: 'DESC',
       },
@@ -293,11 +313,11 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
   }
 
   /**
-   * Count total number of confessions.
+   * Count total number of non-deleted confessions.
    * @returns The total count of confessions
    */
   async countTotal(): Promise<number> {
-    return this.count();
+    return this.count({ where: { isDeleted: false } });
   }
 
   /**

--- a/xconfess-backend/src/reaction/reaction.service.spec.ts
+++ b/xconfess-backend/src/reaction/reaction.service.spec.ts
@@ -132,9 +132,11 @@ describe('ReactionService', () => {
 
       const result = await service.createReaction(dto);
 
-      // Confession loaded with relations for notification lookup
+      // Confession loaded with relations for notification lookup, excluding soft-deleted
       expect(confessionRepo.findOne).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: dto.confessionId } }),
+        expect.objectContaining({
+          where: { id: dto.confessionId, isDeleted: false },
+        }),
       );
 
       expect(managerReactionRepo.create).toHaveBeenCalledWith({
@@ -190,6 +192,26 @@ describe('ReactionService', () => {
       );
 
       // Must not proceed to user/reaction lookup
+      expect(anonymousUserRepo.findOne).not.toHaveBeenCalled();
+      expect(reactionRepo.create).not.toHaveBeenCalled();
+    });
+
+    // ── Soft-delete consistency (#1449) ─────────────────────────────────────
+
+    it('throws NotFoundException when confession is soft-deleted', async () => {
+      // The repository query filters isDeleted: false, so a soft-deleted
+      // confession resolves as "not found" here, the same as a missing one.
+      confessionRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.createReaction(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(confessionRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: dto.confessionId, isDeleted: false },
+        }),
+      );
       expect(anonymousUserRepo.findOne).not.toHaveBeenCalled();
       expect(reactionRepo.create).not.toHaveBeenCalled();
     });

--- a/xconfess-backend/src/reaction/reaction.service.ts
+++ b/xconfess-backend/src/reaction/reaction.service.ts
@@ -35,9 +35,9 @@ export class ReactionService {
   ) {}
 
   async createReaction(dto: CreateReactionDto): Promise<Reaction> {
-    // 1. Verify confession exists.
+    // 1. Verify confession exists and is not soft-deleted.
     const confession = await this.confessionRepo.findOne({
-      where: { id: dto.confessionId },
+      where: { id: dto.confessionId, isDeleted: false },
       relations: [
         'anonymousUser',
         'anonymousUser.userLinks',


### PR DESCRIPTION
fix(backend): add soft-delete consistency across confessions, comments, reactions, and report

Closes #1449 

## What changed

Audited every read path in the confession, comment, reaction, and analytics modules for missing `isDeleted` filters and fixed the gaps: `ConfessionService.findAll()`/`findOne()` and four `AnonymousConfessionRepository` methods (`findByIdWithReactions`, `findBySearchTerm`, `findRecent`, `countTotal`) could return soft-deleted confessions; `GET /confessions/:id/comments` returned comment threads for confessions the author had deleted; reacting to a soft-deleted confession silently succeeded instead of 404ing; and `AnalyticsService` counted soft-deleted confessions and their reactions in trending, platform stats, growth, and reaction-distribution figures. Added a central `excludeDeleted()` helper on the confession repository and regression tests covering each fixed surface.

## Why

Soft-deleted confessions and their comments/reactions were leaking through public detail/listing APIs and being counted in analytics, undermining the delete-content guarantee users expect (P1 privacy bug).

## How to test

1. `npm ci && npx jest --config jest.config.js src/reaction/reaction.service.spec.ts src/comment/comment.service.spec.ts src/confession/confession.service.spec.ts src/analytics/analytics.service.spec.ts` — all 4 suites should pass (85/85 tests).
2. Manually: create a confession, `DELETE /confessions/:id` to soft-delete it, then confirm `GET /confessions/:id` → 404, `GET /confessions/:id/comments` → empty list, `POST /confessions/:id/reactions` → 404.
3. Confirm the deleted confession no longer appears in `GET /analytics/trending`, `GET /analytics/stats` (reaction/category counts), or `GET /analytics/growth`.

---

## Scope check

<!-- Tick every box that applies. If none apply, explain below. -->

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [ ] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

11 files / ~325 changed lines, over the 8-file guideline. The issue's own acceptance criteria calls for regression tests per surface, so each of the 5 fixed source files (`confession.repository.ts`, `confession.service.ts`, `comment.service.ts`, `reaction.service.ts`, `analytics.service.ts`) has a matching spec file — splitting fix from test, or splitting by module, would leave intermediate commits with unverified or partially-fixed leak paths. Two additional spec files (`confession.search.spec.ts`, `confession.pagination.spec.ts`) needed a small DI-provider fix (pre-existing, unrelated `AnomalyDetectionService`/`ConfessionIdempotencyService` gaps) purely to unblock running `confession.service.spec.ts` locally — no soft-delete assertions were added there.

<!-- Tick what applies. -->

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)