### PR TITLE
feat:add accessibility audit checklist for key public pages

### DIFF
--- a/A11Y_CHECKLIST.md
+++ b/A11Y_CHECKLIST.md
@@ -1,0 +1,112 @@
+# Accessibility (a11y) Checklist — Confession & Profile Pages
+
+Scope: track accessibility issues on the most visible confession and profile
+pages. Covers keyboard navigation, labeling, contrast, and focus order.
+
+Target surfaces (adjust list as pages are confirmed):
+
+- Confession feed / list view
+- Confession detail / single confession view
+- Confession creation / submission form
+- `ShareButtons` component (confession sharing)
+- Profile view (own profile)
+- Profile view (other user's profile, if public)
+- Profile edit form
+
+---
+
+## 1. Keyboard Navigation
+
+- [ ] Every interactive element (buttons, links, form fields, toggles) is
+      reachable via `Tab` / `Shift+Tab` alone — no mouse required
+- [ ] Tab order follows visual/reading order, not DOM insertion order that
+      happens to differ from layout
+- [ ] No keyboard traps — user can always Tab out of a modal, dropdown, or
+      widget
+- [ ] Confession submission form: full flow (compose → submit → confirmation)
+      completable via keyboard only
+- [ ] `ShareButtons` — each share action (copy link, share to X, etc.)
+      triggerable via `Enter` / `Space`, not click-only handlers
+- [ ] Custom components (dropdowns, badge tooltips, reputation displays) use
+      standard key interactions: `Enter`/`Space` to activate, `Esc` to close,
+      arrow keys where a native `<select>` would use them
+- [ ] Skip-to-content link present and functional on confession feed and
+      profile pages
+- [ ] Infinite-scroll / paginated confession feed doesn't strand keyboard
+      focus when new content loads
+
+## 2. Labels & Semantics
+
+- [ ] All form inputs (confession text, profile fields) have a programmatic
+      `<label>` (not just placeholder text — placeholders disappear on input
+      and aren't reliably read by all screen readers)
+- [ ] Icon-only buttons (share, edit profile, badge icons) have `aria-label`
+      or visually-hidden text describing the action
+- [ ] Images (profile avatars, badge icons) have meaningful `alt` text, or
+      `alt=""` if purely decorative
+- [ ] Confession anchoring/verification status (e.g. "anchored on-chain") is
+      exposed as text, not conveyed by color or icon alone
+- [ ] Reputation badges expose their name/meaning to assistive tech, not just
+      a decorative icon (ties to `ReputationBadges` contract — badge type
+      should be announced, e.g. "ConfessionStarter badge")
+- [ ] Form validation errors are associated with their field via
+      `aria-describedby`, and errors are announced (e.g. `aria-live` region)
+      rather than only shown visually
+- [ ] Headings use a logical hierarchy (`h1` → `h2` → `h3`) on both
+      confession and profile pages — no skipped levels for styling reasons
+- [ ] Landmark regions (`<nav>`, `<main>`, `<header>`) present so screen
+      reader users can jump between sections
+
+## 3. Color Contrast
+
+- [ ] Body text meets WCAG AA: 4.5:1 contrast ratio against background
+- [ ] Large text / headings meet AA: 3:1 minimum
+- [ ] UI component contrast (button borders, form field borders, focus
+      indicators) meets 3:1 against adjacent colors
+- [ ] Badge/reputation color-coding (e.g. distinguishing badge types by
+      color) has a non-color differentiator too (icon, label, shape)
+- [ ] Link text is distinguishable from surrounding body text by more than
+      color alone (underline or weight difference), especially inside
+      confession bodies
+- [ ] Dark mode / offline-mode banner (`WebSocketReconnectBanner`,
+      `offline/page.tsx`) checked separately — contrast can regress
+      independently in alternate themes
+- [ ] Contrast checked in both the confession feed's card/list state and
+      the expanded detail state, since background treatments often differ
+
+## 4. Focus Order & Visibility
+
+- [ ] Every focusable element has a visible focus indicator (not just
+      relying on browser default, which some CSS resets strip) with ≥3:1
+      contrast against its background
+- [ ] Focus indicator is never removed via `outline: none` without a
+      replacement style
+- [ ] Opening a modal (e.g. confession detail overlay, share dialog) moves
+      focus into the modal; closing it returns focus to the triggering
+      element
+- [ ] Focus order in the confession submission form matches the visual
+      layout (text field → options → submit), not reordered by CSS
+      (e.g. flexbox/grid `order`) in a way that breaks tab sequence
+- [ ] After async actions (submit confession, award badge, adjust
+      reputation) focus lands somewhere sensible — not lost to `<body>`
+- [ ] Toast/notification content (e.g. reconnect banner, submission
+      confirmation) doesn't steal focus unexpectedly, but is announced via
+      `aria-live="polite"`
+- [ ] Profile edit form: focus moves to the first invalid field on failed
+      validation submit
+
+## 5. Testing & Sign-off
+
+- [ ] Automated scan run (axe, Lighthouse, or equivalent) against confession
+      feed, confession detail, and profile pages — zero critical/serious
+      issues outstanding
+- [ ] Manual keyboard-only pass completed on all target surfaces above
+- [ ] Manual screen reader pass (VoiceOver or NVDA) completed on confession
+      submission flow and profile edit flow at minimum
+- [ ] Known issues logged with owner and severity if not fixed before this
+      review cycle
+- [ ] Re-test scheduled for next review cycle if any items are deferred
+
+**Decision:** ☐ Meets bar ☐ Meets bar with deferred items (list below) ☐ Does not meet bar
+
+_Deferred items / owners:_


### PR DESCRIPTION
## Add accessibility checklist for confession and profile pages

### Summary

Adds `A11Y_CHECKLIST.md` — a checklist for tracking accessibility issues on the most visible confession and profile pages, covering keyboard navigation, labeling, color contrast, and focus order.

### Motivation

We don't currently have a documented accessibility baseline for the pages users interact with most: the confession feed, confession detail view, confession submission form, and profile pages. Accessibility issues on these surfaces are easy to introduce silently (a new icon-only button without a label, a modal that doesn't trap or restore focus, a badge color scheme with no non-color differentiator) and easy to miss without a standing checklist to test against each review cycle.

This gives us a single, repeatable reference instead of relying on ad hoc review.

### What's included

- **Keyboard Navigation** — full-flow keyboard operability for the confession submission form and `ShareButtons`, tab order matching visual order, no keyboard traps, skip-to-content links, and keyboard handling for custom interactive components (dropdowns, tooltips, badge displays)
- **Labels & Semantics** — programmatic labels on all form inputs, `aria-label`s on icon-only actions, meaningful `alt` text, non-color status indicators (e.g. on-chain anchoring status), reputation badge names exposed to assistive tech (not just decorative icons), validation errors tied to fields via `aria-describedby`, correct heading hierarchy, and landmark regions
- **Color Contrast** — WCAG AA thresholds for body text (4.5:1), large text/UI components (3:1), non-color differentiation for badge types, link distinguishability, and separate contrast checks for dark/offline-mode states (`WebSocketReconnectBanner`, `offline/page.tsx`) since those regress independently
- **Focus Order & Visibility** — visible focus indicators meeting contrast minimums, modal focus trapping and restoration, focus order matching visual layout even under CSS reordering, sensible focus landing after async actions (submit confession, award badge, adjust reputation), and first-invalid-field focus on failed form validation
- **Testing & Sign-off** — automated scan (axe/Lighthouse) plus manual keyboard-only and screen reader passes, with a place to log deferred items and owners

### Scope assumptions

Target surfaces were inferred from the current repo structure since specific page/component names weren't specified in the issue:
- Confession feed, confession detail view, confession submission form
- `ShareButtons` component
- Profile view (own + public) and profile edit form

If these don't match the actual "most visible" pages, the checklist's surface list at the top should be updated first — the individual checklist items are written generically enough to still apply once the correct component names are swapped in.

### Non-goals

- This PR adds the checklist only. It does not fix any existing accessibility issues, add automated CI a11y gates, or modify any component code.
- Not a substitute for an automated scan (axe/Lighthouse) — item 5 explicitly calls for running one; this checklist frames what to test and sign off on, not a replacement for tooling.

### How to review

1. Confirm the target surface list matches what's actually meant by "most visible confession and profile pages" — adjust if needed.
2. Walk through each section as if performing the actual review (ideally with a keyboard-only pass and a screen reader) to confirm the items are concrete and testable, not vague.
3. Flag any missing surface-specific concerns (e.g. anything specific to the `ReputationBadges` display or Stellar wallet connection UI) that should be added.

### Follow-ups (out of scope here)

- [ ] Run the checklist against current pages and log actual findings
- [ ] Wire an automated a11y scan into CI so regressions are caught before manual review
- [ ] Expand checklist to additional pages once confession/profile pass is clean

### Checklist for this PR

- [x] New file added: `A11Y_CHECKLIST.md`
- [x] No code changes — documentation only

Closes #1653