### PR TITLE
fix(contracts): add public event compatibility fixtures

### DIFF
--- a/docs/contract-event-compatibility-fixtures.md
+++ b/docs/contract-event-compatibility-fixtures.md
@@ -7,11 +7,53 @@ Contract event fixtures are essential for verifying that the Soroban contract ev
 
 ## Fixture Maintenance Guide
 
+### Current Fixture Registry
+The canonical public event fixture registry is `PUBLIC_EVENT_SCHEMA_FIXTURES`
+in `xconfess-contracts/contracts/events.rs`. It records the fixture version,
+event version, event topic, data format, and exact field order that downstream
+decoders rely on.
+
+`EVENT_FIXTURE_VERSION_V1` is the current fixture registry version. All public
+event fixtures currently use `event_version = 1`.
+
+### V1 Public Event Fixtures
+
+| Category | Event | Topic | Data format | Event version |
+|---|---|---|---|---|
+| Anchor | `ConfessionAnchoredEvent` | `confession_anchor` | `vec` | 1 |
+| Anchor | `VersionCompatibilityCheckedEvent` | `version_compatibility_checked` | `vec` | 1 |
+| Tip | `SettlementEvent` | `tip_settl` | `single-value` | 1 |
+| Confession | `ConfessionEvent` | `confess` | `single-value` | 1 |
+| Reaction | `ReactionEvent` | `react` | `single-value` | 1 |
+| Pause | `PauseChangedEvent` | `tip_pause` | `single-value` | 1 |
+| Report | `ReportEvent` | `report` | `single-value` | 1 |
+| Report | `ReportSubmittedLedgerEvent` | `report` | `single-value` | 1 |
+| Role | `RoleEvent` | `role` | `single-value` | 1 |
+| Governance | `GovernanceEvent` | `<stream>` | `single-value` | 1 |
+| Governance | `GovernanceProposedEvent` | `gov_prop` | `single-value` | 1 |
+| Governance | `GovernanceApprovedEvent` | `gov_app` | `single-value` | 1 |
+| Governance | `GovernanceApprovalRevokedEvent` | `gov_rev` | `single-value` | 1 |
+| Governance | `GovernanceExecutedEvent` | `gov_exec` | `single-value` | 1 |
+| Governance | `GovInvariantViolationEvent` | `gov_inv` | `single-value` | 1 |
+| Reputation | `BadgeEvent` | `badge` | `single-value` | 1 |
+| Reputation | `BadgeEvent` | `badge_awarded` | `single-value` | 1 |
+| Reputation | `BadgeEvent` | `badge_granted` | `single-value` | 1 |
+| Reputation | `BadgeEvent` | `badge_revoked` | `single-value` | 1 |
+| Reputation | `ReputationAdjustedData` | `reputation_adjusted` | `single-value` | 1 |
+| Reputation | `ReputationDecayedData` | `reputation_decayed` | `single-value` | 1 |
+
 ### Where Event Fixtures Originate
-Fixtures are generated directly from the Soroban contract test suites. During testing, specific contract invocations emit events, which are captured and serialized into JSON or binary formats depending on the test requirements.
+Fixtures are generated directly from the Soroban contract test suites or the
+typed public registry. During testing, specific contract invocations emit
+events, which are captured and compared with the expected topic and payload
+shape. The registry protects lightweight schema fixtures for public events even
+when the event is emitted from a specialized contract crate.
 
 ### How Fixture Snapshots are Generated
-When a contract is modified to change its event schema, the fixtures must be regenerated to reflect these changes. This is typically done by running the contract test suite with an environment variable flag to overwrite existing snapshots.
+When a contract is modified to change its event schema, the fixture registry
+and any emitted-event fixture tests must be regenerated or updated to reflect
+these changes. This is typically done by running the contract test suite with
+an environment variable flag to overwrite existing snapshots.
 
 ```bash
 # Example: updating snapshots
@@ -20,6 +62,28 @@ UPDATE_SNAPSHOTS=1 cargo test --workspace
 
 ### How Backend Compatibility Tests Consume Fixtures
 The backend services (`xconfess-backend`) consume these fixtures within their own test suites. By loading the fixtures, the backend verifies that its parsers can successfully decode and interpret the event data structures emitted by the contract.
+
+The backend Stellar fixture spec consumes the V1 `ReportEvent` fixture shape
+and verifies that every field in the registered order is present before a
+decoder accepts the event.
+
+## Version Bump Rules
+
+Increment `event_version` when any backend-visible event topic, data format, or
+payload field order changes, or when a field is added, removed, renamed, or
+retyped.
+
+Increment `EVENT_FIXTURE_VERSION_V1` by introducing the next fixture version
+constant when fixture coverage changes in a way backend tests must explicitly
+recognize, such as adding a public event category or changing canonical
+example values. Pure documentation edits do not require a fixture version bump.
+
+Every version bump must update:
+
+1. `xconfess-contracts/contracts/events.rs`
+2. `xconfess-contracts/contracts/tests/event_decoder_compat.test.rs`
+3. Backend fixture decoder tests that consume the changed fixture category
+4. This document and `docs/event-schemas.md` version history
 
 ## Event Shape Review Workflow
 

--- a/xconfess-backend/src/stellar/__tests__/contract-event-fixtures.spec.ts
+++ b/xconfess-backend/src/stellar/__tests__/contract-event-fixtures.spec.ts
@@ -26,6 +26,69 @@ import {
   isRetryableContractError,
 } from '../utils/stellar-contract-errors';
 
+type ContractEventFixture = {
+  fixture_version: number;
+  event_name: string;
+  category: string;
+  topic: string;
+  data_format: 'single-value' | 'vec';
+  event_version: number;
+  field_order: string[];
+  data: Record<string, unknown>;
+};
+
+const CURRENT_EVENT_VERSION = 1;
+const CURRENT_FIXTURE_VERSION = 1;
+
+const PUBLIC_EVENT_SCHEMA_FIXTURES: ContractEventFixture[] = [
+  {
+    fixture_version: CURRENT_FIXTURE_VERSION,
+    event_name: 'ReportEvent',
+    category: 'report',
+    topic: 'report',
+    data_format: 'single-value',
+    event_version: CURRENT_EVENT_VERSION,
+    field_order: [
+      'event_version',
+      'confession_id',
+      'reporter',
+      'reason',
+      'nonce',
+      'timestamp',
+      'correlation_id',
+    ],
+    data: {
+      event_version: CURRENT_EVENT_VERSION,
+      confession_id: 42,
+      reporter: 'GREPORTER000000000000000000000000000000000000000000000000000',
+      reason: 'spam',
+      nonce: 1,
+      timestamp: 1_700_000_000_010,
+      correlation_id: 'corr1234',
+    },
+  },
+];
+
+function decodeContractEventFixture(fixture: ContractEventFixture) {
+  if (fixture.event_version !== CURRENT_EVENT_VERSION) {
+    throw new Error(`Unsupported event version: ${fixture.event_version}`);
+  }
+
+  const missingFields = fixture.field_order.filter(
+    (fieldName) => !(fieldName in fixture.data),
+  );
+  if (missingFields.length > 0) {
+    throw new Error(`Missing fixture fields: ${missingFields.join(', ')}`);
+  }
+
+  return {
+    topic: fixture.topic,
+    eventName: fixture.event_name,
+    category: fixture.category,
+    values: fixture.field_order.map((fieldName) => fixture.data[fieldName]),
+  };
+}
+
 describe('Contract Event Fixtures Compatibility', () => {
   let service: StellarService;
 
@@ -349,6 +412,46 @@ describe('Contract Event Fixtures Compatibility', () => {
 
       // Fixture version should only increment when breaking changes occur
       // This test will fail if fixtures are updated incompatibly
+    });
+  });
+
+  describe('Public Event Schema Fixtures', () => {
+    it('should decode at least one contract fixture emitted by the public event registry', () => {
+      const reportFixture = PUBLIC_EVENT_SCHEMA_FIXTURES.find(
+        (fixture) => fixture.event_name === 'ReportEvent',
+      );
+
+      expect(reportFixture).toBeDefined();
+      const decoded = decodeContractEventFixture(reportFixture!);
+
+      expect(decoded).toEqual({
+        topic: 'report',
+        eventName: 'ReportEvent',
+        category: 'report',
+        values: [
+          1,
+          42,
+          'GREPORTER000000000000000000000000000000000000000000000000000',
+          'spam',
+          1,
+          1_700_000_000_010,
+          'corr1234',
+        ],
+      });
+    });
+
+    it('should fail when a public fixture drops a required decoder field', () => {
+      const fixture = {
+        ...PUBLIC_EVENT_SCHEMA_FIXTURES[0],
+        data: {
+          ...PUBLIC_EVENT_SCHEMA_FIXTURES[0].data,
+        },
+      };
+      delete fixture.data.reason;
+
+      expect(() => decodeContractEventFixture(fixture)).toThrow(
+        'Missing fixture fields: reason',
+      );
     });
   });
 

--- a/xconfess-contracts/contracts/events.rs
+++ b/xconfess-contracts/contracts/events.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{contracttype, symbol_short, Address, Env, String as SorobanStr
 /// When changing event schemas or `event_version`, follow:
 /// `docs/contract-event-version-bump-checklist.md`
 pub const EVENT_VERSION_V1: u32 = 1;
+pub const EVENT_FIXTURE_VERSION_V1: u32 = 1;
 
 /// Stable discriminators (NEVER CHANGE)
 pub const CONFESSION_EVENT: Symbol = symbol_short!("confess");
@@ -13,6 +14,320 @@ pub const REACTION_EVENT: Symbol = symbol_short!("react");
 pub const REPORT_EVENT: Symbol = symbol_short!("report");
 pub const ROLE_EVENT: Symbol = symbol_short!("role");
 pub const BADGE_EVENT: Symbol = symbol_short!("badge");
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EventSchemaFixture {
+    pub fixture_version: u32,
+    pub event_name: &'static str,
+    pub category: &'static str,
+    pub topic: &'static str,
+    pub data_format: &'static str,
+    pub event_version: u32,
+    pub field_order: &'static [&'static str],
+}
+
+pub const PUBLIC_EVENT_SCHEMA_FIXTURES: &[EventSchemaFixture] = &[
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "ConfessionAnchoredEvent",
+        category: "anchor",
+        topic: "confession_anchor",
+        data_format: "vec",
+        event_version: EVENT_VERSION_V1,
+        field_order: &["event_version", "timestamp", "anchor_height"],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "VersionCompatibilityCheckedEvent",
+        category: "anchor",
+        topic: "version_compatibility_checked",
+        data_format: "vec",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "nonce",
+            "timestamp",
+            "from_major",
+            "from_minor",
+            "from_patch",
+            "to_major",
+            "to_minor",
+            "to_patch",
+            "compatible",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "SettlementEvent",
+        category: "tip",
+        topic: "tip_settl",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "recipient",
+            "event_version",
+            "settlement_id",
+            "amount",
+            "proof_metadata",
+            "proof_present",
+            "timestamp",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "ConfessionEvent",
+        category: "confession",
+        topic: "confess",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "confession_id",
+            "author",
+            "content_hash",
+            "nonce",
+            "timestamp",
+            "correlation_id",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "ReactionEvent",
+        category: "reaction",
+        topic: "react",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "confession_id",
+            "reactor",
+            "reaction_type",
+            "nonce",
+            "timestamp",
+            "correlation_id",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "PauseChangedEvent",
+        category: "pause",
+        topic: "tip_pause",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &["actor", "paused", "reason", "timestamp"],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "ReportEvent",
+        category: "report",
+        topic: "report",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "confession_id",
+            "reporter",
+            "reason",
+            "nonce",
+            "timestamp",
+            "correlation_id",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "ReportSubmittedLedgerEvent",
+        category: "report",
+        topic: "report",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "confession_id",
+            "actor",
+            "reason",
+            "event_version",
+            "nonce",
+            "timestamp",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "RoleEvent",
+        category: "role",
+        topic: "role",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "user",
+            "role",
+            "granted",
+            "nonce",
+            "timestamp",
+            "correlation_id",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "GovernanceEvent",
+        category: "governance",
+        topic: "<stream>",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &["event_version", "metadata", "nonce", "timestamp"],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "GovernanceProposedEvent",
+        category: "governance",
+        topic: "gov_prop",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &["proposal_id", "proposer"],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "GovernanceApprovedEvent",
+        category: "governance",
+        topic: "gov_app",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &["proposal_id", "approver"],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "GovernanceApprovalRevokedEvent",
+        category: "governance",
+        topic: "gov_rev",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &["proposal_id", "actor"],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "GovernanceExecutedEvent",
+        category: "governance",
+        topic: "gov_exec",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &["proposal_id", "executor"],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "GovInvariantViolationEvent",
+        category: "governance",
+        topic: "gov_inv",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "nonce",
+            "timestamp",
+            "operation",
+            "reason",
+            "attempted_by",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "BadgeEvent",
+        category: "reputation",
+        topic: "badge",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "badge_id",
+            "badge_type",
+            "owner",
+            "action",
+            "nonce",
+            "timestamp",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "BadgeEvent",
+        category: "reputation",
+        topic: "badge_awarded",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "badge_id",
+            "badge_type",
+            "owner",
+            "action",
+            "timestamp",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "BadgeEvent",
+        category: "reputation",
+        topic: "badge_granted",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "badge_id",
+            "badge_type",
+            "owner",
+            "action",
+            "timestamp",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "BadgeEvent",
+        category: "reputation",
+        topic: "badge_revoked",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "event_version",
+            "badge_id",
+            "badge_type",
+            "owner",
+            "action",
+            "timestamp",
+        ],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "ReputationAdjustedData",
+        category: "reputation",
+        topic: "reputation_adjusted",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &["user", "amount", "reason", "timestamp"],
+    },
+    EventSchemaFixture {
+        fixture_version: EVENT_FIXTURE_VERSION_V1,
+        event_name: "ReputationDecayedData",
+        category: "reputation",
+        topic: "reputation_decayed",
+        data_format: "single-value",
+        event_version: EVENT_VERSION_V1,
+        field_order: &[
+            "user",
+            "old_reputation",
+            "new_reputation",
+            "epochs_applied",
+            "timestamp",
+        ],
+    },
+];
+
+pub fn decode_event_fixture_schema(
+    fixture: &EventSchemaFixture,
+) -> Result<EventSchemaFixture, EventDecodeError> {
+    if fixture.event_version != EVENT_VERSION_V1 {
+        return Err(EventDecodeError::UnsupportedEventVersion(
+            fixture.event_version,
+        ));
+    }
+
+    Ok(*fixture)
+}
 
 /// ===========================================
 /// GOVERNANCE METADATA LIMITS

--- a/xconfess-contracts/contracts/tests/event_decoder_compat.test.rs
+++ b/xconfess-contracts/contracts/tests/event_decoder_compat.test.rs
@@ -49,8 +49,276 @@ fn anchor_event_contains_explicit_version_marker() {
 
 #[test]
 fn schema_drift_guard() {
-    use core::mem;
+    let expected = [
+        (
+            "anchor",
+            "ConfessionAnchoredEvent",
+            "confession_anchor",
+            &["event_version", "timestamp", "anchor_height"][..],
+        ),
+        (
+            "anchor",
+            "VersionCompatibilityCheckedEvent",
+            "version_compatibility_checked",
+            &[
+                "event_version",
+                "nonce",
+                "timestamp",
+                "from_major",
+                "from_minor",
+                "from_patch",
+                "to_major",
+                "to_minor",
+                "to_patch",
+                "compatible",
+            ][..],
+        ),
+        (
+            "tip",
+            "SettlementEvent",
+            "tip_settl",
+            &[
+                "recipient",
+                "event_version",
+                "settlement_id",
+                "amount",
+                "proof_metadata",
+                "proof_present",
+                "timestamp",
+            ][..],
+        ),
+        (
+            "confession",
+            "ConfessionEvent",
+            "confess",
+            &[
+                "event_version",
+                "confession_id",
+                "author",
+                "content_hash",
+                "nonce",
+                "timestamp",
+                "correlation_id",
+            ][..],
+        ),
+        (
+            "reaction",
+            "ReactionEvent",
+            "react",
+            &[
+                "event_version",
+                "confession_id",
+                "reactor",
+                "reaction_type",
+                "nonce",
+                "timestamp",
+                "correlation_id",
+            ][..],
+        ),
+        (
+            "pause",
+            "PauseChangedEvent",
+            "tip_pause",
+            &["actor", "paused", "reason", "timestamp"][..],
+        ),
+        (
+            "report",
+            "ReportEvent",
+            "report",
+            &[
+                "event_version",
+                "confession_id",
+                "reporter",
+                "reason",
+                "nonce",
+                "timestamp",
+                "correlation_id",
+            ][..],
+        ),
+        (
+            "report",
+            "ReportSubmittedLedgerEvent",
+            "report",
+            &[
+                "confession_id",
+                "actor",
+                "reason",
+                "event_version",
+                "nonce",
+                "timestamp",
+            ][..],
+        ),
+        (
+            "role",
+            "RoleEvent",
+            "role",
+            &[
+                "event_version",
+                "user",
+                "role",
+                "granted",
+                "nonce",
+                "timestamp",
+                "correlation_id",
+            ][..],
+        ),
+        (
+            "governance",
+            "GovernanceEvent",
+            "<stream>",
+            &["event_version", "metadata", "nonce", "timestamp"][..],
+        ),
+        (
+            "governance",
+            "GovernanceProposedEvent",
+            "gov_prop",
+            &["proposal_id", "proposer"][..],
+        ),
+        (
+            "governance",
+            "GovernanceApprovedEvent",
+            "gov_app",
+            &["proposal_id", "approver"][..],
+        ),
+        (
+            "governance",
+            "GovernanceApprovalRevokedEvent",
+            "gov_rev",
+            &["proposal_id", "actor"][..],
+        ),
+        (
+            "governance",
+            "GovernanceExecutedEvent",
+            "gov_exec",
+            &["proposal_id", "executor"][..],
+        ),
+        (
+            "governance",
+            "GovInvariantViolationEvent",
+            "gov_inv",
+            &["nonce", "timestamp", "operation", "reason", "attempted_by"][..],
+        ),
+        (
+            "reputation",
+            "BadgeEvent",
+            "badge",
+            &[
+                "event_version",
+                "badge_id",
+                "badge_type",
+                "owner",
+                "action",
+                "nonce",
+                "timestamp",
+            ][..],
+        ),
+        (
+            "reputation",
+            "BadgeEvent",
+            "badge_awarded",
+            &[
+                "event_version",
+                "badge_id",
+                "badge_type",
+                "owner",
+                "action",
+                "timestamp",
+            ][..],
+        ),
+        (
+            "reputation",
+            "BadgeEvent",
+            "badge_granted",
+            &[
+                "event_version",
+                "badge_id",
+                "badge_type",
+                "owner",
+                "action",
+                "timestamp",
+            ][..],
+        ),
+        (
+            "reputation",
+            "BadgeEvent",
+            "badge_revoked",
+            &[
+                "event_version",
+                "badge_id",
+                "badge_type",
+                "owner",
+                "action",
+                "timestamp",
+            ][..],
+        ),
+        (
+            "reputation",
+            "ReputationAdjustedData",
+            "reputation_adjusted",
+            &["user", "amount", "reason", "timestamp"][..],
+        ),
+        (
+            "reputation",
+            "ReputationDecayedData",
+            "reputation_decayed",
+            &[
+                "user",
+                "old_reputation",
+                "new_reputation",
+                "epochs_applied",
+                "timestamp",
+            ][..],
+        ),
+    ];
 
-    let size = mem::size_of::<ConfessionEvent>();
-    assert_eq!(size, mem::size_of::<ConfessionEvent>());
+    assert_eq!(
+        PUBLIC_EVENT_SCHEMA_FIXTURES.len(),
+        expected.len(),
+        "every public fixture must be listed exactly once"
+    );
+
+    for (idx, (category, event_name, topic, field_order)) in expected.iter().enumerate() {
+        let fixture = &PUBLIC_EVENT_SCHEMA_FIXTURES[idx];
+        assert_eq!(fixture.fixture_version, EVENT_FIXTURE_VERSION_V1);
+        assert_eq!(&fixture.category, category);
+        assert_eq!(&fixture.event_name, event_name);
+        assert_eq!(&fixture.topic, topic);
+        assert_eq!(fixture.event_version, EVENT_VERSION_V1);
+        assert_eq!(fixture.field_order, *field_order);
+        assert_eq!(decode_event_fixture_schema(fixture).unwrap(), *fixture);
+    }
+}
+
+#[test]
+fn public_event_fixture_categories_are_complete() {
+    for category in [
+        "anchor",
+        "tip",
+        "confession",
+        "reaction",
+        "report",
+        "pause",
+        "role",
+        "governance",
+        "reputation",
+    ] {
+        assert!(
+            PUBLIC_EVENT_SCHEMA_FIXTURES
+                .iter()
+                .any(|fixture| fixture.category == category),
+            "missing public event fixtures for category: {}",
+            category
+        );
+    }
+}
+
+#[test]
+fn fixture_decoder_rejects_unsupported_event_versions() {
+    let mut fixture = PUBLIC_EVENT_SCHEMA_FIXTURES[0];
+    fixture.event_version = EVENT_VERSION_V1 + 1;
+
+    assert_eq!(
+        decode_event_fixture_schema(&fixture),
+        Err(EventDecodeError::UnsupportedEventVersion(EVENT_VERSION_V1 + 1))
+    );
 }


### PR DESCRIPTION
<!--
  Small PR policy: https://github.com/Xconfess/Xconfess/blob/main/docs/SMALL_PR_POLICY.md
  Keep this PR focused on ONE issue. Fill in every section — mark unused ones N/A.
-->

## Closes

Closes #1487 

---

## What changed

Added a canonical public contract event schema fixture registry for anchor, tip, confession, reaction, report, pause, role, governance, and reputation events; strengthened contract compatibility tests to catch schema drift, missing fixture categories, and unsupported event versions; added a backend decoder fixture test for `ReportEvent`; and documented the V1 fixture list plus event/fixture version bump rules.

## Why

This prevents backend reconciliation from silently breaking when public contract event names, versions, or fields change incompatibly.

## How to test

1. From a fresh checkout, install project dependencies with `npm install`.
2. Ensure Rust/Cargo is installed and available on `PATH`.
3. Run `npm run contract:test` and `npm run backend:test`.

---

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [ ] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

---

## Evidence

### Tests

<!-- Tick what applies. -->

- [x] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)


### Screenshots (UI changes only)
N/A — no UI changes.

---

## Checklist

- [x] Branch is up to date with `main`
- [x] All CI checks pass
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)