### PR TITLE
fix: harden tipping, anchor verification, emergency pause, and secret logging

### DIFF
--- a/docs/stellar-anchor-and-tipping-runbook.md
+++ b/docs/stellar-anchor-and-tipping-runbook.md
@@ -272,6 +272,8 @@ grep '"requestId":"<value>"' app.log | grep '"txHash":"<value>"'
 
 `requestId` is echoed from the incoming `x-request-id` header (or auto-generated). No secrets, private keys, or seed phrases are ever written to logs. Sender addresses are omitted when the tip is marked anonymous.
 
+This is enforced defensively, not just by convention: `src/utils/redact-secrets.ts` scrubs Stellar secret seeds and signed-XDR-shaped blobs from any string or structured payload before it reaches `AppLogger` or the global `AllExceptionsFilter`, so an unexpected error from the signing path cannot echo `STELLAR_SERVER_SECRET` (or a signed transaction envelope) into application logs or the audit log.
+
 ## Metrics & Observability (Reconciliation Lag)
 
 As per Issue #783, the backend emits bounded metrics to track the age of pending records. This allows operators to differentiate between "normal network delay" and "stuck records."

--- a/xconfess-backend/src/common/filters/all-exceptions.filter.spec.ts
+++ b/xconfess-backend/src/common/filters/all-exceptions.filter.spec.ts
@@ -1,5 +1,5 @@
 import { AllExceptionsFilter } from './all-exceptions.filter';
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { ArgumentsHost } from '@nestjs/common';
 
 function makeHost(requestId?: string): ArgumentsHost {
@@ -76,5 +76,38 @@ describe('AllExceptionsFilter', () => {
     const body = response.status.mock.results[0].value.json.mock.calls[0][0];
     expect(body).not.toHaveProperty('stack');
     expect(body.message).toBe('An unexpected error occurred');
+  });
+
+  it('redacts a Stellar secret seed from the logged message and stack (#1472)', () => {
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+    const secret = 'S' + 'A'.repeat(55);
+    const error = new Error(`Failed to sign transaction with secret ${secret}`);
+    error.stack = `Error: leaked ${secret}\n    at somewhere`;
+
+    const host = makeHost('req-id-secret');
+    filter.catch(error, host);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [loggedMessage, loggedStack] = errorSpy.mock.calls[0];
+    expect(loggedMessage).not.toContain(secret);
+    expect(loggedStack).not.toContain(secret);
+
+    errorSpy.mockRestore();
+  });
+
+  it('redacts a long signed-XDR-shaped base64 blob from the logged message (#1472)', () => {
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+    const xdrLike = 'AAAAAgAAAAC'.repeat(20); // > 150 base64 chars
+    const error = new Error(`Submission failed for envelope ${xdrLike}`);
+
+    const host = makeHost('req-id-xdr');
+    filter.catch(error, host);
+
+    const [loggedMessage] = errorSpy.mock.calls[0];
+    expect(loggedMessage).not.toContain(xdrLike);
+
+    errorSpy.mockRestore();
   });
 });

--- a/xconfess-backend/src/common/filters/all-exceptions.filter.ts
+++ b/xconfess-backend/src/common/filters/all-exceptions.filter.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { ErrorCode } from '../errors/error-codes';
+import { redactSecretStrings } from '../../utils/redact-secrets';
 
 /**
  * Catch-all exception filter that handles any error not already caught by
@@ -53,11 +54,15 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const request = ctx.getRequest<Request>();
     const requestId = (request as any).requestId ?? 'unknown';
 
+    // Redact secret-shaped content (Stellar signing seeds, signed XDR) before
+    // it ever reaches the log sink — an unexpected error from the Stellar SDK
+    // could otherwise echo sensitive material back through this catch-all.
+    const rawMessage = exception instanceof Error ? exception.message : String(exception);
+    const rawStack = exception instanceof Error ? exception.stack : undefined;
+
     this.logger.error(
-      `Unhandled exception on ${request.method} ${request.url} [requestId=${requestId}]: ${
-        exception instanceof Error ? exception.message : String(exception)
-      }`,
-      exception instanceof Error ? exception.stack : undefined,
+      `Unhandled exception on ${request.method} ${request.url} [requestId=${requestId}]: ${redactSecretStrings(rawMessage)}`,
+      rawStack ? redactSecretStrings(rawStack) : undefined,
     );
 
     response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({

--- a/xconfess-backend/src/confession/confession.gas-regression.spec.ts
+++ b/xconfess-backend/src/confession/confession.gas-regression.spec.ts
@@ -18,6 +18,7 @@ import { AnonymousUserService } from '../user/anonymous-user.service';
 import { AppLogger } from '../logger/logger.service';
 import { EncryptionService } from '../encryption/encryption.service';
 import { StellarService } from '../stellar/stellar.service';
+import { ContractService } from '../stellar/contract.service';
 import { CacheService } from '../cache/cache.service';
 import { TagService } from './tag.service';
 
@@ -113,6 +114,7 @@ describe('ConfessionService Gas Regression Tests', () => {
             verifyTransaction: jest.fn(),
           },
         },
+        { provide: ContractService, useValue: { verifyConfession: jest.fn() } },
         {
           provide: CacheService,
           useValue: {

--- a/xconfess-backend/src/confession/confession.pagination.spec.ts
+++ b/xconfess-backend/src/confession/confession.pagination.spec.ts
@@ -10,6 +10,7 @@ import { AppLogger } from '../logger/logger.service';
 import { ConfigService } from '@nestjs/config';
 import { EncryptionService } from '../encryption/encryption.service';
 import { StellarService } from '../stellar/stellar.service';
+import { ContractService } from '../stellar/contract.service';
 import { CacheService } from '../cache/cache.service';
 import { TagService } from './tag.service';
 import { SortOrder } from './dto/get-confessions.dto';
@@ -76,6 +77,7 @@ function buildProviders(qb: any, cacheService: any) {
       provide: StellarService,
       useValue: { processAnchorData: jest.fn(), getExplorerUrl: jest.fn(), verifyTransaction: jest.fn() },
     },
+    { provide: ContractService, useValue: { verifyConfession: jest.fn() } },
     { provide: CacheService, useValue: cacheService },
     { provide: TagService, useValue: { validateTags: jest.fn() } },
     anomalyDetectionProvider,
@@ -264,6 +266,7 @@ function buildSearchProviders(repoValue: any) {
       provide: StellarService,
       useValue: { processAnchorData: jest.fn(), getExplorerUrl: jest.fn(), verifyTransaction: jest.fn() },
     },
+    { provide: ContractService, useValue: { verifyConfession: jest.fn() } },
     {
       provide: CacheService,
       useValue: {

--- a/xconfess-backend/src/confession/confession.search.spec.ts
+++ b/xconfess-backend/src/confession/confession.search.spec.ts
@@ -11,6 +11,7 @@ import { ConfigService } from '@nestjs/config';
 import { AnonymousUserService } from '../user/anonymous-user.service';
 import { EncryptionService } from '../encryption/encryption.service';
 import { StellarService } from '../stellar/stellar.service';
+import { ContractService } from '../stellar/contract.service';
 import { CacheService } from '../cache/cache.service';
 import { TagService } from './tag.service';
 import { AnomalyDetectionService } from '../anomaly/anomaly-detection.service';
@@ -94,6 +95,7 @@ describe('ConfessionService - Search Functionality', () => {
             verifyTransaction: jest.fn(),
           },
         },
+        { provide: ContractService, useValue: { verifyConfession: jest.fn() } },
         {
           provide: CacheService,
           useValue: {

--- a/xconfess-backend/src/confession/confession.service.idempotency.spec.ts
+++ b/xconfess-backend/src/confession/confession.service.idempotency.spec.ts
@@ -39,6 +39,7 @@ import { TagService } from './tag.service';
 import { EncryptionService } from '../encryption/encryption.service';
 import { AppLogger } from '../logger/logger.service';
 import { StellarService } from '../stellar/stellar.service';
+import { ContractService } from '../stellar/contract.service';
 import { AnomalyDetectionService } from '../anomaly/anomaly-detection.service';
 
 // ── Stable mocks for encryption so message comparisons are transparent ────────
@@ -378,6 +379,7 @@ describe('ConfessionService – idempotency integration', () => {
             verifyTransaction: jest.fn().mockResolvedValue(false),
           },
         },
+        { provide: ContractService, useValue: { verifyConfession: jest.fn() } },
         {
           provide: CacheService,
           useValue: {
@@ -576,6 +578,7 @@ describe('ConfessionService – idempotency integration', () => {
         { provide: AppLogger, useValue: { log: jest.fn(), error: jest.fn(), warn: jest.fn(), logWithUser: jest.fn() } },
         { provide: EncryptionService, useValue: {} },
         { provide: StellarService, useValue: { processAnchorData: jest.fn().mockReturnValue(null) } },
+        { provide: ContractService, useValue: { verifyConfession: jest.fn() } },
         { provide: CacheService, useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn(), del: jest.fn(), delPattern: jest.fn(), buildKey: jest.fn((...a: string[]) => a.join(':')) } },
         { provide: TagService, useValue: { validateTags: jest.fn().mockResolvedValue([]) } },
         { provide: AnomalyDetectionService, useValue: { getAdjustmentFactor: jest.fn().mockResolvedValue(1) } },

--- a/xconfess-backend/src/confession/confession.service.spec.ts
+++ b/xconfess-backend/src/confession/confession.service.spec.ts
@@ -14,6 +14,7 @@ import { ConfigService } from '@nestjs/config';
 import { AppLogger } from 'src/logger/logger.service';
 import { EncryptionService } from 'src/encryption/encryption.service';
 import { StellarService } from '../stellar/stellar.service';
+import { ContractService } from '../stellar/contract.service';
 import { CacheService, CACHE_TTL } from '../cache/cache.service';
 import { TagService } from './tag.service';
 import { encryptConfession } from '../utils/confession-encryption';
@@ -93,6 +94,10 @@ describe('ConfessionService', () => {
             processAnchorData: jest.fn(),
             getExplorerUrl: jest.fn(),
           },
+        },
+        {
+          provide: ContractService,
+          useValue: { verifyConfession: jest.fn() },
         },
         {
           provide: CacheService,
@@ -262,6 +267,7 @@ describe('ConfessionService — anchor pending-state guard (#776)', () => {
   let service: ConfessionService;
   let confessionRepo: any;
   let stellarService: any;
+  let contractService: any;
 
   beforeEach(async () => {
     confessionRepo = {
@@ -283,6 +289,12 @@ describe('ConfessionService — anchor pending-state guard (#776)', () => {
       verifyTransaction: jest.fn().mockResolvedValue(true),
     };
 
+    contractService = {
+      // Defaults to "matches" so existing chain-verification tests keep
+      // exercising the happy path without every test needing to stub this.
+      verifyConfession: jest.fn().mockResolvedValue(1_700_000_000_000),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ConfessionService,
@@ -296,9 +308,10 @@ describe('ConfessionService — anchor pending-state guard (#776)', () => {
         { provide: EventEmitter2, useValue: { emit: jest.fn() } },
         { provide: AnonymousUserService, useValue: { create: jest.fn(), getAnonIdsForUser: jest.fn() } },
         { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('12345678901234567890123456789012') } },
-        { provide: AppLogger, useValue: { log: jest.fn(), error: jest.fn() } },
+        { provide: AppLogger, useValue: { log: jest.fn(), error: jest.fn(), warn: jest.fn() } },
         { provide: EncryptionService, useValue: { encrypt: jest.fn(), decrypt: jest.fn() } },
         { provide: StellarService, useValue: stellarService },
+        { provide: ContractService, useValue: contractService },
         {
           provide: CacheService,
           useValue: {
@@ -458,6 +471,49 @@ describe('ConfessionService — anchor pending-state guard (#776)', () => {
 
       expect(result.isAnchored).toBe(false);
       expect(result.anchorPending).toBe(false);
+    });
+
+    it('rejects verification when the transaction succeeds but the on-chain hash does not match the confession (#1474)', async () => {
+      const txHash = 'o'.repeat(64);
+      confessionRepo.findOne.mockResolvedValue({
+        id: 'conf-v4',
+        isAnchored: false,
+        stellarTxHash: txHash,
+        stellarHash: 'p'.repeat(64),
+        anchoredAt: null,
+        isDeleted: false,
+      });
+      stellarService.verifyTransaction.mockResolvedValue(true);
+      // Transaction succeeded on Horizon, but the contract never recorded
+      // this confession's hash — the tx hash points at unrelated data.
+      contractService.verifyConfession.mockResolvedValue(null);
+
+      const result = await service.verifyStellarAnchor('conf-v4');
+
+      expect(contractService.verifyConfession).toHaveBeenCalledWith('p'.repeat(64));
+      expect(result.isAnchored).toBe(false);
+      expect(result.anchorPending).toBe(true);
+      expect(result.isVerified).toBe(false);
+      expect(confessionRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('does not promote an already-anchored confession even if a later check reveals a hash mismatch', async () => {
+      const txHash = 'q'.repeat(64);
+      confessionRepo.findOne.mockResolvedValue({
+        id: 'conf-v5',
+        isAnchored: true,
+        stellarTxHash: txHash,
+        stellarHash: 'r'.repeat(64),
+        anchoredAt: new Date('2026-01-01T00:00:00.000Z'),
+        isDeleted: false,
+      });
+      stellarService.verifyTransaction.mockResolvedValue(true);
+      contractService.verifyConfession.mockResolvedValue(1_700_000_000_000);
+
+      const result = await service.verifyStellarAnchor('conf-v5');
+
+      expect(result.isAnchored).toBe(true);
+      expect(confessionRepo.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/xconfess-backend/src/confession/confession.service.ts
+++ b/xconfess-backend/src/confession/confession.service.ts
@@ -41,6 +41,7 @@ import { maskUserId } from 'src/utils/mask-user-id';
 import { EncryptionService } from 'src/encryption/encryption.service';
 import { ConfessionResponseDto } from './dto/confession-response.dto';
 import { StellarService } from '../stellar/stellar.service';
+import { ContractService } from '../stellar/contract.service';
 import { AnchorConfessionDto } from '../stellar/dto/anchor-confession.dto';
 import { CacheService, CACHE_TTL } from '../cache/cache.service';
 import { TagService } from './tag.service';
@@ -63,6 +64,7 @@ export class ConfessionService {
     private readonly logger: AppLogger,
     private encryptionService: EncryptionService,
     private readonly stellarService: StellarService,
+    private readonly contractService: ContractService,
     private readonly cacheService: CacheService,
     private readonly tagService: TagService,
     private readonly configService: ConfigService,
@@ -1127,9 +1129,27 @@ export class ConfessionService {
       };
     }
 
-    const isVerified = await this.stellarService.verifyTransaction(
+    const txSucceeded = await this.stellarService.verifyTransaction(
       confession.stellarTxHash,
     );
+
+    // A successful transaction alone does not prove *this* confession was
+    // anchored — the reported tx hash could belong to an unrelated or stale
+    // submission. Confirm the contract's on-chain state actually holds the
+    // locally-computed hash before trusting the anchor.
+    const payloadMatches =
+      txSucceeded &&
+      !!confession.stellarHash &&
+      (await this.contractService.verifyConfession(confession.stellarHash)) !==
+        null;
+
+    if (txSucceeded && !payloadMatches) {
+      this.logger.warn(
+        `Anchor hash mismatch for confession ${confession.id}: transaction ${confession.stellarTxHash} succeeded on-chain but does not anchor the expected confession hash`,
+      );
+    }
+
+    const isVerified = payloadMatches;
 
     // Pending anchor confirmed on-chain: promote to fully anchored
     if (!confession.isAnchored && isVerified) {

--- a/xconfess-backend/src/confession/confession.view-count.integration.spec.ts
+++ b/xconfess-backend/src/confession/confession.view-count.integration.spec.ts
@@ -9,6 +9,7 @@ import { AnonymousUserService } from '../user/anonymous-user.service';
 import { AppLogger } from '../logger/logger.service';
 import { EncryptionService } from '../encryption/encryption.service';
 import { StellarService } from '../stellar/stellar.service';
+import { ContractService } from '../stellar/contract.service';
 import { CacheService } from '../cache/cache.service';
 import { TagService } from './tag.service';
 import { encryptConfession } from '../utils/confession-encryption';
@@ -45,6 +46,7 @@ describe('ConfessionService - View Counting (Integration-like)', () => {
         { provide: AppLogger, useValue: { log: jest.fn(), error: jest.fn() } },
         { provide: EncryptionService, useValue: {} },
         { provide: StellarService, useValue: {} },
+        { provide: ContractService, useValue: {} },
         { provide: CacheService, useValue: {} },
         { provide: TagService, useValue: {} },
         {

--- a/xconfess-backend/src/confession/confession.view-count.service.spec.ts
+++ b/xconfess-backend/src/confession/confession.view-count.service.spec.ts
@@ -9,6 +9,7 @@ import { AnonymousUserService } from '../user/anonymous-user.service';
 import { AppLogger } from '../logger/logger.service';
 import { EncryptionService } from '../encryption/encryption.service';
 import { StellarService } from '../stellar/stellar.service';
+import { ContractService } from '../stellar/contract.service';
 import { CacheService } from '../cache/cache.service';
 import { TagService } from './tag.service';
 import { encryptConfession } from '../utils/confession-encryption';
@@ -51,6 +52,7 @@ describe('ConfessionService - View Count Logic', () => {
         { provide: AppLogger, useValue: { log: jest.fn(), error: jest.fn() } },
         { provide: EncryptionService, useValue: {} },
         { provide: StellarService, useValue: {} },
+        { provide: ContractService, useValue: {} },
         { provide: CacheService, useValue: {} },
         { provide: TagService, useValue: {} },
         {

--- a/xconfess-backend/src/logger/logger.service.spec.ts
+++ b/xconfess-backend/src/logger/logger.service.spec.ts
@@ -23,4 +23,21 @@ describe('AppLogger', () => {
     );
     expect(sanitized.userId).not.toBe(payload.userId);
   });
+
+  it('redacts a Stellar secret seed embedded in a string message (#1472)', () => {
+    const secret = 'S' + 'B'.repeat(55);
+    const sanitized = (service as any).sanitize(`signing failed: ${secret}`);
+
+    expect(sanitized).not.toContain(secret);
+  });
+
+  it('fully redacts fields whose key name indicates a secret, regardless of nesting (#1472)', () => {
+    const payload = {
+      event: 'stellar_error',
+      details: { serverSecret: 'SCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' },
+    };
+    const sanitized = (service as any).sanitize(payload);
+
+    expect(sanitized.details.serverSecret).toBe('[REDACTED]');
+  });
 });

--- a/xconfess-backend/src/logger/logger.service.ts
+++ b/xconfess-backend/src/logger/logger.service.ts
@@ -5,6 +5,7 @@ import {
   LoggerService as NestLoggerService,
 } from '@nestjs/common';
 import { UserIdMasker } from '../utils/mask-user-id';
+import { redactSecretsDeep } from '../utils/redact-secrets';
 
 type MetricLabels = Record<string, string | number | boolean>;
 type EventSeverity = 'info' | 'warning' | 'alert';
@@ -35,9 +36,9 @@ export class AppLogger implements NestLoggerService {
 
   private sanitize(message: any): any {
     if (typeof message === 'string')
-      return UserIdMasker.maskObject({ msg: message }).msg;
+      return redactSecretsDeep(UserIdMasker.maskObject({ msg: message }).msg);
     if (typeof message === 'object' && message !== null) {
-      return UserIdMasker.maskObject(message);
+      return redactSecretsDeep(UserIdMasker.maskObject(message));
     }
     return message;
   }

--- a/xconfess-backend/src/stellar/contract.service.ts
+++ b/xconfess-backend/src/stellar/contract.service.ts
@@ -8,6 +8,7 @@ import {
 } from './interfaces/stellar-config.interface';
 import { handleStellarError } from './utils/stellar-error.handler';
 import { encodeContractArgs, ContractArg } from './utils/parameter.encoder';
+import { redactSecretStrings } from '../utils/redact-secrets';
 import { InvokeContractDto } from './dto/invoke-contract.dto';
 import { getStellarInvocationPolicy } from './stellar-invocation-policy';
 
@@ -84,7 +85,11 @@ export class ContractService {
         result: decodedResult,
       };
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      // Redacted defensively: this can be the signing path's error, which is
+      // derived from the server secret key and must never log it verbatim.
+      const message = redactSecretStrings(
+        error instanceof Error ? error.message : String(error),
+      );
       this.logger.error('Contract invocation failed: ' + String(message));
       throw handleStellarError(error);
     }

--- a/xconfess-backend/src/stellar/stellar-reconciliation.worker.spec.ts
+++ b/xconfess-backend/src/stellar/stellar-reconciliation.worker.spec.ts
@@ -41,7 +41,10 @@ describe('StellarReconciliationWorker', () => {
 
     contractService = {
       anchorConfession: jest.fn(),
+      verifyConfession: jest.fn(),
     };
+
+    stellarService.verifyTransaction = jest.fn();
 
     auditService = {
       log: jest.fn(),
@@ -218,5 +221,72 @@ describe('StellarReconciliationWorker', () => {
         }),
       }),
     );
+  });
+
+  describe('anchor payload verification (#1474)', () => {
+    it('graduates an OBSERVED anchor to ANCHORED when the on-chain hash matches confession state', async () => {
+      const anchor = {
+        id: 'a6',
+        status: AnchorStatus.OBSERVED,
+        retryCount: 0,
+        lastRetryAt: new Date(),
+        createdAt: new Date(),
+        confessionId: 'c6',
+        stellarTxHash: 'txhash789',
+      } as StellarAnchor;
+
+      anchorRepository.find.mockResolvedValue([anchor]);
+      const confession = {
+        id: 'c6',
+        message: 'enc',
+        stellarHash: 'expectedHash',
+        isAnchored: false,
+      } as unknown as AnonymousConfession;
+      confessionRepository.findOne.mockResolvedValue(confession);
+
+      stellarService.verifyTransaction.mockResolvedValue(true);
+      contractService.verifyConfession.mockResolvedValue(1_700_000_000_000);
+
+      await worker.reconcilePendingAnchors();
+
+      expect(contractService.verifyConfession).toHaveBeenCalledWith('expectedHash');
+      expect(anchor.status).toBe(AnchorStatus.ANCHORED);
+      expect(confessionRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ isAnchored: true }),
+      );
+    });
+
+    it('rejects graduation to ANCHORED when the on-chain hash does not match confession state', async () => {
+      const anchor = {
+        id: 'a7',
+        status: AnchorStatus.OBSERVED,
+        retryCount: 0,
+        lastRetryAt: new Date(),
+        createdAt: new Date(),
+        confessionId: 'c7',
+        stellarTxHash: 'txhash999',
+      } as StellarAnchor;
+
+      anchorRepository.find.mockResolvedValue([anchor]);
+      const confession = {
+        id: 'c7',
+        message: 'enc',
+        stellarHash: 'expectedHash',
+        isAnchored: false,
+      } as unknown as AnonymousConfession;
+      confessionRepository.findOne.mockResolvedValue(confession);
+
+      stellarService.verifyTransaction.mockResolvedValue(true);
+      // The transaction succeeded on Horizon, but the contract never recorded
+      // this confession's hash — i.e. the tx hash points at unrelated data.
+      contractService.verifyConfession.mockResolvedValue(null);
+
+      await worker.reconcilePendingAnchors();
+
+      expect(anchor.status).toBe(AnchorStatus.OBSERVED);
+      expect(anchor.lastError).toMatch(/hash mismatch/i);
+      expect(confession.isAnchored).toBe(false);
+      expect(confessionRepository.save).not.toHaveBeenCalled();
+    });
   });
 });

--- a/xconfess-backend/src/stellar/stellar-reconciliation.worker.ts
+++ b/xconfess-backend/src/stellar/stellar-reconciliation.worker.ts
@@ -165,6 +165,32 @@ export class StellarReconciliationWorker {
         );
         if (txValid) {
           if (anchor.status === AnchorStatus.OBSERVED) {
+            // A successful transaction alone does not prove *this* confession
+            // was anchored — the recorded tx hash could belong to an
+            // unrelated or stale submission. Confirm the contract's on-chain
+            // state actually holds the locally-computed hash before
+            // graduating to the final ANCHORED status.
+            const payloadMatches =
+              !!confession.stellarHash &&
+              (await this.contractService.verifyConfession(
+                confession.stellarHash,
+              )) !== null;
+
+            if (!payloadMatches) {
+              anchor.lastError =
+                'Anchor hash mismatch: on-chain transaction does not anchor the expected confession hash';
+              await this.anchorRepository.save(anchor);
+
+              this.logger.warn({
+                event: 'stellar_anchor_hash_mismatch',
+                requestId,
+                confessionId: anchor.confessionId,
+                txHash: anchor.stellarTxHash,
+                message: `Transaction ${anchor.stellarTxHash} succeeded on-chain but does not anchor the expected confession hash for confession ${anchor.confessionId}`,
+              });
+              return 'failed';
+            }
+
             // Second verification confirmed: graduate from OBSERVED (provisional) -> ANCHORED (final)
             anchor.status = AnchorStatus.ANCHORED;
             anchor.observedAt = null;

--- a/xconfess-backend/src/stellar/stellar.controller.spec.ts
+++ b/xconfess-backend/src/stellar/stellar.controller.spec.ts
@@ -1,6 +1,10 @@
 import request from 'supertest';
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import {
+  INestApplication,
+  InternalServerErrorException,
+  ValidationPipe,
+} from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
@@ -323,5 +327,43 @@ describe('StellarController authz', () => {
 
     expect(res.status).toBe(400);
     expect(contractServiceMock.invokeContract).not.toHaveBeenCalled();
+  });
+});
+
+describe('StellarController — misconfigured signer secret (#1472)', () => {
+  it('returns a generic 500 and never leaks the malformed secret', async () => {
+    const malformedSecret = 'not-a-valid-stellar-secret';
+    const configServiceMock = {
+      get: jest.fn((key: string) =>
+        key === 'STELLAR_SERVER_SECRET' ? malformedSecret : undefined,
+      ),
+    };
+
+    const controller = new StellarController(
+      { getNetworkConfig: jest.fn() } as any,
+      { invocationFromAllowlistedDto: jest.fn(), invokeContract: jest.fn() } as any,
+      configServiceMock as any,
+      { log: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    const dto = {
+      operation: 'anchor_confession',
+      confessionHash: 'a'.repeat(64),
+      timestamp: 1_700_000_000,
+      sourceAccount: 'GSOMEPUBLICKEYVALUEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    } as any;
+    const req = { requestId: 'req-1' } as any;
+
+    let caught: any;
+    try {
+      await controller.invokeContract(dto, req);
+      throw new Error('expected invokeContract to reject');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(InternalServerErrorException);
+    expect(caught.getStatus()).toBe(500);
+    expect(caught.message).not.toContain(malformedSecret);
   });
 });

--- a/xconfess-backend/src/stellar/stellar.controller.ts
+++ b/xconfess-backend/src/stellar/stellar.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   Controller,
   Get,
+  InternalServerErrorException,
   Logger,
   Param,
   Post,
@@ -28,6 +29,7 @@ import {
   buildAuditContextFromRequest,
   buildStellarInvocationAuditMetadata,
 } from './stellar-invocation-audit';
+import { redactSecretStrings } from '../utils/redact-secrets';
 
 @ApiTags('Stellar')
 @Controller('stellar')
@@ -151,7 +153,16 @@ export class StellarController {
       );
     }
 
-    const signerPk = StellarSDK.Keypair.fromSecret(signerSecret).publicKey();
+    let signerPk: string;
+    try {
+      signerPk = StellarSDK.Keypair.fromSecret(signerSecret).publicKey();
+    } catch {
+      // Never propagate the underlying SDK error — it takes the raw secret
+      // as input and its message content is not guaranteed to omit it.
+      throw new InternalServerErrorException(
+        'Stellar server signer secret is misconfigured',
+      );
+    }
     const invocation = this.contractService.invocationFromAllowlistedDto(
       dto,
       signerPk,
@@ -197,7 +208,9 @@ export class StellarController {
         contractId: invocation.contractId,
         functionName: invocation.functionName,
         sourceAccount: dto.sourceAccount,
-        errorMessage: message,
+        // Redacted defensively — this message can originate from the signing
+        // path and must never persist secret-shaped material to the audit log.
+        errorMessage: redactSecretStrings(message),
         authorizedScope: (req as any).stellarInvocationScopeMatch,
       });
       throw err;

--- a/xconfess-backend/src/stellar/stellar.service.ts
+++ b/xconfess-backend/src/stellar/stellar.service.ts
@@ -13,6 +13,7 @@ import * as crypto from 'crypto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
+import { redactSecretStrings } from '../utils/redact-secrets';
 
 export interface AnchorData {
   stellarTxHash: string;
@@ -227,7 +228,11 @@ export class StellarService {
         success: result.successful,
       };
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      // Redacted defensively: this path constructs a keypair directly from
+      // the server secret, so any thrown error is not guaranteed secret-free.
+      const message = redactSecretStrings(
+        error instanceof Error ? error.message : String(error),
+      );
       this.logger.error(`Payment failed: ${message}`);
       throw error;
     }

--- a/xconfess-backend/src/stellar/transaction-builder.service.ts
+++ b/xconfess-backend/src/stellar/transaction-builder.service.ts
@@ -3,6 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as StellarSDK from '@stellar/stellar-sdk';
 import { StellarConfigService } from './stellar-config.service';
 import { ITransactionOptions } from './interfaces/stellar-config.interface';
+import { redactSecretStrings } from '../utils/redact-secrets';
 
 @Injectable()
 export class TransactionBuilderService {
@@ -111,7 +112,11 @@ export class TransactionBuilderService {
       transaction.sign(keypair);
       return transaction;
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      // Redacted defensively: the underlying error is derived from the secret
+      // key itself and must never be assumed safe to log verbatim.
+      const message = redactSecretStrings(
+        error instanceof Error ? error.message : String(error),
+      );
       this.logger.error(`Failed to sign transaction: ${message}`);
       throw new Error(`Transaction signing failed: ${message}`);
     }

--- a/xconfess-backend/src/utils/redact-secrets.spec.ts
+++ b/xconfess-backend/src/utils/redact-secrets.spec.ts
@@ -1,0 +1,58 @@
+import { redactSecretStrings, redactSecretsDeep } from './redact-secrets';
+
+describe('redactSecretStrings', () => {
+  it('redacts a Stellar secret seed', () => {
+    const secret = 'S' + 'A'.repeat(55);
+    const input = `Failed to sign transaction with secret ${secret}`;
+
+    expect(redactSecretStrings(input)).not.toContain(secret);
+    expect(redactSecretStrings(input)).toContain('[REDACTED]');
+  });
+
+  it('redacts a long signed-XDR-shaped base64 blob', () => {
+    const xdrLike = 'AAAAAgAAAAC'.repeat(20);
+    const input = `Submission failed for envelope ${xdrLike}`;
+
+    expect(redactSecretStrings(input)).not.toContain(xdrLike);
+  });
+
+  it('leaves short, unrelated strings untouched', () => {
+    const input = 'Transaction submitted: abc123hash';
+    expect(redactSecretStrings(input)).toBe(input);
+  });
+
+  it('handles empty/falsy input without throwing', () => {
+    expect(redactSecretStrings('')).toBe('');
+  });
+});
+
+describe('redactSecretsDeep', () => {
+  it('redacts by key name regardless of value shape', () => {
+    const value = { serverSecret: 'anything-at-all', ok: true };
+    const result: any = redactSecretsDeep(value);
+
+    expect(result.serverSecret).toBe('[REDACTED]');
+    expect(result.ok).toBe(true);
+  });
+
+  it('redacts secret-shaped strings nested inside arrays and objects', () => {
+    const secret = 'S' + 'Z'.repeat(55);
+    const value = { logs: [{ message: `error: ${secret}` }] };
+    const result: any = redactSecretsDeep(value);
+
+    expect(result.logs[0].message).not.toContain(secret);
+  });
+
+  it('passes through non-string, non-object primitives unchanged', () => {
+    expect(redactSecretsDeep(42)).toBe(42);
+    expect(redactSecretsDeep(true)).toBe(true);
+    expect(redactSecretsDeep(null)).toBe(null);
+  });
+
+  it('does not throw on circular references', () => {
+    const value: any = { a: 1 };
+    value.self = value;
+
+    expect(() => redactSecretsDeep(value)).not.toThrow();
+  });
+});

--- a/xconfess-backend/src/utils/redact-secrets.ts
+++ b/xconfess-backend/src/utils/redact-secrets.ts
@@ -1,0 +1,49 @@
+// src/utils/redact-secrets.ts
+//
+// Defense-in-depth redaction for Stellar signing secrets and signed
+// transaction envelopes (XDR) before they ever reach a log sink. Applied at
+// the global exception filter and the shared structured logger so a secret
+// can never leak regardless of which code path produced the error message.
+
+/** Stellar secret seeds: "S" + 55 base32 (RFC4648, A-Z2-7) characters. */
+const STELLAR_SECRET_SEED_REGEX = /\bS[A-Z2-7]{55}\b/g;
+
+/** Long unbroken base64 runs — typical shape of a signed transaction XDR blob. */
+const LONG_BASE64_REGEX = /\b[A-Za-z0-9+/]{150,}={0,2}\b/g;
+
+/** Object keys that must always be fully redacted regardless of content. */
+const SENSITIVE_KEY_REGEX =
+  /secret|privatekey|signingkey|signedxdr|envelopexdr|serversecret/i;
+
+const REDACTED = '[REDACTED]';
+
+export function redactSecretStrings(input: string): string {
+  if (!input) return input;
+  return input
+    .replace(STELLAR_SECRET_SEED_REGEX, REDACTED)
+    .replace(LONG_BASE64_REGEX, REDACTED);
+}
+
+/**
+ * Recursively redact sensitive keys/values from a log payload.
+ * Safe to call on arbitrary structured data; primitives other than strings
+ * pass through unchanged.
+ */
+export function redactSecretsDeep(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+  if (typeof value === 'string') return redactSecretStrings(value);
+
+  if (Array.isArray(value)) return value.map((item) => redactSecretsDeep(item, seen));
+
+  if (value && typeof value === 'object') {
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = SENSITIVE_KEY_REGEX.test(key) ? REDACTED : redactSecretsDeep(val, seen);
+    }
+    return out;
+  }
+
+  return value;
+}

--- a/xconfess-contracts/contracts/confession-registry/Cargo.toml
+++ b/xconfess-contracts/contracts/confession-registry/Cargo.toml
@@ -27,3 +27,7 @@ path = "../tests/event_nonce_ordering.test.rs"
 [[test]]
 name = "pagination"
 path = "../tests/pagination.rs"
+
+[[test]]
+name = "emergency_pause"
+path = "../tests/emergency_pause.test.rs"

--- a/xconfess-contracts/contracts/confession-registry/src/lib.rs
+++ b/xconfess-contracts/contracts/confession-registry/src/lib.rs
@@ -22,7 +22,7 @@ mod error;
 #[path = "../../events.rs"]
 pub mod events;
 #[path = "../../governance/mod.rs"]
-mod governance;
+pub mod governance;
 // mod confession_reg_auth;
 
 // ─── Data Types ───

--- a/xconfess-contracts/contracts/reputation-badges/src/lib.rs
+++ b/xconfess-contracts/contracts/reputation-badges/src/lib.rs
@@ -28,6 +28,9 @@ pub enum Error {
     NotAuthorized = 4,
     NotInitialized = 5,
     BadgeTypeMetadataNotFound = 6,
+    /// Emergency pause is active; badge/reputation mutations are blocked
+    /// until an admin unpauses. Read-only queries remain available.
+    ContractPaused = 7,
 }
 
 #[contracttype]
@@ -81,6 +84,8 @@ pub enum StorageKey {
     /// Global epoch index: StorageKey::CurrentEpoch -> u32
     /// Incremented each time a global recalibration occurs
     CurrentEpoch,
+    /// Emergency pause flag: StorageKey::Paused -> bool (absent means false)
+    Paused,
 }
 
 #[contracttype]
@@ -145,6 +150,20 @@ fn get_admin(env: &Env) -> Result<Address, Error> {
 fn is_authorized(env: &Env, caller: &Address) -> Result<bool, Error> {
     let admin = get_admin(env)?;
     Ok(admin == *caller)
+}
+
+fn is_paused_internal(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::Paused)
+        .unwrap_or(false)
+}
+
+fn assert_not_paused(env: &Env) -> Result<(), Error> {
+    if is_paused_internal(env) {
+        return Err(Error::ContractPaused);
+    }
+    Ok(())
 }
 
 // Reputation decay helper functions
@@ -291,6 +310,39 @@ impl ReputationBadges {
         Ok(())
     }
 
+    /// Pause the contract (admin only). Blocks badge and reputation
+    /// mutations; read-only queries (get_badges, get_user_reputation, etc.)
+    /// remain available while paused.
+    pub fn pause(env: Env, reason: String) -> Result<(), Error> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        env.storage().persistent().set(&StorageKey::Paused, &true);
+
+        let event_topic = Symbol::new(&env, "contract_paused");
+        env.events().publish((event_topic, admin.clone()), reason);
+
+        Ok(())
+    }
+
+    /// Unpause the contract (admin only).
+    pub fn unpause(env: Env, reason: String) -> Result<(), Error> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        env.storage().persistent().set(&StorageKey::Paused, &false);
+
+        let event_topic = Symbol::new(&env, "contract_unpaused");
+        env.events().publish((event_topic, admin.clone()), reason);
+
+        Ok(())
+    }
+
+    /// Check whether the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        is_paused_internal(&env)
+    }
+
     /// Create or update metadata for a badge type (admin only)
     pub fn create_badge(
         env: Env,
@@ -299,6 +351,8 @@ impl ReputationBadges {
         description: String,
         criteria: String,
     ) -> Result<(), Error> {
+        assert_not_paused(&env)?;
+
         let admin = get_admin(&env)?;
         admin.require_auth();
 
@@ -323,6 +377,8 @@ impl ReputationBadges {
     /// Award a badge to a user (admin only)
     /// Returns the badge ID
     pub fn award_badge(env: Env, recipient: Address, badge_type: BadgeType) -> Result<u64, Error> {
+        assert_not_paused(&env)?;
+
         let admin = get_admin(&env)?;
         admin.require_auth();
 
@@ -393,6 +449,8 @@ impl ReputationBadges {
         amount: i128,
         reason: String,
     ) -> Result<i128, Error> {
+        assert_not_paused(&env)?;
+
         let admin = get_admin(&env)?;
         admin.require_auth();
 
@@ -485,6 +543,8 @@ impl ReputationBadges {
     /// Mint a new badge for a recipient (self-service)
     /// Returns the badge ID if successful
     pub fn mint_badge(env: Env, recipient: Address, badge_type: BadgeType) -> Result<u64, Error> {
+        assert_not_paused(&env)?;
+
         recipient.require_auth();
 
         // Check if recipient already has this badge type
@@ -585,6 +645,8 @@ impl ReputationBadges {
 
     /// Transfer a badge to another address (optional feature)
     pub fn transfer_badge(env: Env, badge_id: u64, to: Address) -> Result<(), Error> {
+        assert_not_paused(&env)?;
+
         // Get the badge
         let badge_key = StorageKey::Badge(badge_id);
         let mut badge: Badge = env
@@ -711,6 +773,8 @@ impl ReputationBadges {
 
     /// Revoke a badge
     pub fn revoke_badge(env: Env, badge_id: u64) -> Result<(), Error> {
+        assert_not_paused(&env)?;
+
         // Get the badge
         let badge_key = StorageKey::Badge(badge_id);
         let badge: Badge = env
@@ -792,6 +856,8 @@ impl ReputationBadges {
     /// This is a bounded operation - processes a batch of user addresses provided
     /// Returns the number of users whose reputation was updated
     pub fn recalibrate_epoch(env: Env, user_batch: Vec<Address>) -> Result<u32, Error> {
+        assert_not_paused(&env)?;
+
         let admin = get_admin(&env)?;
         admin.require_auth();
 

--- a/xconfess-contracts/contracts/reputation-badges/src/test.rs
+++ b/xconfess-contracts/contracts/reputation-badges/src/test.rs
@@ -761,3 +761,137 @@ fn test_reputation_no_decay_when_active() {
     let rep = client.get_user_reputation(&user);
     assert_eq!(rep, 1000);
 }
+
+// ── Emergency pause (#1484) ─────────────────────────────────────────────
+
+#[test]
+fn test_pause_requires_admin_authorization() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReputationBadges, ());
+    let client = ReputationBadgesClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.pause(&String::from_str(&env, "incident"));
+
+    // Pausing must authorize as the stored admin — no other address can
+    // satisfy this, even under mock_all_auths (which only removes the
+    // signature-verification step, not the "which address" requirement).
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1);
+    assert_eq!(auths[0].0, admin);
+}
+
+#[test]
+fn test_pause_blocks_mutating_entry_points() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReputationBadges, ());
+    let client = ReputationBadgesClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    client.initialize(&admin);
+    // Pre-seed a badge and reputation so revoke/transfer/adjust have a target.
+    client.award_badge(&user, &BadgeType::ConfessionStarter);
+    client.adjust_reputation(&user, &100i128, &String::from_str(&env, "seed"));
+
+    client.pause(&String::from_str(&env, "incident"));
+    assert!(client.is_paused());
+
+    assert!(client
+        .try_create_badge(
+            &BadgeType::PopularVoice,
+            &String::from_str(&env, "n"),
+            &String::from_str(&env, "d"),
+            &String::from_str(&env, "c"),
+        )
+        .is_err());
+    assert!(client
+        .try_award_badge(&user, &BadgeType::PopularVoice)
+        .is_err());
+    assert!(client
+        .try_adjust_reputation(&user, &10i128, &String::from_str(&env, "x"))
+        .is_err());
+    assert!(client
+        .try_mint_badge(&other, &BadgeType::GenerousSoul)
+        .is_err());
+    assert!(client.try_transfer_badge(&1u64, &other).is_err());
+    assert!(client.try_revoke_badge(&1u64).is_err());
+
+    let mut batch = Vec::new(&env);
+    batch.push_back(user.clone());
+    assert!(client.try_recalibrate_epoch(&batch).is_err());
+}
+
+#[test]
+fn test_pause_does_not_block_read_only_calls() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReputationBadges, ());
+    let client = ReputationBadgesClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.award_badge(&user, &BadgeType::ConfessionStarter);
+    client.adjust_reputation(&user, &50i128, &String::from_str(&env, "seed"));
+
+    client.pause(&String::from_str(&env, "incident"));
+
+    // Read-only queries must remain available while paused.
+    assert_eq!(client.get_admin(), admin);
+    assert!(client.has_badge(&user, &BadgeType::ConfessionStarter));
+    assert_eq!(client.get_badge_count(&user), 1);
+    assert_eq!(client.get_user_reputation(&user), 50);
+    assert!(client.get_badge(&1u64).is_some());
+    assert_eq!(client.get_total_badges(), 1);
+}
+
+#[test]
+fn test_unpause_restores_mutations() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReputationBadges, ());
+    let client = ReputationBadgesClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    client.pause(&String::from_str(&env, "incident"));
+    assert!(client.is_paused());
+    assert!(client
+        .try_award_badge(&user, &BadgeType::ConfessionStarter)
+        .is_err());
+
+    client.unpause(&String::from_str(&env, "resolved"));
+    assert!(!client.is_paused());
+
+    // Mutations succeed again once unpaused.
+    let badge_id = client.award_badge(&user, &BadgeType::ConfessionStarter);
+    assert_eq!(badge_id, 1);
+}
+
+#[test]
+fn test_pause_requires_initialized_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReputationBadges, ());
+    let client = ReputationBadgesClient::new(&env, &contract_id);
+
+    // No admin set yet — pause must fail rather than silently succeed.
+    let result = client.try_pause(&String::from_str(&env, "incident"));
+    assert!(result.is_err());
+}

--- a/xconfess-contracts/contracts/tests/emergency_pause.test.rs
+++ b/xconfess-contracts/contracts/tests/emergency_pause.test.rs
@@ -1,29 +1,260 @@
-use soroban_sdk::{Env, String};
+//! Cross-contract emergency pause integration tests (#1484).
+//!
+//! Each contract enforces its own pause flag using either the shared
+//! `emergency_pause` module (confession-anchor) or a self-contained
+//! equivalent (anonymous-tipping, reputation-badges) or a governance-gated
+//! toggle (confession-registry). Per-contract unit suites already exercise
+//! this in isolation; this file proves the guarantee holds consistently
+//! *across all four mutating contracts* in one place:
+//!
+//!   - All mutating entry points fail while paused.
+//!   - Read-only entry points keep working while paused.
+//!   - An authorized admin can pause and unpause.
+//!   - An unauthorized caller cannot pause.
 
-use crate::emergency_pause::*;
-#[path = "../access_control.rs"]
-mod access_control;
+extern crate std;
+
+use confession_anchor::{ConfessionAnchor, ConfessionAnchorClient};
+use confession_registry::governance::model::CriticalAction;
+use confession_registry::{ConfessionRegistry, ConfessionRegistryClient};
+use anonymous_tipping::{AnonymousTipping, AnonymousTippingClient, Error as TippingError};
+use reputation_badges::{BadgeType, ReputationBadges, ReputationBadgesClient};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String as SorobanString};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// confession-anchor
+// ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn test_pause_flow() {
+fn anchor_pause_blocks_anchor_confession_and_admin_can_unpause() {
     let env = Env::default();
     env.mock_all_auths();
 
-    // Use shared access control so emergency pause cannot be stranded behind a
-    // separate pause-admin key.
-    let owner = env.accounts().generate();
-    access_control::init_owner(&env, &owner).unwrap();
+    let contract_id = env.register(ConfessionAnchor, ());
+    let client = ConfessionAnchorClient::new(&env, &contract_id);
 
-    assert_eq!(is_paused(&env), false);
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
 
-    pause(env.clone(), owner.clone(), String::from_str(&env, "incident")).unwrap();
+    let reason = SorobanString::from_str(&env, "incident");
+    client.pause(&owner, &reason);
+    assert!(client.is_paused(), "anchor: must report paused");
 
-    assert_eq!(is_paused(&env), true);
+    let hash = BytesN::from_array(&env, &[0x11; 32]);
+    assert!(
+        client.try_anchor_confession(&hash, &1_000u64).is_err(),
+        "anchor: anchor_confession must fail while paused"
+    );
 
-    let result = assert_not_paused(&env);
-    assert!(result.is_err());
+    // Read-only calls remain available while paused.
+    assert_eq!(client.verify_confession(&hash), None);
+    assert_eq!(client.get_confession_count(), 0);
 
-    unpause(env.clone(), owner, String::from_str(&env, "resolved")).unwrap();
+    client.unpause(&owner, &reason);
+    assert!(!client.is_paused());
+    assert_eq!(
+        client.anchor_confession(&hash, &1_000u64),
+        soroban_sdk::symbol_short!("anchored"),
+        "anchor: writes must resume after unpause"
+    );
+}
 
-    assert_eq!(is_paused(&env), false);
+#[test]
+fn anchor_unauthorized_caller_cannot_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ConfessionAnchor, ());
+    let client = ConfessionAnchorClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    client.initialize(&owner);
+
+    let reason = SorobanString::from_str(&env, "incident");
+    assert!(
+        client.try_pause(&outsider, &reason).is_err(),
+        "anchor: non-owner/non-admin must not be able to pause"
+    );
+    assert!(!client.is_paused());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// anonymous-tipping
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn tipping_setup(env: &Env) -> (Address, AnonymousTippingClient<'static>) {
+    let id = env.register(AnonymousTipping, ());
+    let client = AnonymousTippingClient::new(env, &id);
+    client.init(&id);
+    let owner = Address::generate(env);
+    client.configure_controls(&owner, &1_000u32, &60u64);
+    (owner, client)
+}
+
+#[test]
+fn tipping_pause_blocks_send_tip_and_admin_can_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (owner, client) = tipping_setup(&env);
+    let recipient = Address::generate(&env);
+
+    client.pause(&owner, &SorobanString::from_str(&env, "incident"));
+    assert!(client.is_paused(), "tipping: must report paused");
+
+    assert_eq!(
+        client.try_send_tip(&Address::generate(&env), &recipient, &1i128),
+        Err(Ok(TippingError::ContractPaused)),
+        "tipping: send_tip must fail while paused"
+    );
+
+    // Read-only calls remain available while paused.
+    assert_eq!(client.get_tips(&recipient), 0);
+    let _ = client.is_paused();
+
+    client.unpause(&owner, &SorobanString::from_str(&env, "resolved"));
+    assert!(!client.is_paused());
+    client.send_tip(&Address::generate(&env), &recipient, &5i128);
+    assert_eq!(client.get_tips(&recipient), 5);
+}
+
+#[test]
+fn tipping_unauthorized_caller_cannot_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_owner, client) = tipping_setup(&env);
+    let outsider = Address::generate(&env);
+
+    let result = client.try_pause(&outsider, &SorobanString::from_str(&env, "incident"));
+    assert!(result.is_err(), "tipping: non-owner must not be able to pause");
+    assert!(!client.is_paused());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// reputation-badges
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn reputation_badges_pause_blocks_award_badge_and_admin_can_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReputationBadges, ());
+    let client = ReputationBadgesClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.pause(&SorobanString::from_str(&env, "incident"));
+    assert!(client.is_paused(), "reputation-badges: must report paused");
+
+    assert!(
+        client
+            .try_award_badge(&user, &BadgeType::ConfessionStarter)
+            .is_err(),
+        "reputation-badges: award_badge must fail while paused"
+    );
+
+    // Read-only calls remain available while paused.
+    assert!(!client.has_badge(&user, &BadgeType::ConfessionStarter));
+    assert_eq!(client.get_admin(), admin);
+
+    client.unpause(&SorobanString::from_str(&env, "resolved"));
+    assert!(!client.is_paused());
+    client.award_badge(&user, &BadgeType::ConfessionStarter);
+    assert!(client.has_badge(&user, &BadgeType::ConfessionStarter));
+}
+
+#[test]
+fn reputation_badges_pause_requires_the_stored_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReputationBadges, ());
+    let client = ReputationBadgesClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    client.pause(&SorobanString::from_str(&env, "incident"));
+
+    // Pausing authorizes as the stored admin — no other address can satisfy
+    // this, even under mock_all_auths (which only removes signature
+    // verification, not the "which address" requirement).
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1);
+    assert_eq!(auths[0].0, admin);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// confession-registry (pause is governance-gated: propose → approve → execute)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn registry_governance_pause_blocks_create_confession_and_execute_can_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ConfessionRegistry, ());
+    let client = ConfessionRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let author = Address::generate(&env);
+    client.initialize(&admin);
+
+    let pause_id = client.gov_propose(&admin, &CriticalAction::Pause);
+    client.gov_approve(&admin, &pause_id);
+    client.gov_execute(&admin, &pause_id);
+
+    let hash = BytesN::from_array(&env, &[0x22; 32]);
+    assert!(
+        client.try_create_confession(&author, &hash, &1_000u64).is_err(),
+        "registry: create_confession must fail while paused"
+    );
+
+    // Read-only calls remain available while paused.
+    assert_eq!(client.get_total_count(), 0);
+
+    let unpause_id = client.gov_propose(&admin, &CriticalAction::Unpause);
+    client.gov_approve(&admin, &unpause_id);
+    client.gov_execute(&admin, &unpause_id);
+
+    let id = client.create_confession(&author, &hash, &2_000u64);
+    assert_eq!(id, 1, "registry: writes must resume after unpause");
+}
+
+#[test]
+fn registry_unauthorized_caller_cannot_propose_or_execute_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ConfessionRegistry, ());
+    let client = ConfessionRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    client.initialize(&admin);
+
+    // An outsider cannot even propose a critical action.
+    assert!(
+        client
+            .try_gov_propose(&outsider, &CriticalAction::Pause)
+            .is_err(),
+        "registry: an outsider must not be able to propose a pause"
+    );
+
+    // A legitimately-proposed action still cannot be executed by an outsider
+    // lacking admin authorization.
+    let pause_id = client.gov_propose(&admin, &CriticalAction::Pause);
+    assert!(
+        client.try_gov_execute(&outsider, &pause_id).is_err(),
+        "registry: an outsider must not be able to execute a pause proposal"
+    );
+
+    let author = Address::generate(&env);
+    let hash = BytesN::from_array(&env, &[0x33; 32]);
+    // Contract must remain unpaused — neither bogus attempt took effect.
+    client.create_confession(&author, &hash, &3_000u64);
 }

--- a/xconfess-frontend/app/components/confession/TipButton.tsx
+++ b/xconfess-frontend/app/components/confession/TipButton.tsx
@@ -66,7 +66,7 @@ export const TipButton = ({ confessionId, recipientAddress, initialStats }: TipB
   const wallet = useWallet();
   const { isConnected, connect } = wallet;
 
-  const { info, submit, retryVerify, reset } = useTipStateMachine({
+  const { info, submit, retryVerify, cancel, reset } = useTipStateMachine({
     confessionId,
     recipientAddress,
     onConfirmed: (hash, amount) => {
@@ -125,6 +125,7 @@ export const TipButton = ({ confessionId, recipientAddress, initialStats }: TipB
     verifying: "Verifying with backend…",
     confirmed: null,
     failed: null,
+    stale: null,
   }[info.state];
 
   return (
@@ -194,6 +195,46 @@ export const TipButton = ({ confessionId, recipientAddress, initialStats }: TipB
                   Tx: {info.txHash}
                 </p>
               )}
+              <button
+                onClick={cancel}
+                className="mt-2 text-xs text-yellow-300 underline hover:text-yellow-200"
+                aria-label="Cancel"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {/* Stale — a submitted tx was recovered after a reload but is too old to auto-verify */}
+          {info.state === "stale" && info.txHash && (
+            <div className="mb-3 rounded-lg border border-orange-700/50 bg-orange-900/30 p-3">
+              <div className="flex items-center gap-2 text-orange-400 text-sm font-medium">
+                <span>Verification link expired</span>
+              </div>
+              <p className="text-xs text-orange-400 mt-1">
+                This tip was submitted a while ago. It may have completed — check the explorer or retry verification.
+              </p>
+              <p className="mt-1 truncate font-mono text-xs text-zinc-400">Tx: {info.txHash}</p>
+              <div className="mt-2 flex gap-2">
+                <button
+                  onClick={retryVerify}
+                  disabled={isBusy}
+                  className="flex-1 rounded py-1.5 text-xs text-white bg-orange-700 hover:bg-orange-600 transition-colors disabled:opacity-50"
+                  aria-label="Retry verification"
+                >
+                  Retry Verification
+                </button>
+                {info.explorerUrl && (
+                  <a
+                    href={info.explorerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded bg-zinc-700 px-2 py-1.5 text-xs text-zinc-300 hover:bg-zinc-600"
+                  >
+                    View on Explorer
+                  </a>
+                )}
+              </div>
             </div>
           )}
 

--- a/xconfess-frontend/lib/hooks/useTipStateMachine.ts
+++ b/xconfess-frontend/lib/hooks/useTipStateMachine.ts
@@ -9,23 +9,35 @@
  *
  * States
  *   idle        — no tip in progress
- *   submitting  — building + signing + submitting tx to Stellar
+ *   submitting  — building + signing + submitting tx to Stellar (covers wallet
+ *                 rejection / disconnect, which surface here as a `failed`
+ *                 transition with no txHash — fully recoverable via `reset`)
  *   pending     — tx submitted; polling Horizon for ledger inclusion (5-6 s typical)
  *   verifying   — tx confirmed on-chain; backend verification in progress
  *   confirmed   — backend verified; tip credited
  *   failed      — any step failed; `error` contains human-readable reason
+ *   stale       — a submitted tx was recovered from a previous page load but
+ *                 is too old to trust further; manual retry/explorer check only
  *
  * Duplicate protection
- *   `inFlightRef` blocks concurrent calls to `submit` or `retry`.
+ *   `inFlightRef` blocks concurrent calls to `submit`/`retryVerify`, including
+ *   the automatic resume-on-mount verification below.
+ *
+ * Reload resilience
+ *   Once a transaction hash is obtained, it is persisted to localStorage keyed
+ *   by confessionId. On mount, a pending record resumes backend verification
+ *   automatically so a reload after submission does not strand the user.
  */
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { sendTip, verifyTip } from "@/lib/services/tipping.service";
 
 const HORIZON_TESTNET = "https://horizon-testnet.stellar.org";
 const HORIZON_MAINNET = "https://horizon.stellar.org";
 const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_ATTEMPTS = 8; // ~16 s max wait (covers 5-6 s Stellar finality + margin)
+const PERSIST_KEY_PREFIX = "xconfess:pendingTip:";
+const STALE_AFTER_MS = 30 * 60 * 1000; // 30 min
 
 export type TipState =
   | "idle"
@@ -33,7 +45,8 @@ export type TipState =
   | "pending"
   | "verifying"
   | "confirmed"
-  | "failed";
+  | "failed"
+  | "stale";
 
 export interface TipStateInfo {
   state: TipState;
@@ -42,6 +55,12 @@ export interface TipStateInfo {
   error: string | null;
   explorerUrl: string | null;
   isBusy: boolean;
+}
+
+interface PersistedTip {
+  txHash: string;
+  amount: number;
+  submittedAt: number;
 }
 
 function getHorizonBase(): string {
@@ -59,6 +78,34 @@ function getSteexpUrl(txHash: string): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+function loadPersistedTip(confessionId: string): PersistedTip | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(PERSIST_KEY_PREFIX + confessionId);
+    return raw ? (JSON.parse(raw) as PersistedTip) : null;
+  } catch {
+    return null;
+  }
+}
+
+function savePersistedTip(confessionId: string, tip: PersistedTip): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PERSIST_KEY_PREFIX + confessionId, JSON.stringify(tip));
+  } catch {
+    /* localStorage unavailable (private mode, quota) — resume-on-reload degrades gracefully */
+  }
+}
+
+function clearPersistedTip(confessionId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(PERSIST_KEY_PREFIX + confessionId);
+  } catch {
+    /* no-op */
+  }
 }
 
 type HorizonTxStatus = "pending" | "confirmed" | "failed" | "not_found";
@@ -82,9 +129,11 @@ async function pollHorizonStatus(txHash: string): Promise<HorizonTxStatus> {
 
 async function waitForHorizonConfirmation(
   txHash: string,
-): Promise<"confirmed" | "failed" | "timeout"> {
+  isCancelled: () => boolean,
+): Promise<"confirmed" | "failed" | "timeout" | "cancelled"> {
   for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
     await sleep(POLL_INTERVAL_MS);
+    if (isCancelled()) return "cancelled";
     const status = await pollHorizonStatus(txHash);
     if (status === "confirmed") return "confirmed";
     if (status === "failed") return "failed";
@@ -110,6 +159,8 @@ export function useTipStateMachine({
   const [amount, setAmount] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const inFlightRef = useRef(false);
+  const cancelledRef = useRef(false);
+  const resumedRef = useRef(false);
 
   const isBusy =
     state === "submitting" || state === "pending" || state === "verifying";
@@ -118,11 +169,12 @@ export function useTipStateMachine({
 
   const reset = useCallback(() => {
     if (inFlightRef.current) return;
+    clearPersistedTip(confessionId);
     setState("idle");
     setTxHash(null);
     setAmount(null);
     setError(null);
-  }, []);
+  }, [confessionId]);
 
   const submit = useCallback(
     async (tipAmount: number) => {
@@ -134,6 +186,7 @@ export function useTipStateMachine({
       }
 
       inFlightRef.current = true;
+      cancelledRef.current = false;
       setState("submitting");
       setError(null);
       setTxHash(null);
@@ -141,7 +194,11 @@ export function useTipStateMachine({
 
       try {
         // --- Phase 1: submit to Stellar ---
+        // Wallet rejection/disconnect during signing surfaces as a thrown
+        // error here and lands in `failed` with no txHash — fully
+        // recoverable: the input reappears and the user can retry from scratch.
         const sendResult = await sendTip(confessionId, tipAmount, recipientAddress);
+        if (cancelledRef.current) return;
         if (!sendResult.success || !sendResult.txHash) {
           throw new Error(sendResult.error || "Failed to submit transaction");
         }
@@ -149,9 +206,11 @@ export function useTipStateMachine({
         const hash = sendResult.txHash;
         setTxHash(hash);
         setState("pending");
+        savePersistedTip(confessionId, { txHash: hash, amount: tipAmount, submittedAt: Date.now() });
 
         // --- Phase 2: poll Horizon until ledger inclusion ---
-        const horizonResult = await waitForHorizonConfirmation(hash);
+        const horizonResult = await waitForHorizonConfirmation(hash, () => cancelledRef.current);
+        if (horizonResult === "cancelled") return;
         if (horizonResult === "failed") {
           throw new Error("Transaction was rejected by the Stellar network");
         }
@@ -164,6 +223,7 @@ export function useTipStateMachine({
         // --- Phase 3: backend verification ---
         setState("verifying");
         const verifyResult = await verifyTip(confessionId, hash);
+        if (cancelledRef.current) return;
         if (!verifyResult.success) {
           throw new Error(
             verifyResult.error || "Backend verification still pending.",
@@ -171,8 +231,10 @@ export function useTipStateMachine({
         }
 
         setState("confirmed");
+        clearPersistedTip(confessionId);
         onConfirmed?.(hash, tipAmount);
       } catch (err) {
+        if (cancelledRef.current) return;
         const msg = err instanceof Error ? err.message : "Failed to send tip";
         setError(msg);
         setState("failed");
@@ -189,17 +251,21 @@ export function useTipStateMachine({
     if (inFlightRef.current || !txHash) return;
 
     inFlightRef.current = true;
+    cancelledRef.current = false;
     setState("verifying");
     setError(null);
 
     try {
       const verifyResult = await verifyTip(confessionId, txHash);
+      if (cancelledRef.current) return;
       if (!verifyResult.success) {
         throw new Error(verifyResult.error || "Backend verification still pending.");
       }
       setState("confirmed");
+      clearPersistedTip(confessionId);
       onConfirmed?.(txHash, amount ?? 0);
     } catch (err) {
+      if (cancelledRef.current) return;
       const msg = err instanceof Error ? err.message : "Verification failed";
       setError(msg);
       setState("failed");
@@ -209,7 +275,74 @@ export function useTipStateMachine({
     }
   }, [confessionId, txHash, amount, onConfirmed, onFailed]);
 
+  /**
+   * Cancel an in-flight submit/verify. The underlying Stellar transaction may
+   * already be broadcast and cannot be un-sent, so cancelling lands on
+   * `failed` (with the txHash preserved for explorer/retry) rather than
+   * silently discarding a possibly-successful transaction.
+   */
+  const cancel = useCallback(() => {
+    if (!isBusy) return;
+    cancelledRef.current = true;
+    inFlightRef.current = false;
+
+    if (txHash) {
+      setError("Cancelled. Your transaction may still be processing — check the explorer or retry verification.");
+      setState("failed");
+    } else {
+      setState("idle");
+      setError(null);
+    }
+  }, [isBusy, txHash]);
+
+  // Resume verification for a tip that was submitted before a page reload.
+  // Guarded against React StrictMode's double-invoke and against racing an
+  // already-in-flight submit/retry so verifyTip is never called twice.
+  useEffect(() => {
+    if (resumedRef.current) return;
+    resumedRef.current = true;
+
+    const persisted = loadPersistedTip(confessionId);
+    if (!persisted || inFlightRef.current) return;
+
+    setTxHash(persisted.txHash);
+    setAmount(persisted.amount);
+
+    const age = Date.now() - persisted.submittedAt;
+    if (age > STALE_AFTER_MS) {
+      setState("stale");
+      return;
+    }
+
+    inFlightRef.current = true;
+    setState("verifying");
+
+    verifyTip(confessionId, persisted.txHash)
+      .then((verifyResult) => {
+        if (verifyResult.success) {
+          setState("confirmed");
+          clearPersistedTip(confessionId);
+          onConfirmed?.(persisted.txHash, persisted.amount);
+        } else {
+          setState("failed");
+          const msg = verifyResult.error || "Backend verification still pending.";
+          setError(msg);
+          onFailed?.(msg);
+        }
+      })
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : "Verification failed";
+        setState("failed");
+        setError(msg);
+        onFailed?.(msg);
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [confessionId]);
+
   const info: TipStateInfo = { state, txHash, amount, error, explorerUrl, isBusy };
 
-  return { info, submit, retryVerify, reset };
+  return { info, submit, retryVerify, cancel, reset };
 }

--- a/xconfess-frontend/tests/tipping/useTipStateMachine.spec.ts
+++ b/xconfess-frontend/tests/tipping/useTipStateMachine.spec.ts
@@ -1,7 +1,9 @@
 /**
  * Tests for useTipStateMachine
- * Covers: pending → confirmed/failed states, Horizon polling, duplicate blocking, retry-verify
+ * Covers: pending → confirmed/failed states, Horizon polling, duplicate blocking, retry-verify,
+ * reload-resume persistence, stale recovery, and cancel behavior (#1481).
  */
+import React from "react";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useTipStateMachine } from "@/lib/hooks/useTipStateMachine";
 import { sendTip, verifyTip } from "@/lib/services/tipping.service";
@@ -46,7 +48,10 @@ jest.useFakeTimers();
 afterEach(() => {
   jest.clearAllMocks();
   jest.clearAllTimers();
+  window.localStorage.clear();
 });
+
+const PERSIST_KEY = `xconfess:pendingTip:${CONFESSION_ID}`;
 
 describe("useTipStateMachine", () => {
   it("starts in idle state", () => {
@@ -197,5 +202,149 @@ describe("useTipStateMachine", () => {
     await p;
 
     expect(result.current.info.explorerUrl).toBe(`https://testnet.steexp.com/tx/${TX_HASH}`);
+  });
+
+  it("persists the tx hash once submitted, and clears it once confirmed", async () => {
+    mockSendTip.mockResolvedValue({ success: true, txHash: TX_HASH });
+    mockFetch.mockResolvedValue(makeHorizonResponse(true));
+    mockVerifyTip.mockResolvedValue({ success: true });
+
+    const { result } = renderMachine();
+    const p = act(async () => { result.current.submit(0.5); });
+
+    // pending: persisted record should now exist
+    await act(async () => { await Promise.resolve(); });
+    const persisted = JSON.parse(window.localStorage.getItem(PERSIST_KEY) as string);
+    expect(persisted.txHash).toBe(TX_HASH);
+
+    await act(async () => { jest.runAllTimersAsync(); });
+    await p;
+
+    expect(result.current.info.state).toBe("confirmed");
+    expect(window.localStorage.getItem(PERSIST_KEY)).toBeNull();
+  });
+
+  it("resumes verification automatically for a tip persisted before a reload", async () => {
+    window.localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({ txHash: TX_HASH, amount: 0.5, submittedAt: Date.now() }),
+    );
+    mockVerifyTip.mockResolvedValue({ success: true });
+
+    const { result } = renderMachine();
+
+    await waitFor(() => expect(result.current.info.state).toBe("confirmed"));
+
+    expect(mockSendTip).not.toHaveBeenCalled();
+    expect(mockVerifyTip).toHaveBeenCalledTimes(1);
+    expect(mockVerifyTip).toHaveBeenCalledWith(CONFESSION_ID, TX_HASH);
+    expect(result.current.info.txHash).toBe(TX_HASH);
+    expect(window.localStorage.getItem(PERSIST_KEY)).toBeNull();
+  });
+
+  it("marks a stale-recovered tip as failed when resumed verification does not succeed", async () => {
+    window.localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({ txHash: TX_HASH, amount: 0.5, submittedAt: Date.now() }),
+    );
+    mockVerifyTip.mockResolvedValue({ success: false, error: "still pending" });
+
+    const { result } = renderMachine();
+
+    await waitFor(() => expect(result.current.info.state).toBe("failed"));
+    expect(result.current.info.txHash).toBe(TX_HASH);
+  });
+
+  it("marks a persisted tip older than the staleness threshold as `stale` without calling verifyTip", async () => {
+    const THIRTY_ONE_MINUTES_AGO = Date.now() - 31 * 60 * 1000;
+    window.localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({ txHash: TX_HASH, amount: 0.5, submittedAt: THIRTY_ONE_MINUTES_AGO }),
+    );
+
+    const { result } = renderMachine();
+
+    await waitFor(() => expect(result.current.info.state).toBe("stale"));
+    expect(result.current.info.txHash).toBe(TX_HASH);
+    expect(mockVerifyTip).not.toHaveBeenCalled();
+
+    // Still recoverable — retryVerify works from the stale state.
+    mockVerifyTip.mockResolvedValue({ success: true });
+    await act(async () => { await result.current.retryVerify(); });
+    expect(result.current.info.state).toBe("confirmed");
+  });
+
+  it("does not call verifyTip more than once when the resume effect double-invokes (StrictMode)", async () => {
+    window.localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({ txHash: TX_HASH, amount: 0.5, submittedAt: Date.now() }),
+    );
+    let resolveVerify!: (v: any) => void;
+    mockVerifyTip.mockReturnValue(new Promise((r) => { resolveVerify = r; }) as any);
+
+    renderHook(
+      () => useTipStateMachine({ confessionId: CONFESSION_ID, recipientAddress: RECIPIENT }),
+      { wrapper: React.StrictMode },
+    );
+
+    await act(async () => { await Promise.resolve(); });
+    expect(mockVerifyTip).toHaveBeenCalledTimes(1);
+
+    resolveVerify({ success: true });
+    await act(async () => { await Promise.resolve(); });
+  });
+
+  it("cancel() during pending stops further processing and preserves the tx hash for recovery", async () => {
+    mockSendTip.mockResolvedValue({ success: true, txHash: TX_HASH });
+    mockFetch.mockResolvedValue(makeHorizonResponse(true));
+
+    const { result } = renderMachine();
+    act(() => { result.current.submit(0.5); });
+
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.info.state).toBe("pending");
+
+    act(() => { result.current.cancel(); });
+
+    expect(result.current.info.state).toBe("failed");
+    expect(result.current.info.txHash).toBe(TX_HASH);
+
+    // Draining any in-flight polling/timers must not flip the state again.
+    await act(async () => { jest.runAllTimersAsync(); });
+    expect(result.current.info.state).toBe("failed");
+    expect(mockVerifyTip).not.toHaveBeenCalled();
+  });
+
+  it("cancel() before a tx hash exists returns to idle", async () => {
+    let resolveSend!: (v: any) => void;
+    mockSendTip.mockReturnValue(new Promise((r) => { resolveSend = r; }) as any);
+
+    const { result } = renderMachine();
+    act(() => { result.current.submit(0.5); });
+    expect(result.current.info.state).toBe("submitting");
+
+    act(() => { result.current.cancel(); });
+    expect(result.current.info.state).toBe("idle");
+    expect(result.current.info.txHash).toBeNull();
+
+    resolveSend({ success: true, txHash: TX_HASH });
+    await act(async () => { jest.runAllTimersAsync(); });
+    // The late resolution must not resurrect state after cancellation.
+    expect(result.current.info.state).toBe("idle");
+  });
+
+  it("reset clears the persisted tip so a stale record cannot resurrect on the next mount", async () => {
+    mockSendTip.mockResolvedValue({ success: false, error: "nope" });
+
+    const { result } = renderMachine();
+    await act(async () => { await result.current.submit(0.5); });
+
+    window.localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({ txHash: TX_HASH, amount: 0.5, submittedAt: Date.now() }),
+    );
+    act(() => { result.current.reset(); });
+
+    expect(window.localStorage.getItem(PERSIST_KEY)).toBeNull();
   });
 });


### PR DESCRIPTION
  ## Summary
  - Make the tip state machine resilient to wallet disconnects/reloads: reload-resume persistence,
  a `stale` state, and a `cancel()` action, all duplicate-verify-safe.
  - Reject confession anchor verification when the on-chain payload doesn't match the confession's
  locally-computed hash, instead of trusting any successful Horizon transaction.
  - Add emergency-pause enforcement to reputation-badges (previously had none) and a
  cross-contract integration suite proving pause/unpause/admin-only control across all four
  mutating contracts.
  - Redact Stellar secrets and signed-XDR-shaped content before they can reach logs or the audit
  trail; fix an unguarded key-derivation call that could leak a misconfigured secret.

  ## Test plan
  - [x] `npm run contract:test` (confession-registry, reputation-badges) — new pause/verification
  tests pass
  - [x] `npm run backend:test` — new/touched specs pass (redact-secrets, all-exceptions filter,
  logger, stellar controller/worker, confession.service)
  - [x] `npm run frontend:typecheck` — no errors in changed files (full run pre-existing broken,
  unrelated to this change)
  - [ ] Manual: submit a tip, reload mid-verification, confirm it resumes

  Closes #1481, Closes #1474, Closes #1484, Closes #1472