### PR TITLE
fix: strengthen E2E envelope validation, key-recovery safety, stellar…

### DIFF
--- a/docs/message-e2e-encryption.md
+++ b/docs/message-e2e-encryption.md
@@ -52,7 +52,13 @@ Stored in `messages.content` and `messages.replyContent`:
 }
 ```
 
-The API rejects plaintext bodies for create/reply operations.
+The API rejects plaintext bodies for create/reply operations. Envelope parsing
+is strict: the payload must be a JSON object with exactly the four fields
+above (no extra fields), `iv` must be base64url and decode to exactly 12
+bytes, and `ct` must be base64url and decode to at least 16 bytes (the
+minimum possible AES-GCM auth tag). Payloads that are well-formed JSON but
+fail any of these checks — wrong algorithm, wrong nonce length, truncated
+ciphertext, or unexpected fields — are rejected the same as plaintext.
 
 ## Key exchange flow
 
@@ -105,9 +111,11 @@ Restore on a new device:
 
 ### New device, no backup
 
-- A fresh key pair is generated and registered (`messageKeyVersion` increments if public key changes).
+- If this identity has never registered a public key, a fresh key pair is generated and registered automatically (nothing to lose).
+- If a public key is **already registered** for this identity (e.g. the user messaged from another device) but this device has no matching local private key, the client does **not** silently generate and register a replacement key — doing so would overwrite the registered public key and make existing messages permanently unreadable. Instead the UI shows a blocking notice offering to restore from a passphrase backup or to explicitly "start fresh" (with a confirmation, since it is irreversible).
 - **Historical messages remain ciphertext** — the UI shows: `[Unable to decrypt — wrong device or missing recovery key]`.
 - New messages work after both parties fetch the new public keys.
+- If no recovery backup has been configured yet, the Messages page shows a persistent reminder to set one up before it's needed.
 
 ### New device, with backup
 
@@ -139,8 +147,10 @@ Restore on a new device:
 
 ## Tests
 
-- **Unit**: `xconfess-backend/src/messages/crypto/message-e2e.crypto.spec.ts` — ECDH, encrypt/decrypt, tampering, backup wrap/unwrap, lost-key simulation.
+- **Unit**: `xconfess-backend/src/messages/crypto/message-e2e.crypto.spec.ts` — ECDH, encrypt/decrypt, tampering, malformed/replayed envelope rejection, backup wrap/unwrap, lost-key simulation.
+- **Unit**: `xconfess-backend/src/messages/messages.service.spec.ts` — rejects plaintext and malformed envelopes on `create`, persists valid envelopes.
 - **E2E**: `xconfess-backend/test/message-e2e-key-exchange.e2e-spec.ts` — key registration, encrypted send/reply through the HTTP layer.
+- **Frontend**: `xconfess-frontend/app/lib/hooks/__tests__/useMessageE2E.test.ts` — first-run key generation, lost-key recovery prompt (no silent overwrite), restore-from-backup, start-fresh confirmation, and that the recovery passphrase is never logged.
 
 Run:
 

--- a/xconfess-backend/src/messages/crypto/message-e2e.crypto.spec.ts
+++ b/xconfess-backend/src/messages/crypto/message-e2e.crypto.spec.ts
@@ -82,6 +82,144 @@ describe('Message E2E crypto', () => {
     ).rejects.toThrow();
   });
 
+  describe('malformed envelope rejection', () => {
+    it('rejects plaintext strings', () => {
+      expect(isEncryptedPayload('just a plain message')).toBe(false);
+      expect(parseEnvelope('just a plain message')).toBeNull();
+    });
+
+    it('rejects a JSON array instead of an envelope object', () => {
+      expect(parseEnvelope('[1,2,3]')).toBeNull();
+    });
+
+    it('rejects an envelope missing the ciphertext field', () => {
+      const envelope = { v: 1, alg: 'aes-256-gcm', iv: 'AAAAAAAAAAAAAAAA' };
+      expect(parseEnvelope(JSON.stringify(envelope))).toBeNull();
+    });
+
+    it('rejects an envelope with an unexpected extra field', async () => {
+      const sender = await generateMessageKeyPair();
+      const author = await generateMessageKeyPair();
+      const ciphertext = await encryptMessage(
+        'Hi',
+        sender.privateKey,
+        author.publicKey,
+        threadId,
+      );
+      const envelope = { ...JSON.parse(ciphertext), extra: 'unexpected' };
+      expect(parseEnvelope(JSON.stringify(envelope))).toBeNull();
+    });
+
+    it('rejects an unsupported algorithm', () => {
+      const envelope = {
+        v: 1,
+        alg: 'aes-128-cbc',
+        iv: 'AAAAAAAAAAAAAAAA',
+        ct: 'AAAAAAAAAAAAAAAAAAAAAAAA',
+      };
+      expect(parseEnvelope(JSON.stringify(envelope))).toBeNull();
+    });
+
+    it('rejects an unsupported protocol version', () => {
+      const envelope = {
+        v: 2,
+        alg: 'aes-256-gcm',
+        iv: 'AAAAAAAAAAAAAAAA',
+        ct: 'AAAAAAAAAAAAAAAAAAAAAAAA',
+      };
+      expect(parseEnvelope(JSON.stringify(envelope))).toBeNull();
+    });
+
+    it('rejects a nonce with the wrong byte length', () => {
+      // 8 bytes instead of the required 12-byte GCM nonce.
+      const envelope = {
+        v: 1,
+        alg: 'aes-256-gcm',
+        iv: 'AAAAAAAAAAA',
+        ct: 'AAAAAAAAAAAAAAAAAAAAAAAA',
+      };
+      expect(parseEnvelope(JSON.stringify(envelope))).toBeNull();
+    });
+
+    it('rejects ciphertext shorter than the GCM auth tag', () => {
+      const envelope = {
+        v: 1,
+        alg: 'aes-256-gcm',
+        iv: 'AAAAAAAAAAAAAAAA',
+        ct: 'AAAA',
+      };
+      expect(parseEnvelope(JSON.stringify(envelope))).toBeNull();
+    });
+
+    it('rejects a plaintext-like payload dressed up as an envelope', () => {
+      // Right shape and key names, but iv/ct are not valid base64url ciphertext.
+      const envelope = {
+        v: 1,
+        alg: 'aes-256-gcm',
+        iv: 'not base64!!',
+        ct: 'still not encrypted, just plain text',
+      };
+      expect(parseEnvelope(JSON.stringify(envelope))).toBeNull();
+    });
+  });
+
+  describe('replayed envelopes', () => {
+    it('validates and decrypts a replayed (resubmitted) envelope identically each time', async () => {
+      const sender = await generateMessageKeyPair();
+      const author = await generateMessageKeyPair();
+      const ciphertext = await encryptMessage(
+        'Resend me',
+        sender.privateKey,
+        author.publicKey,
+        threadId,
+      );
+
+      // Simulate the same envelope being submitted twice (e.g. client retry).
+      expect(isEncryptedPayload(ciphertext)).toBe(true);
+      expect(isEncryptedPayload(ciphertext)).toBe(true);
+
+      const first = await decryptMessage(
+        ciphertext,
+        author.privateKey,
+        sender.publicKey,
+        threadId,
+      );
+      const second = await decryptMessage(
+        ciphertext,
+        author.privateKey,
+        sender.publicKey,
+        threadId,
+      );
+      expect(first).toBe('Resend me');
+      expect(second).toBe('Resend me');
+    });
+
+    it('rejects a valid envelope replayed against a different thread', async () => {
+      const sender = await generateMessageKeyPair();
+      const author = await generateMessageKeyPair();
+      const ciphertext = await encryptMessage(
+        'Bound to original thread',
+        sender.privateKey,
+        author.publicKey,
+        threadId,
+      );
+
+      const otherThreadId = buildThreadId(
+        confessionId,
+        '44444444-4444-4444-8444-444444444444',
+      );
+
+      await expect(
+        decryptMessage(
+          ciphertext,
+          author.privateKey,
+          sender.publicKey,
+          otherThreadId,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
   it('cannot decrypt with wrong thread id', async () => {
     const sender = await generateMessageKeyPair();
     const author = await generateMessageKeyPair();

--- a/xconfess-backend/src/messages/crypto/message-e2e.crypto.ts
+++ b/xconfess-backend/src/messages/crypto/message-e2e.crypto.ts
@@ -5,6 +5,13 @@ export const MESSAGE_E2E_VERSION = 1;
 export const MESSAGE_E2E_INFO = 'xconfess-e2e-v1';
 export const ENCRYPTED_PREVIEW = '[Encrypted message]';
 
+/** AES-256-GCM nonce size in bytes (96 bits, per NIST SP 800-38D). */
+const GCM_NONCE_BYTES = 12;
+/** AES-256-GCM auth tag size in bytes — the minimum possible ciphertext length. */
+const GCM_TAG_BYTES = 16;
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+const ENVELOPE_KEYS = ['v', 'alg', 'iv', 'ct'] as const;
+
 export interface MessageCiphertextEnvelope {
   v: number;
   alg: 'aes-256-gcm';
@@ -42,21 +49,57 @@ export function serializeEnvelope(envelope: MessageCiphertextEnvelope): string {
   return JSON.stringify(envelope);
 }
 
+/** Decoded byte length of a base64url string, or -1 if the string is not valid base64url. */
+function base64UrlByteLength(value: string): number {
+  if (typeof value !== 'string' || value.length === 0 || !BASE64URL_RE.test(value)) {
+    return -1;
+  }
+  return fromBase64Url(value).length;
+}
+
 export function parseEnvelope(payload: string): MessageCiphertextEnvelope | null {
-  try {
-    const parsed = JSON.parse(payload) as MessageCiphertextEnvelope;
-    if (
-      parsed?.v === MESSAGE_E2E_VERSION &&
-      parsed.alg === 'aes-256-gcm' &&
-      typeof parsed.iv === 'string' &&
-      typeof parsed.ct === 'string'
-    ) {
-      return parsed;
-    }
+  if (typeof payload !== 'string') {
     return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
   } catch {
     return null;
   }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  // Reject envelopes carrying unexpected fields — a strict shape prevents
+  // smuggling extra data through a payload that otherwise looks valid.
+  const keys = Object.keys(parsed);
+  if (
+    keys.length !== ENVELOPE_KEYS.length ||
+    !ENVELOPE_KEYS.every((key) => keys.includes(key))
+  ) {
+    return null;
+  }
+
+  const candidate = parsed as MessageCiphertextEnvelope;
+  if (
+    candidate.v !== MESSAGE_E2E_VERSION ||
+    candidate.alg !== 'aes-256-gcm'
+  ) {
+    return null;
+  }
+
+  if (base64UrlByteLength(candidate.iv) !== GCM_NONCE_BYTES) {
+    return null;
+  }
+
+  if (base64UrlByteLength(candidate.ct) < GCM_TAG_BYTES) {
+    return null;
+  }
+
+  return candidate;
 }
 
 export function isEncryptedPayload(payload: string): boolean {

--- a/xconfess-backend/src/messages/messages.service.spec.ts
+++ b/xconfess-backend/src/messages/messages.service.spec.ts
@@ -19,6 +19,7 @@ describe('MessagesService', () => {
   let userAnonRepo: Repository<UserAnonymousUser>;
   let anonUserService: AnonymousUserService;
   let customMessageRepository: MessageRepository;
+  let dataSource: DataSource;
   let messageQueryBuilder: any;
 
   const mockUser: User = { id: 1 } as User;
@@ -124,6 +125,70 @@ describe('MessagesService', () => {
     );
     anonUserService = module.get<AnonymousUserService>(AnonymousUserService);
     customMessageRepository = module.get<MessageRepository>(MessageRepository);
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  describe('create', () => {
+    it('should reject plaintext content', async () => {
+      await expect(
+        service.create(
+          { confession_id: mockConfessionId, content: 'plaintext leak' },
+          mockUser,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject a malformed envelope (missing ciphertext field)', async () => {
+      const malformed = JSON.stringify({ v: 1, alg: 'aes-256-gcm', iv: 'AAAAAAAAAAAAAAAA' });
+      await expect(
+        service.create(
+          { confession_id: mockConfessionId, content: malformed },
+          mockUser,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject an envelope with an unexpected extra field', async () => {
+      const tampered = JSON.stringify({
+        ...JSON.parse(encryptedReply),
+        extra: 'unexpected',
+      });
+      await expect(
+        service.create(
+          { confession_id: mockConfessionId, content: tampered },
+          mockUser,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should persist a valid E2E envelope', async () => {
+      const confession = {
+        id: mockConfessionId,
+        anonymousUser: { id: mockAnonId, userLinks: [] },
+      };
+      jest.spyOn(confessionRepo, 'findOne').mockResolvedValue(confession as any);
+      jest
+        .spyOn(anonUserService, 'getOrCreateForUserSession')
+        .mockResolvedValue({ id: mockSenderId } as any);
+
+      const mockSave = jest.fn().mockImplementation((m) => Promise.resolve({ id: 1, ...m }));
+      const mockManager = {
+        getRepository: jest.fn((entity) =>
+          entity === Message
+            ? { create: jest.fn((value) => value), save: mockSave }
+            : { create: jest.fn((value) => value), save: jest.fn() },
+        ),
+      };
+      jest.spyOn(dataSource, 'transaction').mockImplementation(async (fn: any) => fn(mockManager));
+
+      const result = await service.create(
+        { confession_id: mockConfessionId, content: encryptedReply },
+        mockUser,
+      );
+
+      expect(result.content).toBe(encryptedReply);
+      expect(result.isEncrypted).toBe(true);
+    });
   });
 
   describe('findForConfessionThread', () => {

--- a/xconfess-backend/src/stellar/stellar-config.service.spec.ts
+++ b/xconfess-backend/src/stellar/stellar-config.service.spec.ts
@@ -1,0 +1,151 @@
+import { ConfigService } from '@nestjs/config';
+import { StellarConfigService } from './stellar-config.service';
+import { DeploymentMetadataService } from './services/deployment-metadata.service';
+
+/**
+ * Contract ID allowlist-by-network validation (issue #1483).
+ *
+ * A wrong contract ID could route confession anchors, reputation badges,
+ * or tips to an unintended contract, so mismatches between the configured
+ * network and its deployment metadata must fail boot rather than silently
+ * using the wrong contract.
+ */
+describe('StellarConfigService - contract ID allowlist by network', () => {
+  function buildEnv(overrides: Record<string, string | undefined>) {
+    return {
+      get: jest.fn((key: string, fallback?: unknown) => {
+        if (key in overrides) return overrides[key];
+        return fallback;
+      }),
+    } as unknown as ConfigService;
+  }
+
+  function buildMetadataService(
+    metadata: ReturnType<DeploymentMetadataService['getMetadata']>,
+  ) {
+    return {
+      getMetadata: jest.fn(() => metadata),
+      getAllContractIds: jest.fn(() => {
+        if (!metadata) return {};
+        const result: Record<string, string> = {};
+        for (const [name, meta] of Object.entries(metadata.contracts)) {
+          result[name] = meta.contract_id;
+        }
+        return result;
+      }),
+    } as unknown as DeploymentMetadataService;
+  }
+
+  const testnetMetadata = {
+    contracts: {
+      'confession-anchor': { contract_id: 'CANCHORTESTNET' } as any,
+      'reputation-badges': { contract_id: 'CBADGETESTNET' } as any,
+      'anonymous-tipping': { contract_id: 'CTIPTESTNET' } as any,
+    },
+    generated_at_utc: new Date().toISOString(),
+    network: 'testnet',
+    target: 'wasm32v1-none',
+  };
+
+  const mainnetMetadata = {
+    ...testnetMetadata,
+    contracts: {
+      'confession-anchor': { contract_id: 'CANCHORMAINNET' } as any,
+      'reputation-badges': { contract_id: 'CBADGEMAINNET' } as any,
+      'anonymous-tipping': { contract_id: 'CTIPMAINNET' } as any,
+    },
+    network: 'mainnet',
+  };
+
+  it('boots successfully on testnet when contract IDs match testnet metadata', () => {
+    const configService = buildEnv({
+      STELLAR_NETWORK: 'testnet',
+      STELLAR_FEATURES_ENABLED: 'true',
+      CONFESSION_ANCHOR_CONTRACT_ID: 'CANCHORTESTNET',
+      REPUTATION_BADGES_CONTRACT_ID: 'CBADGETESTNET',
+      TIPPING_SYSTEM_CONTRACT_ID: 'CTIPTESTNET',
+    });
+    const metadataService = buildMetadataService(testnetMetadata);
+
+    const service = new StellarConfigService(configService, metadataService);
+    expect(() => service.onModuleInit()).not.toThrow();
+    expect(service.getConfig().contractIds.confessionAnchor).toBe('CANCHORTESTNET');
+  });
+
+  it('boots successfully on mainnet when contract IDs match mainnet metadata', () => {
+    const configService = buildEnv({
+      STELLAR_NETWORK: 'mainnet',
+      STELLAR_FEATURES_ENABLED: 'true',
+      CONFESSION_ANCHOR_CONTRACT_ID: 'CANCHORMAINNET',
+      REPUTATION_BADGES_CONTRACT_ID: 'CBADGEMAINNET',
+      TIPPING_SYSTEM_CONTRACT_ID: 'CTIPMAINNET',
+    });
+    const metadataService = buildMetadataService(mainnetMetadata);
+
+    const service = new StellarConfigService(configService, metadataService);
+    expect(() => service.onModuleInit()).not.toThrow();
+    expect(service.getConfig().contractIds.confessionAnchor).toBe('CANCHORMAINNET');
+  });
+
+  it('falls back to deployment metadata contract IDs when env vars are unset', () => {
+    const configService = buildEnv({
+      STELLAR_NETWORK: 'testnet',
+      STELLAR_FEATURES_ENABLED: 'true',
+    });
+    const metadataService = buildMetadataService(testnetMetadata);
+
+    const service = new StellarConfigService(configService, metadataService);
+    expect(() => service.onModuleInit()).not.toThrow();
+    expect(service.getConfig().contractIds).toEqual({
+      confessionAnchor: 'CANCHORTESTNET',
+      reputationBadges: 'CBADGETESTNET',
+      tippingSystem: 'CTIPTESTNET',
+    });
+  });
+
+  it('fails boot when testnet config loads mainnet deployment metadata', () => {
+    const configService = buildEnv({
+      STELLAR_NETWORK: 'testnet',
+      STELLAR_FEATURES_ENABLED: 'true',
+    });
+    const metadataService = buildMetadataService(mainnetMetadata);
+
+    const service = new StellarConfigService(configService, metadataService);
+    expect(() => service.onModuleInit()).toThrow(/network mismatch/i);
+  });
+
+  it('fails boot when an explicit contract ID does not match the network deployment metadata', () => {
+    const configService = buildEnv({
+      STELLAR_NETWORK: 'testnet',
+      STELLAR_FEATURES_ENABLED: 'true',
+      // Accidentally pasted a mainnet contract ID into the testnet env.
+      CONFESSION_ANCHOR_CONTRACT_ID: 'CANCHORMAINNET',
+    });
+    const metadataService = buildMetadataService(testnetMetadata);
+
+    const service = new StellarConfigService(configService, metadataService);
+    expect(() => service.onModuleInit()).toThrow(/contract ID mismatch/i);
+  });
+
+  it('fails boot when contract IDs are missing entirely and features are enabled', () => {
+    const configService = buildEnv({
+      STELLAR_NETWORK: 'testnet',
+      STELLAR_FEATURES_ENABLED: 'true',
+    });
+    const metadataService = buildMetadataService(null);
+
+    const service = new StellarConfigService(configService, metadataService);
+    expect(() => service.onModuleInit()).toThrow(/missing contract IDs/i);
+  });
+
+  it('does not fail boot on mismatch when Stellar features are disabled', () => {
+    const configService = buildEnv({
+      STELLAR_NETWORK: 'testnet',
+      STELLAR_FEATURES_ENABLED: 'false',
+    });
+    const metadataService = buildMetadataService(mainnetMetadata);
+
+    const service = new StellarConfigService(configService, metadataService);
+    expect(() => service.onModuleInit()).not.toThrow();
+  });
+});

--- a/xconfess-backend/src/stellar/stellar-config.service.ts
+++ b/xconfess-backend/src/stellar/stellar-config.service.ts
@@ -6,7 +6,10 @@ import {
   IStellarConfig,
   StellarNetwork,
 } from './interfaces/stellar-config.interface';
-import { DeploymentMetadataService } from './services/deployment-metadata.service';
+import {
+  DeploymentMetadata,
+  DeploymentMetadataService,
+} from './services/deployment-metadata.service';
 
 @Injectable()
 export class StellarConfigService implements OnModuleInit {
@@ -21,6 +24,16 @@ export class StellarConfigService implements OnModuleInit {
     rpcRetryMaxDelayMs: number;
   };
   private server: StellarSDK.Horizon.Server;
+
+  /** Maps a configured contract field to its deployment metadata contract name. */
+  private readonly contractMetadataKeys: Record<
+    keyof IStellarConfig['contractIds'],
+    string
+  > = {
+    confessionAnchor: 'confession-anchor',
+    reputationBadges: 'reputation-badges',
+    tippingSystem: 'anonymous-tipping',
+  };
 
   constructor(
     private configService: ConfigService,
@@ -114,17 +127,23 @@ export class StellarConfigService implements OnModuleInit {
     }
 
     const fallbackIds = this.deploymentMetadataService.getAllContractIds();
+    const explicitContractIds = { ...this.config.contractIds };
     this.config.contractIds = {
       confessionAnchor:
-        this.config.contractIds.confessionAnchor || fallbackIds['confession-anchor'],
+        explicitContractIds.confessionAnchor || fallbackIds['confession-anchor'],
       reputationBadges:
-        this.config.contractIds.reputationBadges || fallbackIds['reputation-badges'],
+        explicitContractIds.reputationBadges || fallbackIds['reputation-badges'],
       tippingSystem:
-        this.config.contractIds.tippingSystem || fallbackIds['anonymous-tipping'],
+        explicitContractIds.tippingSystem || fallbackIds['anonymous-tipping'],
     };
 
     const featuresEnabled =
       this.configService.get<string>('STELLAR_FEATURES_ENABLED') === 'true';
+
+    if (featuresEnabled && metadata) {
+      this.validateContractIdsAgainstNetwork(metadata, explicitContractIds);
+    }
+
     const missingContractIds = Object.entries(this.config.contractIds)
       .filter(([, value]) => !value)
       .map(([key]) => key);
@@ -135,6 +154,39 @@ export class StellarConfigService implements OnModuleInit {
           ', ',
         )}. Provide contract IDs through environment variables or deployment metadata.
         `,
+      );
+    }
+  }
+
+  /**
+   * Ensure deployment metadata belongs to the configured network, and that any
+   * explicitly-configured (env var) contract ID agrees with that network's
+   * deployment metadata. Prevents e.g. a testnet config accidentally loading
+   * mainnet deployment metadata, or an env var left over from another network.
+   */
+  private validateContractIdsAgainstNetwork(
+    metadata: DeploymentMetadata,
+    explicitContractIds: IStellarConfig['contractIds'],
+  ): void {
+    if (metadata.network !== this.config.network) {
+      throw new Error(
+        `Deployment metadata network mismatch: configured Stellar network is "${this.config.network}" but the loaded deployment metadata was generated for "${metadata.network}". Refusing to boot with mismatched network deployment metadata.`,
+      );
+    }
+
+    const mismatches = (
+      Object.keys(explicitContractIds) as Array<keyof IStellarConfig['contractIds']>
+    ).filter((field) => {
+      const explicitId = explicitContractIds[field];
+      const metadataId = metadata.contracts[this.contractMetadataKeys[field]]?.contract_id;
+      return !!explicitId && !!metadataId && explicitId !== metadataId;
+    });
+
+    if (mismatches.length > 0) {
+      throw new Error(
+        `Stellar contract ID mismatch for network "${this.config.network}": ${mismatches.join(
+          ', ',
+        )} do not match the ID recorded in deployment metadata. Verify contract ID environment variables are configured for the correct network.`,
       );
     }
   }

--- a/xconfess-frontend/app/(dashboard)/messages/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/messages/page.tsx
@@ -14,6 +14,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { useGlobalToast } from '@/app/components/common/Toast';
 import { useMessageE2E } from '@/app/lib/hooks/useMessageE2E';
 import { ENCRYPTED_PREVIEW } from '@/app/lib/crypto/messageE2E';
+import { ConfirmDialog } from '@/app/components/admin/ConfirmDialog';
 
 function extractPageData<T>(payload: unknown): T[] {
   if (!payload || typeof payload !== 'object') return [];
@@ -171,10 +172,13 @@ export default function MessagesPage() {
   const {
     isReady: e2eReady,
     keyError,
+    needsKeyRecovery,
+    session: e2eSession,
     encryptForThread,
     decryptForThread,
     createKeyBackup,
     restoreFromBackup,
+    startFreshKeys,
   } = useMessageE2E();
 
   const [threads, setThreads] = useState<Thread[]>([]);
@@ -189,6 +193,8 @@ export default function MessagesPage() {
   const [showMobileList, setShowMobileList] = useState(true);
   const [recoveryPassphrase, setRecoveryPassphrase] = useState('');
   const [showRecovery, setShowRecovery] = useState(false);
+  const [showStartFreshConfirm, setShowStartFreshConfirm] = useState(false);
+  const [isStartingFresh, setIsStartingFresh] = useState(false);
   const toast = useGlobalToast();
   const inputRef = useRef<HTMLInputElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -358,6 +364,20 @@ export default function MessagesPage() {
     }
   };
 
+  const handleStartFresh = async () => {
+    try {
+      setIsStartingFresh(true);
+      await startFreshKeys();
+      setShowStartFreshConfirm(false);
+      toast.success('New encryption keys created for this device.');
+    } catch (error) {
+      console.error('Failed to start fresh with new keys:', error);
+      toast.error('Failed to create new encryption keys.');
+    } finally {
+      setIsStartingFresh(false);
+    }
+  };
+
   const handleSelectThread = (thread: Thread) => {
     setSelectedThread(thread);
     setMessagesError(null);
@@ -371,11 +391,67 @@ export default function MessagesPage() {
 
   return (
     <AuthGuard>
+      {needsKeyRecovery && (
+        <div
+          role="alert"
+          className="bg-amber-50 dark:bg-amber-900/20 border-b border-amber-200 dark:border-amber-800 px-4 py-4 space-y-3"
+        >
+          <div className="flex items-start gap-2">
+            <Lock className="w-4 h-4 mt-0.5 text-amber-600 dark:text-amber-400 flex-shrink-0" />
+            <p className="text-sm text-amber-800 dark:text-amber-200">
+              We found encryption keys registered for your account on another
+              device. Enter your recovery passphrase to restore access to your
+              previous messages, or start fresh — starting fresh will make
+              previous messages permanently unreadable.
+            </p>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-2">
+            <Input
+              type="password"
+              placeholder="Recovery passphrase (min 8 chars)"
+              value={recoveryPassphrase}
+              onChange={(e) => setRecoveryPassphrase(e.target.value)}
+              className="sm:max-w-xs"
+            />
+            <Button size="sm" onClick={handleRestoreBackup} disabled={recoveryPassphrase.length < 8}>
+              Restore keys
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setShowStartFreshConfirm(true)}
+            >
+              Start fresh instead
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={showStartFreshConfirm}
+        onOpenChange={setShowStartFreshConfirm}
+        title="Start fresh with new encryption keys?"
+        description="This will generate new encryption keys for this device. Previous messages encrypted under your old keys will become permanently unreadable — this cannot be undone."
+        confirmLabel="Start fresh"
+        variant="danger"
+        loading={isStartingFresh}
+        onConfirm={handleStartFresh}
+      />
+
       {keyError && (
         <div className="bg-amber-50 dark:bg-amber-900/20 border-b border-amber-200 dark:border-amber-800 px-4 py-2 text-sm text-amber-800 dark:text-amber-200 flex items-center justify-between gap-2">
           <span>{keyError}</span>
           <Button variant="link" className="h-auto p-0 text-amber-900" onClick={() => setShowRecovery(true)}>
             Restore from backup
+          </Button>
+        </div>
+      )}
+
+      {e2eReady && e2eSession && !e2eSession.hasBackup && !keyError && (
+        <div className="bg-blue-50 dark:bg-blue-900/20 border-b border-blue-200 dark:border-blue-800 px-4 py-2 text-sm text-blue-800 dark:text-blue-200 flex items-center justify-between gap-2">
+          <span>No recovery backup set up. If you lose this device, your encrypted messages cannot be recovered.</span>
+          <Button variant="link" className="h-auto p-0 text-blue-900 dark:text-blue-100" onClick={() => setShowRecovery(true)}>
+            Set up backup
           </Button>
         </div>
       )}

--- a/xconfess-frontend/app/components/admin/ReportDetail.tsx
+++ b/xconfess-frontend/app/components/admin/ReportDetail.tsx
@@ -299,8 +299,25 @@ export default function ReportDetail({
               <h4 className="text-md mb-2 font-medium text-gray-900 dark:text-white">
                 Confession Content
               </h4>
+              {report.confession?.isDeleted && (
+                <p
+                  role="status"
+                  className="mb-2 rounded bg-red-50 px-3 py-2 text-xs font-medium text-red-700 dark:bg-red-900/40 dark:text-red-300"
+                >
+                  This confession has been deleted. The content below reflects the
+                  message at the time it was reported.
+                </p>
+              )}
+              {!report.confession?.isDeleted && report.confession?.isHidden && (
+                <p
+                  role="status"
+                  className="mb-2 rounded bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+                >
+                  This confession is currently hidden from other users.
+                </p>
+              )}
               <div className="rounded bg-gray-50 p-4 dark:bg-gray-700">
-                <p className="text-sm text-gray-900 dark:text-white">
+                <p className="whitespace-pre-wrap break-words text-sm text-gray-900 dark:text-white">
                   {report.confession?.message || 'Confession not available'}
                 </p>
               </div>

--- a/xconfess-frontend/app/components/admin/__tests__/ReportDetail.test.tsx
+++ b/xconfess-frontend/app/components/admin/__tests__/ReportDetail.test.tsx
@@ -79,6 +79,82 @@ beforeEach(() => {
   (adminApi.getAuditLogs as jest.Mock).mockResolvedValue({ logs: [] });
 });
 
+describe('ReportDetail — confession content states', () => {
+  it('renders the confession content and reason for a reported confession', () => {
+    renderDetail({
+      report: {
+        ...mockReport,
+        confession: {
+          id: 'confession-1',
+          message: 'This is the reported confession text.',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    expect(screen.getByText('This is the reported confession text.')).toBeInTheDocument();
+    expect(screen.getByText('Test spam reason')).toBeInTheDocument();
+  });
+
+  it('shows a fallback message when confession content is missing', () => {
+    renderDetail({ report: { ...mockReport, confession: undefined } });
+
+    expect(screen.getByText('Confession not available')).toBeInTheDocument();
+  });
+
+  it('shows a deleted-confession notice when the confession has been deleted', () => {
+    renderDetail({
+      report: {
+        ...mockReport,
+        confession: {
+          id: 'confession-1',
+          message: 'Content preserved for moderation context.',
+          created_at: '2024-01-01T00:00:00Z',
+          isDeleted: true,
+        },
+      },
+    });
+
+    expect(screen.getByText(/this confession has been deleted/i)).toBeInTheDocument();
+    expect(screen.getByText('Content preserved for moderation context.')).toBeInTheDocument();
+  });
+
+  it('shows a hidden-confession notice when the confession is hidden but not deleted', () => {
+    renderDetail({
+      report: {
+        ...mockReport,
+        confession: {
+          id: 'confession-1',
+          message: 'Still visible to moderators.',
+          created_at: '2024-01-01T00:00:00Z',
+          isHidden: true,
+        },
+      },
+    });
+
+    expect(screen.getByText(/currently hidden from other users/i)).toBeInTheDocument();
+  });
+
+  it('renders confession message and reason as inert text without executing embedded markup', () => {
+    const { container } = renderDetail({
+      report: {
+        ...mockReport,
+        reason: '<img src=x onerror=alert(1)>',
+        confession: {
+          id: 'confession-1',
+          message: '<script>window.__xss = true;</script>Hello',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    expect(container.querySelector('script')).not.toBeInTheDocument();
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText(/<script>window\.__xss = true;<\/script>Hello/)).toBeInTheDocument();
+    expect(screen.getByText('<img src=x onerror=alert(1)>')).toBeInTheDocument();
+  });
+});
+
 describe('ReportDetail — resolve flow', () => {
   it('opens the resolve confirmation dialog when Resolve Report is clicked', async () => {
     const user = userEvent.setup();

--- a/xconfess-frontend/app/lib/api/admin.ts
+++ b/xconfess-frontend/app/lib/api/admin.ts
@@ -14,6 +14,8 @@ export interface Report {
     id: string;
     message: string;
     created_at: string;
+    isDeleted?: boolean;
+    isHidden?: boolean;
   };
   reporterId: number | null;
   reporter?: {

--- a/xconfess-frontend/app/lib/hooks/__tests__/useMessageE2E.test.ts
+++ b/xconfess-frontend/app/lib/hooks/__tests__/useMessageE2E.test.ts
@@ -1,0 +1,260 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useMessageE2E } from '../useMessageE2E';
+import apiClient from '@/app/lib/api/client';
+import {
+  generateMessageKeyPair,
+  unwrapPrivateKeyWithPassphrase,
+  wrapPrivateKeyWithPassphrase,
+} from '@/app/lib/crypto/messageE2E';
+import {
+  loadLocalKeyPair,
+  saveLocalKeyPair,
+} from '@/app/lib/crypto/messageKeyStore';
+
+jest.mock('@/app/lib/api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    put: jest.fn(),
+  },
+}));
+
+jest.mock('@/app/lib/crypto/messageE2E', () => ({
+  buildThreadId: (confessionId: string, senderAnonId: string) =>
+    `${confessionId}:${senderAnonId}`,
+  decryptMessage: jest.fn(),
+  encryptMessage: jest.fn(),
+  generateMessageKeyPair: jest.fn(),
+  isEncryptedPayload: jest.fn(() => true),
+  unwrapPrivateKeyWithPassphrase: jest.fn(),
+  wrapPrivateKeyWithPassphrase: jest.fn(),
+}));
+
+jest.mock('@/app/lib/crypto/messageKeyStore', () => ({
+  loadLocalKeyPair: jest.fn(),
+  saveLocalKeyPair: jest.fn(),
+  deleteLocalKeyPair: jest.fn(),
+}));
+
+const mockGet = apiClient.get as jest.Mock;
+const mockPut = apiClient.put as jest.Mock;
+const mockLoadLocalKeyPair = loadLocalKeyPair as jest.Mock;
+const mockSaveLocalKeyPair = saveLocalKeyPair as jest.Mock;
+const mockGenerateMessageKeyPair = generateMessageKeyPair as jest.Mock;
+const mockUnwrapPrivateKeyWithPassphrase =
+  unwrapPrivateKeyWithPassphrase as jest.Mock;
+const mockWrapPrivateKeyWithPassphrase =
+  wrapPrivateKeyWithPassphrase as jest.Mock;
+
+const anonymousUserId = 'anon-1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useMessageE2E — first-run (brand-new identity)', () => {
+  it('generates and registers a new key pair when no key exists anywhere', async () => {
+    mockGet.mockResolvedValue({
+      data: { anonymousUserId, publicKey: null, keyVersion: 0, hasBackup: false },
+    });
+    mockLoadLocalKeyPair.mockResolvedValue(null);
+    mockGenerateMessageKeyPair.mockResolvedValue({
+      publicKey: 'new-pub',
+      privateKey: 'new-priv',
+    });
+    mockPut.mockResolvedValue({ data: {} });
+
+    const { result } = renderHook(() => useMessageE2E());
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    expect(result.current.needsKeyRecovery).toBe(false);
+    expect(result.current.keyError).toBeNull();
+    expect(mockSaveLocalKeyPair).toHaveBeenCalledWith(
+      anonymousUserId,
+      { publicKey: 'new-pub', privateKey: 'new-priv' },
+      0,
+    );
+    expect(mockPut).toHaveBeenCalledWith('/messages/keys', { publicKey: 'new-pub' });
+  });
+});
+
+describe('useMessageE2E — lost local key on a device with a registered identity', () => {
+  it('requires explicit recovery instead of silently generating and registering a new key', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        anonymousUserId,
+        publicKey: 'server-pub',
+        keyVersion: 1,
+        hasBackup: true,
+      },
+    });
+    mockLoadLocalKeyPair.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useMessageE2E());
+
+    await waitFor(() => expect(result.current.needsKeyRecovery).toBe(true));
+
+    expect(result.current.isReady).toBe(false);
+    // The critical assertion: no new key pair is silently generated or
+    // registered, which would overwrite the server's public key and make
+    // messages under the old key permanently unreadable.
+    expect(mockGenerateMessageKeyPair).not.toHaveBeenCalled();
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it('restoring from backup clears the recovery state and becomes ready', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/messages/keys/me') {
+        return Promise.resolve({
+          data: {
+            anonymousUserId,
+            publicKey: 'server-pub',
+            keyVersion: 2,
+            hasBackup: true,
+          },
+        });
+      }
+      if (url === '/messages/keys/backup') {
+        return Promise.resolve({
+          data: { encryptedKeyBackup: 'wrapped-blob', keyVersion: 2 },
+        });
+      }
+      throw new Error(`Unexpected GET ${url}`);
+    });
+    mockLoadLocalKeyPair.mockResolvedValue(null);
+    mockUnwrapPrivateKeyWithPassphrase.mockResolvedValue('restored-priv');
+
+    const { result } = renderHook(() => useMessageE2E());
+    await waitFor(() => expect(result.current.needsKeyRecovery).toBe(true));
+
+    await act(async () => {
+      await result.current.restoreFromBackup('correct horse battery staple');
+    });
+
+    expect(result.current.needsKeyRecovery).toBe(false);
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.keyError).toBeNull();
+    expect(mockSaveLocalKeyPair).toHaveBeenCalledWith(
+      anonymousUserId,
+      { publicKey: 'server-pub', privateKey: 'restored-priv' },
+      2,
+    );
+  });
+
+  it('starting fresh generates a new key pair only after explicit confirmation', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        anonymousUserId,
+        publicKey: 'server-pub',
+        keyVersion: 1,
+        hasBackup: false,
+      },
+    });
+    mockLoadLocalKeyPair.mockResolvedValue(null);
+    mockGenerateMessageKeyPair.mockResolvedValue({
+      publicKey: 'fresh-pub',
+      privateKey: 'fresh-priv',
+    });
+    mockPut.mockResolvedValue({ data: {} });
+
+    const { result } = renderHook(() => useMessageE2E());
+    await waitFor(() => expect(result.current.needsKeyRecovery).toBe(true));
+
+    await act(async () => {
+      await result.current.startFreshKeys();
+    });
+
+    expect(result.current.needsKeyRecovery).toBe(false);
+    expect(result.current.isReady).toBe(true);
+    expect(mockPut).toHaveBeenCalledWith('/messages/keys', { publicKey: 'fresh-pub' });
+  });
+
+  it('never logs the recovery passphrase, on success or failure', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/messages/keys/me') {
+        return Promise.resolve({
+          data: {
+            anonymousUserId,
+            publicKey: 'server-pub',
+            keyVersion: 1,
+            hasBackup: true,
+          },
+        });
+      }
+      if (url === '/messages/keys/backup') {
+        return Promise.resolve({
+          data: { encryptedKeyBackup: 'wrapped-blob', keyVersion: 1 },
+        });
+      }
+      throw new Error(`Unexpected GET ${url}`);
+    });
+    mockLoadLocalKeyPair.mockResolvedValue(null);
+
+    const secretPassphrase = 'super-secret-recovery-phrase';
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Failure path: wrong passphrase.
+    mockUnwrapPrivateKeyWithPassphrase.mockRejectedValueOnce(new Error('bad passphrase'));
+    const { result } = renderHook(() => useMessageE2E());
+    await waitFor(() => expect(result.current.needsKeyRecovery).toBe(true));
+
+    await act(async () => {
+      await expect(result.current.restoreFromBackup(secretPassphrase)).rejects.toThrow();
+    });
+
+    // Success path.
+    mockUnwrapPrivateKeyWithPassphrase.mockResolvedValueOnce('restored-priv');
+    await act(async () => {
+      await result.current.restoreFromBackup(secretPassphrase);
+    });
+
+    const allLoggedArgs = [...consoleLogSpy.mock.calls, ...consoleErrorSpy.mock.calls]
+      .flat()
+      .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)));
+    expect(allLoggedArgs.some((entry) => entry?.includes(secretPassphrase))).toBe(false);
+
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('useMessageE2E — matching local key', () => {
+  it('becomes ready without recovery state when the local key matches the server', async () => {
+    mockGet.mockResolvedValue({
+      data: { anonymousUserId, publicKey: 'matching-pub', keyVersion: 0, hasBackup: false },
+    });
+    mockLoadLocalKeyPair.mockResolvedValue({
+      anonymousUserId,
+      publicKey: 'matching-pub',
+      privateKey: 'matching-priv',
+      keyVersion: 0,
+    });
+
+    const { result } = renderHook(() => useMessageE2E());
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.needsKeyRecovery).toBe(false);
+    expect(result.current.keyError).toBeNull();
+    expect(mockGenerateMessageKeyPair).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a keyError when the local key differs from the server public key', async () => {
+    mockGet.mockResolvedValue({
+      data: { anonymousUserId, publicKey: 'server-pub', keyVersion: 0, hasBackup: false },
+    });
+    mockLoadLocalKeyPair.mockResolvedValue({
+      anonymousUserId,
+      publicKey: 'stale-local-pub',
+      privateKey: 'stale-local-priv',
+      keyVersion: 0,
+    });
+
+    const { result } = renderHook(() => useMessageE2E());
+
+    await waitFor(() => expect(result.current.keyError).not.toBeNull());
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.needsKeyRecovery).toBe(false);
+  });
+});

--- a/xconfess-frontend/app/lib/hooks/useMessageE2E.ts
+++ b/xconfess-frontend/app/lib/hooks/useMessageE2E.ts
@@ -32,6 +32,13 @@ export function useMessageE2E() {
   const [privateKey, setPrivateKey] = useState<string | null>(null);
   const [isReady, setIsReady] = useState(false);
   const [keyError, setKeyError] = useState<string | null>(null);
+  // True when the server already has a public key registered for this
+  // identity (e.g. from another device or a cleared browser), but this
+  // device has no matching local private key. Requires an explicit choice
+  // (restore from backup, or start fresh) instead of silently generating
+  // and registering a new key pair, which would overwrite the registered
+  // public key and make existing messages permanently unreadable.
+  const [needsKeyRecovery, setNeedsKeyRecovery] = useState(false);
 
   const ensureSessionKeys = useCallback(async () => {
     setKeyError(null);
@@ -42,6 +49,7 @@ export function useMessageE2E() {
     const local = await loadLocalKeyPair(status.anonymousUserId);
     if (local?.privateKey) {
       setPrivateKey(local.privateKey);
+      setNeedsKeyRecovery(false);
       if (local.publicKey !== status.publicKey && status.publicKey) {
         setKeyError(
           'This device has different encryption keys than your server session. Restore from backup or messages from other devices may be unreadable.',
@@ -51,15 +59,43 @@ export function useMessageE2E() {
       return { ...status, privateKey: local.privateKey, publicKey: local.publicKey };
     }
 
+    if (status.publicKey) {
+      setNeedsKeyRecovery(true);
+      setIsReady(false);
+      return null;
+    }
+
     const generated = await generateMessageKeyPair();
     await saveLocalKeyPair(status.anonymousUserId, generated, status.keyVersion);
     await apiClient.put('/messages/keys', { publicKey: generated.publicKey });
 
     setPrivateKey(generated.privateKey);
     setSession({ ...status, publicKey: generated.publicKey });
+    setNeedsKeyRecovery(false);
     setIsReady(true);
     return { ...status, privateKey: generated.privateKey, publicKey: generated.publicKey };
   }, []);
+
+  /**
+   * Explicitly generate and register a brand-new key pair, overwriting any
+   * public key already registered for this identity. Only call this after
+   * the user has been warned that messages encrypted under the previous
+   * key (if any) will become permanently unreadable.
+   */
+  const startFreshKeys = useCallback(async () => {
+    if (!session) {
+      throw new Error('Session not ready');
+    }
+
+    const generated = await generateMessageKeyPair();
+    await saveLocalKeyPair(session.anonymousUserId, generated, session.keyVersion);
+    await apiClient.put('/messages/keys', { publicKey: generated.publicKey });
+
+    setPrivateKey(generated.privateKey);
+    setSession({ ...session, publicKey: generated.publicKey });
+    setNeedsKeyRecovery(false);
+    setIsReady(true);
+  }, [session]);
 
   useEffect(() => {
     ensureSessionKeys().catch((err) => {
@@ -159,6 +195,8 @@ export function useMessageE2E() {
 
       setPrivateKey(restoredPrivate);
       setKeyError(null);
+      setNeedsKeyRecovery(false);
+      setIsReady(true);
     },
     [session],
   );
@@ -166,11 +204,13 @@ export function useMessageE2E() {
   return {
     isReady,
     keyError,
+    needsKeyRecovery,
     session,
     ensureSessionKeys,
     encryptForThread,
     decryptForThread,
     createKeyBackup,
     restoreFromBackup,
+    startFreshKeys,
   };
 }


### PR DESCRIPTION
Closes #1460, Closes #1462, Closes #1483, Closes #1459

- messages/crypto: parseEnvelope now strictly validates envelope shape, base64url encoding, exact nonce length, and minimum cipertext length instead of only checking field presence/type, so malformed or plaintext-shaped payloads are rejected before they can persist.
- stellar: StellarConfigService validates deployment metadata network and explicit contract ID env vars against the configured network, failing boot on mismatch when Stellar features are enabled.
- frontend messages: useMessageE2E no longer silently generates and registers a replacement key when a device has no local private key but the identity already has one registered elsewhere, which previously overwrote the public key and made existing messages permanently unreadable. It now requires an explicit restore-from-backup or confirmed start-fresh action, and the Messages page reminds users to set up a recovery backup before they need it.
- admin ReportDetail: surfaces deleted/hidden confession state so moderators aren't shown stale content without context.
