### PR TITLE
[codex] Harden contract event and invocation compatibility

### DIFF
--- a/docs/contract-storage-migrations.md
+++ b/docs/contract-storage-migrations.md
@@ -1,0 +1,31 @@
+# Contract storage migration notes
+
+Contract upgrades must preserve the serialized representation of existing
+storage keys. Deploy application consumers only after the contract migration
+has completed and its schema version has been verified.
+
+## Current schema additions
+
+| Contract | Field | Default for existing deployments | Migration entry point |
+| --- | --- | --- | --- |
+| confession-anchor | `SchemaVersion` | `1` | `migrate` |
+| confession-anchor | `LastAnchorTimestamp` | `0` | `migrate` |
+| confession-registry | `SchemaVersion` | `1` | `migrate` |
+| reputation-badges | `SchemaVersion` | initial schema constant | `migrate` |
+| reputation-badges | `ReputationLastUpdate(Address)` | current ledger timestamp on first write | lazy-compatible |
+| reputation-badges | `CurrentEpoch` | `0` | lazy-compatible |
+| reputation-badges | `Paused` | `false` | lazy-compatible |
+
+## Required deployment order
+
+1. Back up contract IDs, current schema versions, and deployment metadata.
+2. Upload the new WASM without switching application traffic.
+3. Upgrade the contract and invoke its `migrate` entry point as the admin.
+4. Verify the reported schema version and read the new fields.
+5. Deploy backend decoders and invocation clients.
+6. Deploy the frontend after backend health and event decoding checks pass.
+
+Do not deploy consumers that require a new field before migration. Rolling
+back application code is safe while the new fields remain additive; rolling
+back contract WASM requires a compatibility review because migrated storage is
+not automatically removed.

--- a/xconfess-backend/src/stellar/__tests__/contract.service.spec.ts
+++ b/xconfess-backend/src/stellar/__tests__/contract.service.spec.ts
@@ -245,6 +245,40 @@ describe('ContractService', () => {
   // ── Negative Paths & Error Handling ────────────────────────────────────────
 
   describe('Negative Paths & Error Handling', () => {
+    it('times out a stalled invocation without leaving a timer behind', async () => {
+      jest.useFakeTimers();
+      jest
+        .spyOn(StellarSDK.Contract.prototype, 'call')
+        .mockReturnValue(MOCK_OPERATION);
+      jest
+        .spyOn(txBuilderService, 'buildTransaction')
+        .mockResolvedValue({} as any);
+      jest
+        .spyOn(txBuilderService, 'signTransaction')
+        .mockReturnValue({} as any);
+      jest
+        .spyOn(txBuilderService, 'submitTransaction')
+        .mockReturnValue(new Promise(() => undefined));
+      jest
+        .spyOn(module.get(StellarConfigService), 'getConfig')
+        .mockReturnValue({ rpcTimeoutMs: 25 } as any);
+
+      const invocation = service.invokeContract(
+        {
+          contractId: VALID_CONTRACT_ID,
+          functionName: 'test',
+          args: [],
+          sourceAccount: VALID_SOURCE_ACCOUNT,
+        },
+        VALID_SIGNER_SECRET,
+      );
+
+      await jest.advanceTimersByTimeAsync(25);
+      await expect(invocation).rejects.toThrow(StellarTimeoutError);
+      expect(jest.getTimerCount()).toBe(0);
+      jest.useRealTimers();
+    });
+
     it('should throw StellarTimeoutError when transaction times out', async () => {
       jest
         .spyOn(StellarSDK.Contract.prototype, 'call')

--- a/xconfess-backend/src/stellar/contract.service.ts
+++ b/xconfess-backend/src/stellar/contract.service.ts
@@ -75,8 +75,23 @@ export class ContractService {
         [operation],
       );
       const signedTx = this.txBuilder.signTransaction(tx, signerSecret);
-      const result: ITransactionResult =
-        await this.txBuilder.submitTransaction(signedTx);
+      const timeoutMs = this.stellarConfig.getConfig().rpcTimeoutMs;
+      let timeoutId: NodeJS.Timeout | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`Contract invocation timeout after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      });
+      let result: ITransactionResult;
+      try {
+        result = await Promise.race([
+          this.txBuilder.submitTransaction(signedTx),
+          timeout,
+        ]);
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+      }
       const decodedResult = this.decodeContractResult(result);
 
       return {

--- a/xconfess-contracts/contracts/events.rs
+++ b/xconfess-contracts/contracts/events.rs
@@ -762,4 +762,25 @@ mod tests {
             Ok(())
         );
     }
+
+    #[test]
+    fn public_event_metadata_matches_documented_abi() {
+        let abi_docs = include_str!("../../docs/contract-abi-reference.md");
+
+        for fixture in PUBLIC_EVENT_SCHEMA_FIXTURES {
+            assert!(
+                abi_docs.contains(fixture.event_name),
+                "{} is missing from the ABI reference",
+                fixture.event_name
+            );
+            for field in fixture.field_order {
+                assert!(
+                    abi_docs.contains(field),
+                    "{} field {} is missing from the ABI reference",
+                    fixture.event_name,
+                    field
+                );
+            }
+        }
+    }
 }

--- a/xconfess-contracts/contracts/tests/event_nonce_ordering.test.rs
+++ b/xconfess-contracts/contracts/tests/event_nonce_ordering.test.rs
@@ -15,9 +15,13 @@ extern crate std;
 use confession_registry::events::{
     emit_confession, emit_reaction, emit_report, emit_role, latest_confession_nonce,
     latest_governance_nonce, latest_reaction_nonce, latest_report_nonce, latest_role_nonce,
-    next_governance_nonce,
+    next_governance_nonce, ConfessionEvent,
 };
-use soroban_sdk::{contract, contractimpl, symbol_short, testutils::Address as _, Address, Env};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, Env, IntoVal,
+};
 
 /// Minimal contract whose sole purpose is to give tests a stable contract ID
 /// so that storage and event calls can execute within a valid contract context.
@@ -29,6 +33,41 @@ impl NonceTestHarness {}
 
 fn harness_id(env: &Env) -> Address {
     env.register(NonceTestHarness, ())
+}
+
+fn identical_timestamp_ordering() -> std::vec::Vec<(u64, u64)> {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_725_000_000);
+    let id = harness_id(&env);
+    let author = Address::generate(&env);
+
+    env.as_contract(&id, || {
+        for hash in [
+            symbol_short!("first"),
+            symbol_short!("second"),
+            symbol_short!("third"),
+        ] {
+            emit_confession(&env, 42, author.clone(), hash, None);
+        }
+    });
+
+    env.events()
+        .all()
+        .iter()
+        .map(|(_, _, value)| {
+            let event: ConfessionEvent = value.into_val(&env);
+            (event.timestamp, event.nonce)
+        })
+        .collect()
+}
+
+#[test]
+fn identical_timestamps_have_stable_nonce_ordering_across_runs() {
+    let expected = std::vec![(1_725_000_000, 1), (1_725_000_000, 2), (1_725_000_000, 3),];
+
+    for _ in 0..10 {
+        assert_eq!(identical_timestamp_ordering(), expected);
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- prove identical-timestamp contract events retain deterministic nonce ordering across repeated runs
- guard public event metadata against drift from the documented ABI reference
- enforce the configured RPC timeout around stalled contract submission and clear the timeout handle on every exit path
- document new contract storage fields, compatibility defaults, upgrade impact, and required deployment order

## Validation

- `cargo fmt --all -- --check` passes for the Xconfess contracts workspace after formatting the changed Rust files
- Rust test compilation was attempted but this Windows environment does not have the required MSVC `link.exe`
- Backend dependency installation was attempted but did not complete within the registry timeout window

Closes #1621
Closes #1622
Closes #1623
Closes #1624