### PR TITLE
fix(backend): prevent duplicate reactions under concurrent requests

### DIFF
--- a/xconfess-backend/src/migrations/20260725000003-add-unique-reaction-constraint.ts
+++ b/xconfess-backend/src/migrations/20260725000003-add-unique-reaction-constraint.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUniqueReactionConstraint20260725000003
+  implements MigrationInterface
+{
+  name = 'AddUniqueReactionConstraint20260725000003';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "uq_reaction_confession_user"
+        ON "reaction" ("confession_id", "anonymous_user_id");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "uq_reaction_confession_user";
+    `);
+  }
+}

--- a/xconfess-backend/src/reaction/entities/reaction.entity.ts
+++ b/xconfess-backend/src/reaction/entities/reaction.entity.ts
@@ -7,8 +7,12 @@ import {
   ManyToOne,
   JoinColumn,
   CreateDateColumn,
+  Index,
 } from 'typeorm';
 
+@Index('uq_reaction_confession_user', ['confession', 'anonymousUser'], {
+  unique: true,
+})
 @Entity()
 export class Reaction {
   @PrimaryGeneratedColumn('uuid')

--- a/xconfess-backend/src/reaction/reaction.service.spec.ts
+++ b/xconfess-backend/src/reaction/reaction.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { DataSource } from 'typeorm';
+import { DataSource, QueryFailedError } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { ReactionService } from './reaction.service';
 import { Reaction } from './entities/reaction.entity';
@@ -8,6 +8,7 @@ import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { AnonymousUser } from '../user/entities/anonymous-user.entity';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
 import { AnalyticsService } from '../analytics/analytics.service';
+import { ReactionsGateway } from './reactions.gateway';
 
 // ─── Factories ───────────────────────────────────────────────────────────────
 
@@ -49,6 +50,7 @@ const repoMock = () => ({
   create: jest.fn(),
   save: jest.fn(),
   remove: jest.fn(),
+  count: jest.fn().mockResolvedValue(1),
 });
 
 // ─── Suite ───────────────────────────────────────────────────────────────────
@@ -61,10 +63,17 @@ describe('ReactionService', () => {
   // inner manager repo shared so transaction-based calls can be asserted
   let managerReactionRepo: ReturnType<typeof repoMock>;
   let managerOutboxRepo: ReturnType<typeof repoMock>;
+  let gatewayMock: jest.Mocked<ReactionsGateway>;
 
   beforeEach(async () => {
     managerReactionRepo = repoMock();
     managerOutboxRepo = repoMock();
+
+    gatewayMock = {
+      broadcastReactionAdded: jest.fn(),
+      broadcastReactionRemoved: jest.fn(),
+      broadcastConfessionUpdated: jest.fn(),
+    } as any;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -98,6 +107,7 @@ describe('ReactionService', () => {
               .mockResolvedValue(undefined),
           },
         },
+        { provide: ReactionsGateway, useValue: gatewayMock },
       ],
     }).compile();
 
@@ -129,6 +139,7 @@ describe('ReactionService', () => {
       managerReactionRepo.findOne.mockResolvedValue(null);
       managerReactionRepo.create.mockReturnValue(reaction);
       managerReactionRepo.save.mockResolvedValue(reaction);
+      managerReactionRepo.count.mockResolvedValue(1);
 
       const result = await service.createReaction(dto);
 
@@ -247,6 +258,7 @@ describe('ReactionService', () => {
       managerReactionRepo.findOne.mockResolvedValue(null);
       managerReactionRepo.create.mockReturnValue(makeReaction());
       managerReactionRepo.save.mockResolvedValue(makeReaction());
+      managerReactionRepo.count.mockResolvedValue(1);
 
       await service.createReaction(dto);
 
@@ -263,6 +275,7 @@ describe('ReactionService', () => {
       managerReactionRepo.findOne.mockResolvedValue(null);
       managerReactionRepo.create.mockReturnValue(reaction);
       managerReactionRepo.save.mockResolvedValue(reaction);
+      managerReactionRepo.count.mockResolvedValue(1);
 
       await service.createReaction(dto);
 
@@ -273,6 +286,111 @@ describe('ReactionService', () => {
       expect(managerReactionRepo.create).not.toHaveBeenCalledWith(
         expect.objectContaining({ user: expect.anything() }),
       );
+    });
+
+    // ── Race condition: concurrent duplicate insert ────────────────────────
+
+    it('handles race condition by returning existing reaction on unique violation', async () => {
+      const confession = makeConfession();
+      const user = makeAnonymousUser();
+      const existing = makeReaction({ confession, anonymousUser: user });
+
+      confessionRepo.findOne.mockResolvedValue(confession);
+      anonymousUserRepo.findOne.mockResolvedValue(user);
+
+      // First findOne inside transaction returns null (race window open)
+      managerReactionRepo.findOne.mockResolvedValueOnce(null);
+
+      // save throws unique-violation (SQLSTATE 23505)
+      const uniqueError = new QueryFailedError(
+        'INSERT',
+        [],
+        Object.assign(new Error('duplicate key'), { code: '23505' }),
+      );
+      managerReactionRepo.save.mockRejectedValueOnce(uniqueError);
+
+      // Re-fetch after constraint violation returns the winning row
+      managerReactionRepo.findOne.mockResolvedValueOnce(existing);
+
+      const result = await service.createReaction(dto);
+
+      expect(result).toBe(existing);
+      expect(managerReactionRepo.save).toHaveBeenCalledTimes(1);
+      // findOne called twice: once before save, once after constraint violation
+      expect(managerReactionRepo.findOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-throws non-unique-violation QueryFailedErrors', async () => {
+      const confession = makeConfession();
+      const user = makeAnonymousUser();
+
+      confessionRepo.findOne.mockResolvedValue(confession);
+      anonymousUserRepo.findOne.mockResolvedValue(user);
+      managerReactionRepo.findOne.mockResolvedValue(null);
+
+      // save throws a different DB error (not unique violation)
+      const dbError = new QueryFailedError(
+        'INSERT',
+        [],
+        Object.assign(new Error('connection refused'), { code: '08006' }),
+      );
+      managerReactionRepo.save.mockRejectedValue(dbError);
+
+      await expect(service.createReaction(dto)).rejects.toThrow(dbError);
+    });
+
+    // ── WebSocket broadcast ────────────────────────────────────────────────
+
+    it('broadcasts reaction:added via gateway for a new reaction', async () => {
+      const confession = makeConfession();
+      const user = makeAnonymousUser();
+      const reaction = makeReaction({ confession, anonymousUser: user });
+
+      confessionRepo.findOne.mockResolvedValue(confession);
+      anonymousUserRepo.findOne.mockResolvedValue(user);
+      managerReactionRepo.findOne.mockResolvedValue(null);
+      managerReactionRepo.create.mockReturnValue(reaction);
+      managerReactionRepo.save.mockResolvedValue(reaction);
+      managerReactionRepo.count.mockResolvedValue(3);
+
+      await service.createReaction(dto);
+
+      expect(gatewayMock.broadcastReactionAdded).toHaveBeenCalledWith(
+        confession.id,
+        expect.objectContaining({
+          reactionId: reaction.id,
+          userId: dto.anonymousUserId,
+          reactionType: reaction.emoji,
+          totalCount: 3,
+        }),
+      );
+    });
+
+    it('does NOT broadcast when reaction is idempotent (same emoji)', async () => {
+      const existing = makeReaction({ emoji: '❤️' });
+
+      confessionRepo.findOne.mockResolvedValue(makeConfession());
+      anonymousUserRepo.findOne.mockResolvedValue(makeAnonymousUser());
+      managerReactionRepo.findOne.mockResolvedValue(existing);
+
+      await service.createReaction(dto);
+
+      expect(gatewayMock.broadcastReactionAdded).not.toHaveBeenCalled();
+      expect(gatewayMock.broadcastReactionRemoved).not.toHaveBeenCalled();
+    });
+
+    it('does NOT broadcast when emoji is updated (existing reaction changes)', async () => {
+      const existing = makeReaction({ emoji: '😂' });
+      const updated = { ...existing, emoji: '❤️' } as Reaction;
+
+      confessionRepo.findOne.mockResolvedValue(makeConfession());
+      anonymousUserRepo.findOne.mockResolvedValue(makeAnonymousUser());
+      managerReactionRepo.findOne.mockResolvedValue(existing);
+      managerReactionRepo.save.mockResolvedValue(updated);
+
+      await service.createReaction({ ...dto, emoji: '❤️' });
+
+      expect(gatewayMock.broadcastReactionAdded).not.toHaveBeenCalled();
     });
   });
 });
@@ -292,6 +410,7 @@ describe('ReactionService – analytics cache invalidation', () => {
     findOne: jest.fn().mockResolvedValue(null),
     create: jest.fn().mockReturnValue({ id: 'r1', emoji: '❤️' }),
     save: jest.fn().mockResolvedValue({ id: 'r1', emoji: '❤️' }),
+    count: jest.fn().mockResolvedValue(1),
   });
 
   const confession = {
@@ -329,7 +448,7 @@ describe('ReactionService – analytics cache invalidation', () => {
         ReactionService,
         {
           provide: getRepositoryToken(Reaction),
-          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn() },
+          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn(), count: jest.fn() },
         },
         {
           provide: getRepositoryToken(AnonymousConfession),
@@ -345,6 +464,14 @@ describe('ReactionService – analytics cache invalidation', () => {
         },
         { provide: DataSource, useValue: dataSourceMock },
         { provide: AnalyticsService, useValue: analyticsService },
+        {
+          provide: ReactionsGateway,
+          useValue: {
+            broadcastReactionAdded: jest.fn(),
+            broadcastReactionRemoved: jest.fn(),
+            broadcastConfessionUpdated: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -392,6 +519,14 @@ describe('ReactionService – analytics cache invalidation', () => {
         },
         { provide: DataSource, useValue: { transaction: jest.fn() } },
         { provide: AnalyticsService, useValue: analyticsService },
+        {
+          provide: ReactionsGateway,
+          useValue: {
+            broadcastReactionAdded: jest.fn(),
+            broadcastReactionRemoved: jest.fn(),
+            broadcastConfessionUpdated: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/xconfess-backend/src/reaction/reaction.service.ts
+++ b/xconfess-backend/src/reaction/reaction.service.ts
@@ -6,7 +6,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { Repository, DataSource, QueryFailedError } from 'typeorm';
 import { CreateReactionDto } from './dto/create-reaction.dto';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { Reaction } from './entities/reaction.entity';
@@ -16,6 +16,7 @@ import {
   OutboxStatus,
 } from '../common/entities/outbox-event.entity';
 import { AnalyticsService } from '../analytics/analytics.service';
+import { ReactionsGateway } from './reactions.gateway';
 
 @Injectable()
 export class ReactionService {
@@ -32,6 +33,7 @@ export class ReactionService {
     private outboxRepo: Repository<OutboxEvent>,
     private readonly dataSource: DataSource,
     private readonly analyticsService: AnalyticsService,
+    private readonly reactionsGateway: ReactionsGateway,
   ) {}
 
   async createReaction(dto: CreateReactionDto): Promise<Reaction> {
@@ -64,7 +66,7 @@ export class ReactionService {
       throw new NotFoundException('Anonymous user not found');
     }
 
-    return this.dataSource
+    const result = await this.dataSource
       .transaction(async (manager) => {
         const reactionRepo = manager.getRepository(Reaction);
         const outboxRepo = manager.getRepository(OutboxEvent);
@@ -79,14 +81,12 @@ export class ReactionService {
 
         if (existing) {
           if (existing.emoji === dto.emoji) {
-            return existing;
+            return { reaction: existing, isNew: false, isUpdate: false };
           }
 
           existing.emoji = dto.emoji;
           const updated = await reactionRepo.save(existing);
 
-          // Update outbox event for the change?
-          // Usually reactions are high volume, but let's notify the author.
           await this.createOutboxEvent(
             outboxRepo,
             confession,
@@ -94,7 +94,7 @@ export class ReactionService {
             'reaction_update',
           );
 
-          return updated;
+          return { reaction: updated, isNew: false, isUpdate: true };
         }
 
         // 4. Persist new reaction
@@ -104,16 +104,44 @@ export class ReactionService {
           anonymousUser,
         });
 
-        const savedReaction = await reactionRepo.save(reaction);
+        try {
+          const savedReaction = await reactionRepo.save(reaction);
 
-        await this.createOutboxEvent(
-          outboxRepo,
-          confession,
-          savedReaction,
-          'reaction_notification',
-        );
+          await this.createOutboxEvent(
+            outboxRepo,
+            confession,
+            savedReaction,
+            'reaction_notification',
+          );
 
-        return savedReaction;
+          return { reaction: savedReaction, isNew: true, isUpdate: false };
+        } catch (err) {
+          // Handle race condition: a concurrent request may have inserted the
+          // same reaction between our findOne and save. The DB unique
+          // constraint on (confession_id, anonymous_user_id) will reject the
+          // duplicate insert. In that case, re-fetch the existing row so the
+          // caller receives a stable idempotent response.
+          if (
+            err instanceof QueryFailedError &&
+            this.isUniqueViolation(err)
+          ) {
+            this.logger.debug(
+              `Race-condition duplicate detected for reaction ` +
+                `(confession=${dto.confessionId}, user=${dto.anonymousUserId})`,
+            );
+            const raceExisting = await reactionRepo.findOne({
+              where: {
+                confession: { id: dto.confessionId },
+                anonymousUser: { id: dto.anonymousUserId },
+              },
+            });
+
+            if (raceExisting) {
+              return { reaction: raceExisting, isNew: false, isUpdate: false };
+            }
+          }
+          throw err;
+        }
       })
       .then(async (result) => {
         // Invalidate analytics segments that are affected by a reaction change.
@@ -135,8 +163,41 @@ export class ReactionService {
               err,
             ),
           );
-        return result;
+
+        // 5. Broadcast canonical WebSocket event for new reactions only.
+        // Duplicate / idempotent requests must not emit extra events.
+        if (result.isNew) {
+          this.reactionsGateway.broadcastReactionAdded(confession.id, {
+            reactionId: result.reaction.id,
+            userId: dto.anonymousUserId,
+            reactionType: result.reaction.emoji,
+            timestamp: result.reaction.createdAt,
+            totalCount: await this.getReactionCount(confession.id),
+          });
+        }
+
+        return result.reaction;
       });
+  }
+
+  /**
+   * Returns the total reaction count for a confession.
+   * Used after persisting a new reaction to include an accurate count in the
+   * WebSocket broadcast payload.
+   */
+  private async getReactionCount(confessionId: string): Promise<number> {
+    return this.reactionRepo.count({
+      where: { confession: { id: confessionId } },
+    });
+  }
+
+  /**
+   * Detects whether a TypeORM QueryFailedError wraps a Postgres unique
+   * constraint violation (SQLSTATE 23505).
+   */
+  private isUniqueViolation(err: QueryFailedError): boolean {
+    const driverError = err.driverError as { code?: string };
+    return driverError?.code === '23505';
   }
 
   private async createOutboxEvent(

--- a/xconfess-frontend/app/lib/api/reactions.ts
+++ b/xconfess-frontend/app/lib/api/reactions.ts
@@ -1,6 +1,6 @@
 import { normalizeApiError, type ApiError } from "./errors";
 import type { ReactionType, ReactionCounts } from "../types/reaction";
-import { isValidReactionType } from "../constants/reactions";
+import { isValidReactionType, REACTION_EMOJI_MAP } from "../constants/reactions";
 import { ANONYMOUS_USER_ID_KEY } from "./constants";
 
 const API_BASE = "";
@@ -65,7 +65,7 @@ export async function addReaction(
         },
         body: JSON.stringify({ 
           confessionId,
-          type,
+          emoji: REACTION_EMOJI_MAP[type],
         }),
         signal,
       }


### PR DESCRIPTION
## Summary

Fixes race condition where concurrent reaction requests can create duplicate rows, inflating engagement counts.

Closes #1426

## Changes

### 1. Database-level unique constraint
- **Migration** `20260725000003-add-unique-reaction-constraint.ts`: Adds a composite unique index `uq_reaction_confession_user` on `reaction(confession_id, anonymous_user_id)` — the DB-level guard that prevents duplicate rows regardless of application logic.
- **Entity** `reaction.entity.ts`: Added `@Index('uq_reaction_confession_user', [...], { unique: true })` so TypeORM's schema sync stays consistent with the migration.

### 2. Service-layer race condition handling
- **`reaction.service.ts`**: The transaction now catches `QueryFailedError` with Postgres SQLSTATE `23505` (unique violation) on insert. When a concurrent request wins the race, the losing request re-fetches the existing row and returns it idempotently instead of throwing or creating a duplicate.
- The return type from the transaction now carries `isNew` / `isUpdate` flags so the post-transaction logic knows whether to broadcast.

### 3. WebSocket fanout on new reactions
- **`reaction.service.ts`**: `ReactionsGateway` is now injected and `broadcastReactionAdded` is called only for genuinely new reactions — not for idempotent duplicates or emoji updates. This ensures clients receive exactly one canonical event per reaction.

### 4. Frontend API contract fix
- **`reactions.ts`**: The frontend was sending `{ type: "like" } ` but the backend expects `{ emoji: "👍" }`. Now uses `REACTION_EMOJI_MAP` to translate `ReactionType` → emoji before sending.

### 5. Tests
- **`reaction.service.spec.ts`**: Added tests for:
  - Race condition: unique violation returns existing reaction
  - Non-unique QueryFailedErrors are re-thrown
  - WebSocket broadcast fires for new reactions only
  - WebSocket broadcast suppressed for idempotent / update paths
- All existing tests updated to provide the new `ReactionsGateway` dependency.

## How to verify

```bash
npm run test -- --runTestsByPath src/reaction/reaction.service.spec.ts
```

## Files changed

| File | Change |
|------|--------|
| `src/migrations/20260725000003-add-unique-reaction-constraint.ts` | New migration — composite unique index |
| `src/reaction/entities/reaction.entity.ts` | `@Index` decorator for unique constraint |
| `src/reaction/reaction.service.ts` | Race-condition handling, gateway injection, broadcast logic |
| `src/reaction/reaction.service.spec.ts` | New concurrency + broadcast tests |
| `xconfess-frontend/app/lib/api/reactions.ts` | Fix type→emoji translation |