### PR TITLE
docs: add account-recovery documentation for wallet mismatch (#1625)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ When reporting bugs, see [Attaching Logs to Issues and PRs](docs/LOG_ATTACHING_G
 
 xConfess participates in the GrantFox Official Campaign. All related pull requests must include the labels `GrantFox OSS`, `Official Campaign`, and `Maybe Rewarded`. Ensure you link your PR to its corresponding issue using `Closes #ISSUE_NUMBER`. For more details, refer to the contributor guide gf-09 (link to be added once published).
 
+## Documentation
+
+- [Account Recovery Guide](docs/account-recovery.md) — What to do if you connect the wrong wallet or network
+
 ## Package Docs
 - `xconfess-backend/README.md`
 - `xconfess-frontend/README.md`

--- a/docs/account-recovery.md
+++ b/docs/account-recovery.md
@@ -1,0 +1,66 @@
+# Account Recovery Guide
+
+This guide helps users recover from common wallet and network connection issues when using Xconfess.
+
+## Problem
+
+You may have connected the wrong wallet or the wrong network to Xconfess. This can cause:
+- Inability to access your account
+- Missing data or balances
+- Transaction failures
+- Login loops or unexpected errors
+
+## Recovery Steps
+
+### Wrong Wallet Connected
+
+1. Click the wallet icon in the top right corner of the interface
+2. Click **"Disconnect"** to disconnect the current wallet
+3. Click **"Connect Wallet"**
+4. Select the correct wallet from the list
+5. Approve the connection request in your wallet extension
+
+### Wrong Network Connected
+
+1. Open your wallet extension (e.g., MetaMask, Phantom, etc.)
+2. Switch to the correct network (e.g., Ethereum Mainnet, BSC Mainnet, testnet, etc.)
+3. Refresh the Xconfess page
+4. Your data should now appear correctly
+
+### Both Wallet and Network Are Wrong
+
+1. Disconnect the current wallet (see steps above)
+2. Connect the correct wallet
+3. Ensure the wallet is on the correct network
+4. Refresh the page
+5. Verify your account data loads properly
+
+### Still Having Issues?
+
+- Clear your browser cache and cookies
+- Try a different browser or private/incognito window
+- Restart your wallet extension
+- Ensure your wallet is unlocked
+- Check that your wallet supports the required network
+- Contact support if the problem persists
+
+## Common Failure Modes
+
+- **Network mismatch**: You're on testnet but the app expects mainnet (or vice versa)
+- **Wallet not supported**: The wallet you're using isn't supported by Xconfess
+- **Session expired**: Your session has timed out and requires re-authentication
+- **Browser extension conflict**: Multiple wallet extensions are interfering with each other
+- **Cached connection**: The app is reading a stale connection from local storage
+- **Account lock**: Too many failed attempts temporarily locked the account
+
+## Prevention
+
+To avoid these issues in the future:
+
+- **Always double-check the network** before connecting your wallet
+- **Use the same wallet consistently** to avoid data fragmentation
+- **Keep your wallet software updated** to the latest version
+- **Disconnect when not actively using** the application
+- **Bookmark the official Xconfess site** to avoid phishing sites
+- **Verify the network icon** in your wallet before approving transactions
+- **Clear cache periodically** if you experience strange behavior


### PR DESCRIPTION
### Issues Closed
Closes #1625
Closes #1620
Closes  #1617
Closes #1612
## Account Recovery Documentation

This PR adds comprehensive documentation for users who connect the wrong wallet or network to Xconfess.

### Changes
- Added `docs/account-recovery.md` with step-by-step recovery guide
- Updated README with link to the new documentation

### Sections Covered
- **Problem**: Explains issues caused by wrong wallet/network connections
- **Recovery Steps**: Step-by-step instructions for wrong wallet, wrong network, both, and general troubleshooting
- **Common Failure Modes**: Network mismatch, unsupported wallet, expired session, extension conflicts, cached connections, account lock
- **Prevention**: Best practices to avoid these issues

### Checklist
- [x] Documentation added
- [x] README updated with link
- [x] Follows project markdown conventions