### PR TITLE
fix(backend): ensure scheduled confessions publish exactly once

### DIFF
--- a/xconfess-backend/src/confession/confession-scheduler.service.spec.ts
+++ b/xconfess-backend/src/confession/confession-scheduler.service.spec.ts
@@ -1,0 +1,256 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { ConfessionSchedulerService } from './confession-scheduler.service';
+import { AnonymousConfession } from './entities/confession.entity';
+
+describe('ConfessionSchedulerService', () => {
+  let service: ConfessionSchedulerService;
+  let repo: jest.Mocked<Repository<AnonymousConfession>>;
+  let queryBuilder: any;
+  let updateBuilder: any;
+
+  beforeEach(async () => {
+    queryBuilder = {
+      setLock: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+    };
+
+    updateBuilder = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      execute: jest.fn(),
+    };
+
+    repo = {
+      createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+    } as any;
+
+    // First createQueryBuilder call = select, second = update
+    repo.createQueryBuilder
+      .mockReturnValueOnce(queryBuilder)
+      .mockReturnValue(updateBuilder);
+
+    const mockDataSource = {
+      transaction: jest.fn(async (cb: any) =>
+        cb({ getRepository: () => repo }),
+      ),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConfessionSchedulerService,
+        {
+          provide: getRepositoryToken(AnonymousConfession),
+          useValue: repo,
+        },
+        { provide: DataSource, useValue: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<ConfessionSchedulerService>(
+      ConfessionSchedulerService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('publishScheduledConfessions', () => {
+    it('publishes scheduled confessions whose publishAt has passed', async () => {
+      const scheduled = [
+        {
+          id: 'conf-1',
+          status: 'scheduled',
+          publishAt: new Date('2025-01-01'),
+        },
+      ] as AnonymousConfession[];
+
+      queryBuilder.getMany.mockResolvedValue(scheduled);
+      updateBuilder.execute.mockResolvedValue({ affected: 1 });
+
+      await service.publishScheduledConfessions();
+
+      expect(updateBuilder.set).toHaveBeenCalledWith({
+        status: 'published',
+        created_at: expect.any(Date),
+      });
+      expect(updateBuilder.where).toHaveBeenCalledWith('id = :id', {
+        id: 'conf-1',
+      });
+      expect(updateBuilder.andWhere).toHaveBeenCalledWith(
+        'status = :status',
+        { status: 'scheduled' },
+      );
+    });
+
+    it('skips confessions already published by a concurrent run (affected: 0)', async () => {
+      const scheduled = [
+        {
+          id: 'conf-1',
+          status: 'scheduled',
+          publishAt: new Date('2025-01-01'),
+        },
+      ] as AnonymousConfession[];
+
+      queryBuilder.getMany.mockResolvedValue(scheduled);
+      updateBuilder.execute.mockResolvedValue({ affected: 0 });
+
+      await service.publishScheduledConfessions();
+
+      expect(updateBuilder.execute).toHaveBeenCalled();
+    });
+
+    it('continues processing remaining confessions when one publish fails', async () => {
+      const scheduled = [
+        {
+          id: 'conf-1',
+          status: 'scheduled',
+          publishAt: new Date('2025-01-01'),
+        },
+        {
+          id: 'conf-2',
+          status: 'scheduled',
+          publishAt: new Date('2025-01-01'),
+        },
+      ] as AnonymousConfession[];
+
+      queryBuilder.getMany.mockResolvedValue(scheduled);
+
+      // First update throws, second succeeds
+      updateBuilder.execute
+        .mockRejectedValueOnce(new Error('DB error'))
+        .mockResolvedValueOnce({ affected: 1 });
+
+      await service.publishScheduledConfessions();
+
+      expect(updateBuilder.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('acquires pessimistic write lock on scheduled confessions', async () => {
+      queryBuilder.getMany.mockResolvedValue([]);
+
+      await service.publishScheduledConfessions();
+
+      expect(queryBuilder.setLock).toHaveBeenCalledWith('pessimistic_write');
+    });
+
+    it('does nothing when no confessions are due', async () => {
+      queryBuilder.getMany.mockResolvedValue([]);
+
+      await service.publishScheduledConfessions();
+
+      expect(updateBuilder.execute).not.toHaveBeenCalled();
+    });
+
+    it('wraps the entire batch in a transaction', async () => {
+      queryBuilder.getMany.mockResolvedValue([]);
+      const ds = { transaction: jest.fn() };
+      const svc = new ConfessionSchedulerService(repo, ds as any);
+
+      ds.transaction.mockImplementation(async (cb: any) => cb({ getRepository: () => repo }));
+
+      await svc.publishScheduledConfessions();
+      expect(ds.transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('scheduleConfession', () => {
+    it('schedules a confession for future publishing', async () => {
+      const futureDate = new Date(Date.now() + 3600000);
+      const confession = {
+        id: 'conf-1',
+        status: 'published',
+        publishAt: null,
+      } as AnonymousConfession;
+
+      repo.findOne.mockResolvedValue(confession);
+      repo.save.mockResolvedValue({
+        ...confession,
+        status: 'scheduled',
+        publishAt: futureDate,
+      });
+
+      const result = await service.scheduleConfession('conf-1', futureDate);
+
+      expect(result.status).toBe('scheduled');
+      expect(result.publishAt).toEqual(futureDate);
+    });
+
+    it('throws when confession is not found', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.scheduleConfession('missing', new Date(Date.now() + 3600000)),
+      ).rejects.toThrow('Confession not found');
+    });
+
+    it('throws when publish date is in the past', async () => {
+      repo.findOne.mockResolvedValue({
+        id: 'conf-1',
+        status: 'published',
+      } as AnonymousConfession);
+
+      await expect(
+        service.scheduleConfession('conf-1', new Date('2020-01-01')),
+      ).rejects.toThrow('Publish date must be in the future');
+    });
+  });
+
+  describe('cancelSchedule', () => {
+    it('reverts a scheduled confession back to draft', async () => {
+      const confession = {
+        id: 'conf-1',
+        status: 'scheduled',
+        publishAt: new Date(Date.now() + 3600000),
+      } as AnonymousConfession;
+
+      repo.findOne.mockResolvedValue(confession);
+      repo.save.mockResolvedValue({
+        ...confession,
+        status: 'draft',
+        publishAt: null,
+      });
+
+      const result = await service.cancelSchedule('conf-1');
+
+      expect(result.status).toBe('draft');
+      expect(result.publishAt).toBeNull();
+    });
+
+    it('throws when confession is not found', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.cancelSchedule('missing')).rejects.toThrow(
+        'Confession not found',
+      );
+    });
+  });
+
+  describe('getScheduledConfessions', () => {
+    it('returns scheduled confessions for a user ordered by publishAt ASC', async () => {
+      const confessions = [
+        { id: 'c2', publishAt: new Date('2025-02-01') },
+        { id: 'c1', publishAt: new Date('2025-01-01') },
+      ] as AnonymousConfession[];
+
+      repo.find.mockResolvedValue(confessions);
+
+      const result = await service.getScheduledConfessions('user-1');
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { anonymousUserId: 'user-1', status: 'scheduled' },
+        order: { publishAt: 'ASC' },
+      });
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/xconfess-backend/src/confession/confession-scheduler.service.ts
+++ b/xconfess-backend/src/confession/confession-scheduler.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThanOrEqual } from 'typeorm';
+import { Repository, LessThanOrEqual, DataSource } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { AnonymousConfession } from './entities/confession.entity';
 
@@ -11,32 +11,52 @@ export class ConfessionSchedulerService {
   constructor(
     @InjectRepository(AnonymousConfession)
     private confessionRepository: Repository<AnonymousConfession>,
+    private readonly dataSource: DataSource,
   ) {}
 
   @Cron(CronExpression.EVERY_MINUTE)
   async publishScheduledConfessions() {
-    const now = new Date();
+    await this.dataSource.transaction(async (manager) => {
+      const repo = manager.getRepository(AnonymousConfession);
+      const now = new Date();
 
-    const scheduledConfessions = await this.confessionRepository.find({
-      where: {
-        status: 'scheduled',
-        publishAt: LessThanOrEqual(now),
-      },
-    });
+      const scheduledConfessions = await repo
+        .createQueryBuilder('confession')
+        .setLock('pessimistic_write')
+        .where('confession.status = :status', { status: 'scheduled' })
+        .andWhere('confession.publishAt <= :now', { now })
+        .getMany();
 
-    for (const confession of scheduledConfessions) {
-      try {
-        confession.status = 'published';
-        confession.created_at = new Date();
-        await this.confessionRepository.save(confession);
+      for (const confession of scheduledConfessions) {
+        try {
+          const result = await repo
+            .createQueryBuilder()
+            .update(AnonymousConfession)
+            .set({
+              status: 'published',
+              created_at: now,
+            })
+            .where('id = :id', { id: confession.id })
+            .andWhere('status = :status', { status: 'scheduled' })
+            .execute();
 
-        this.logger.log(`Published scheduled confession ${confession.id}`);
-      } catch (error) {
-        this.logger.error(
-          `Failed to publish scheduled confession ${confession.id}: ${error.message}`,
-        );
+          if (result.affected && result.affected > 0) {
+            this.logger.log(
+              `Published scheduled confession id=${confession.id} publishAt=${confession.publishAt?.toISOString()}`,
+            );
+          } else {
+            this.logger.warn(
+              `Skipped already-published confession id=${confession.id} (status no longer 'scheduled')`,
+            );
+          }
+        } catch (error) {
+          this.logger.error(
+            `Failed to publish scheduled confession id=${confession.id}: ${error instanceof Error ? error.message : String(error)}`,
+            error instanceof Error ? error.stack : undefined,
+          );
+        }
       }
-    }
+    });
   }
 
   async scheduleConfession(


### PR DESCRIPTION
Fixes #1447 - Cron races can publish duplicates or miss scheduled content. Added transaction-level pessimistic write locking and idempotent UPDATE with WHERE status='scheduled' guard. Includes 12 unit tests for concurrent execution, error resilience, and idempotent transition logic.