### PR TITLE
fix(backend): expose health details for redis, postgres, and queue workers

### DIFF
--- a/xconfess-backend/src/health/health.controller.spec.ts
+++ b/xconfess-backend/src/health/health.controller.spec.ts
@@ -1,12 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+import { HealthCheckService } from '@nestjs/terminus';
 import { ConfigService } from '@nestjs/config';
 import { HealthController } from './health.controller';
 import { RedisHealthIndicator } from './redis.health';
 import { SchemaReadinessHealthIndicator } from './schema-readiness.health';
 import { QueueHealthIndicator } from './queue.health';
+import { PostgresHealthIndicator } from './postgres.health';
 
-const UP = (key: string) => ({ [key]: { status: 'up' } });
+const UP = (key: string, extra?: Record<string, unknown>) => ({
+  [key]: { status: 'up', ...extra },
+});
 
 describe('HealthController', () => {
   let controller: HealthController;
@@ -18,14 +21,22 @@ describe('HealthController', () => {
       .mockImplementation((checks: Array<() => Promise<unknown>>) =>
         Promise.all(checks.map((fn) => fn())).then((results) => ({
           status: 'ok',
+          info: Object.assign({}, ...results),
+          error: {},
           details: Object.assign({}, ...results),
         })),
       ),
   };
   const dbIndicator = {
-    pingCheck: jest.fn().mockResolvedValue(UP('database')),
+    isHealthy: jest.fn().mockResolvedValue(
+      UP('database', { latencyMs: 2, version: 'PostgreSQL 16.3', activeConnections: 5, maxConnections: 100 }),
+    ),
   };
-  const redisIndicator = { isHealthy: jest.fn().mockResolvedValue(UP('redis')) };
+  const redisIndicator = {
+    isHealthy: jest.fn().mockResolvedValue(
+      UP('redis', { host: 'localhost', port: 6379, latencyMs: 1, version: '7.2.0', connectedClients: 3 }),
+    ),
+  };
   const schemaIndicator = {
     isHealthy: jest.fn().mockResolvedValue(UP('schema')),
   };
@@ -42,7 +53,7 @@ describe('HealthController', () => {
       controllers: [HealthController],
       providers: [
         { provide: HealthCheckService, useValue: healthService },
-        { provide: TypeOrmHealthIndicator, useValue: dbIndicator },
+        { provide: PostgresHealthIndicator, useValue: dbIndicator },
         { provide: RedisHealthIndicator, useValue: redisIndicator },
         { provide: SchemaReadinessHealthIndicator, useValue: schemaIndicator },
         { provide: QueueHealthIndicator, useValue: queueIndicator },
@@ -76,7 +87,7 @@ describe('HealthController', () => {
 
     it('calls all four indicators', async () => {
       await controller.readiness();
-      expect(dbIndicator.pingCheck).toHaveBeenCalledWith('database');
+      expect(dbIndicator.isHealthy).toHaveBeenCalledWith('database');
       expect(redisIndicator.isHealthy).toHaveBeenCalledWith('redis');
       expect(queueIndicator.isHealthy).toHaveBeenCalledWith('queues');
       expect(schemaIndicator.isHealthy).toHaveBeenCalledWith('schema');
@@ -93,12 +104,36 @@ describe('HealthController', () => {
       const result = await controller.readiness();
       expect(result).toHaveProperty('backgroundJobMode', 'enabled');
     });
+
+    it('includes subsystems summary array', async () => {
+      const result = await controller.readiness();
+      expect(result.subsystems).toEqual(
+        expect.arrayContaining([
+          { name: 'database', status: 'up' },
+          { name: 'redis', status: 'up' },
+          { name: 'queues', status: 'up' },
+          { name: 'schema', status: 'up' },
+        ]),
+      );
+    });
+
+    it('marks disabled subsystems in the summary', async () => {
+      redisIndicator.isHealthy.mockResolvedValue({
+        redis: { status: 'up', mode: 'disabled', reason: 'test', severity: 'info' },
+      });
+
+      const result = await controller.readiness();
+      const redisSub = result.subsystems.find(
+        (s: { name: string }) => s.name === 'redis',
+      );
+      expect(redisSub).toEqual({ name: 'redis', status: 'disabled' });
+    });
   });
 
   describe('GET /health (backward-compat alias)', () => {
     it('calls the same four indicators as /health/ready', async () => {
       await controller.check();
-      expect(dbIndicator.pingCheck).toHaveBeenCalledWith('database');
+      expect(dbIndicator.isHealthy).toHaveBeenCalledWith('database');
       expect(redisIndicator.isHealthy).toHaveBeenCalledWith('redis');
       expect(queueIndicator.isHealthy).toHaveBeenCalledWith('queues');
       expect(schemaIndicator.isHealthy).toHaveBeenCalledWith('schema');
@@ -108,6 +143,11 @@ describe('HealthController', () => {
       configService.get.mockReturnValue('false');
       const result = await controller.check();
       expect(result).toHaveProperty('backgroundJobMode', 'disabled');
+    });
+
+    it('includes subsystems summary in check response', async () => {
+      const result = await controller.check();
+      expect(result.subsystems).toHaveLength(4);
     });
   });
 });

--- a/xconfess-backend/src/health/health.controller.ts
+++ b/xconfess-backend/src/health/health.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get } from '@nestjs/common';
 import {
   HealthCheck,
   HealthCheckService,
-  TypeOrmHealthIndicator,
+  HealthCheckResult,
 } from '@nestjs/terminus';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
@@ -10,13 +10,46 @@ import { ConfigService } from '@nestjs/config';
 import { RedisHealthIndicator } from './redis.health';
 import { SchemaReadinessHealthIndicator } from './schema-readiness.health';
 import { QueueHealthIndicator } from './queue.health';
+import { PostgresHealthIndicator } from './postgres.health';
+
+interface SubsystemStatus {
+  name: string;
+  status: 'up' | 'down' | 'degraded' | 'disabled';
+}
+
+function buildSubsystemSummary(
+  result: HealthCheckResult,
+): SubsystemStatus[] {
+  const subsystems: SubsystemStatus[] = [];
+  const info = result.info ?? {};
+  const errors = result.error ?? {};
+
+  const keys = ['database', 'redis', 'queues', 'schema'];
+  for (const key of keys) {
+    const detail = info[key] ?? errors[key];
+    if (!detail) {
+      subsystems.push({ name: key, status: 'down' });
+      continue;
+    }
+
+    if (detail.mode === 'disabled') {
+      subsystems.push({ name: key, status: 'disabled' });
+    } else if (detail.status === 'up') {
+      subsystems.push({ name: key, status: 'up' });
+    } else {
+      subsystems.push({ name: key, status: 'down' });
+    }
+  }
+
+  return subsystems;
+}
 
 @ApiTags('Health')
 @Controller('health')
 export class HealthController {
   constructor(
     private readonly health: HealthCheckService,
-    private readonly db: TypeOrmHealthIndicator,
+    private readonly db: PostgresHealthIndicator,
     private readonly redis: RedisHealthIndicator,
     private readonly schemaReadiness: SchemaReadinessHealthIndicator,
     private readonly queues: QueueHealthIndicator,
@@ -43,6 +76,7 @@ export class HealthController {
   /**
    * Readiness probe — are all dependencies available?
    * Returns 503 when any dependency is unavailable.
+   * Includes per-subsystem diagnostics with actionable error messages.
    */
   @Get('ready')
   @HealthCheck()
@@ -50,8 +84,9 @@ export class HealthController {
   @ApiOperation({
     summary: 'Readiness probe',
     description:
-      'Checks Postgres, Redis, BullMQ queue workers, and confession-table schema. ' +
-      'Returns 503 with per-check detail on failure. ' +
+      'Checks Postgres (latency, version, connections), Redis (latency, version), ' +
+      'BullMQ queue workers, and confession-table schema. ' +
+      'Returns 503 with per-subsystem diagnostics and actionable hints on failure. ' +
       'Use for Kubernetes readiness probes.',
   })
   @ApiResponse({ status: 200, description: 'All dependencies ready' })
@@ -61,7 +96,7 @@ export class HealthController {
   })
   async readiness() {
     const result = await this.health.check([
-      async () => this.db.pingCheck('database'),
+      async () => this.db.isHealthy('database'),
       async () => this.redis.isHealthy('redis'),
       async () => this.queues.isHealthy('queues'),
       async () => this.schemaReadiness.isHealthy('schema'),
@@ -71,6 +106,7 @@ export class HealthController {
     return {
       ...result,
       backgroundJobMode: jobsEnabled ? 'enabled' : 'disabled',
+      subsystems: buildSubsystemSummary(result),
     };
   }
 
@@ -88,7 +124,7 @@ export class HealthController {
   @ApiResponse({ status: 503, description: 'One or more checks failed' })
   async check() {
     const result = await this.health.check([
-      async () => this.db.pingCheck('database'),
+      async () => this.db.isHealthy('database'),
       async () => this.redis.isHealthy('redis'),
       async () => this.queues.isHealthy('queues'),
       async () => this.schemaReadiness.isHealthy('schema'),
@@ -98,6 +134,7 @@ export class HealthController {
     return {
       ...result,
       backgroundJobMode: jobsEnabled ? 'enabled' : 'disabled',
+      subsystems: buildSubsystemSummary(result),
     };
   }
 }

--- a/xconfess-backend/src/health/health.module.ts
+++ b/xconfess-backend/src/health/health.module.ts
@@ -5,6 +5,7 @@ import { HealthController } from './health.controller';
 import { RedisHealthIndicator } from './redis.health';
 import { SchemaReadinessHealthIndicator } from './schema-readiness.health';
 import { QueueHealthIndicator } from './queue.health';
+import { PostgresHealthIndicator } from './postgres.health';
 
 // Inlined to keep the health module self-contained and avoid importing from
 // feature-module internals.
@@ -22,6 +23,7 @@ const MONITORED_QUEUES = [
   ],
   controllers: [HealthController],
   providers: [
+    PostgresHealthIndicator,
     RedisHealthIndicator,
     SchemaReadinessHealthIndicator,
     QueueHealthIndicator,

--- a/xconfess-backend/src/health/postgres.health.spec.ts
+++ b/xconfess-backend/src/health/postgres.health.spec.ts
@@ -1,0 +1,208 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthCheckError } from '@nestjs/terminus';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { PostgresHealthIndicator } from './postgres.health';
+
+function makeMockDataSource(
+  overrides: {
+    versionResult?: { version: string }[];
+    connResult?: { active: string; max: string }[];
+    queryError?: Error;
+  } = {},
+) {
+  const versionResult = overrides.versionResult ?? [
+    { version: 'PostgreSQL 16.3 on x86_64-pc-linux-gnu' },
+  ];
+  const connResult = overrides.connResult ?? [
+    { active: '5', max: '100' },
+  ];
+
+  return {
+    query: jest.fn().mockImplementation((sql: string) => {
+      if (overrides.queryError) {
+        return Promise.reject(overrides.queryError);
+      }
+      if (sql.includes('version()')) {
+        return Promise.resolve(versionResult);
+      }
+      if (sql.includes('pg_stat_activity')) {
+        return Promise.resolve(connResult);
+      }
+      return Promise.resolve([]);
+    }),
+  };
+}
+
+async function buildModule(dataSource: ReturnType<typeof makeMockDataSource>) {
+  return Test.createTestingModule({
+    providers: [
+      PostgresHealthIndicator,
+      {
+        provide: getDataSourceToken(),
+        useValue: dataSource,
+      },
+    ],
+  }).compile();
+}
+
+describe('PostgresHealthIndicator', () => {
+  let indicator: PostgresHealthIndicator;
+  let dataSource: ReturnType<typeof makeMockDataSource>;
+
+  describe('when postgres is healthy', () => {
+    beforeEach(async () => {
+      dataSource = makeMockDataSource();
+      const module: TestingModule = await buildModule(dataSource);
+      indicator = module.get(PostgresHealthIndicator);
+    });
+
+    it('returns up with version, latency, and connection counts', async () => {
+      const result = await indicator.isHealthy('database');
+
+      expect(result.database.status).toBe('up');
+      expect(result.database.version).toBe('PostgreSQL 16.3');
+      expect(result.database.activeConnections).toBe(5);
+      expect(result.database.maxConnections).toBe(100);
+      expect(typeof result.database.latencyMs).toBe('number');
+    });
+
+    it('calls the correct queries', async () => {
+      await indicator.isHealthy('database');
+
+      expect(dataSource.query).toHaveBeenCalledTimes(2);
+      expect(dataSource.query).toHaveBeenCalledWith('SELECT version()');
+      expect(dataSource.query).toHaveBeenCalledWith(
+        expect.stringContaining('pg_stat_activity'),
+      );
+    });
+  });
+
+  describe('when postgres connection is refused', () => {
+    beforeEach(async () => {
+      dataSource = makeMockDataSource({
+        queryError: new Error('connect ECONNREFUSED 127.0.0.1:5432'),
+      });
+      const module: TestingModule = await buildModule(dataSource);
+      indicator = module.get(PostgresHealthIndicator);
+    });
+
+    it('throws HealthCheckError', async () => {
+      await expect(indicator.isHealthy('database')).rejects.toThrow(
+        HealthCheckError,
+      );
+    });
+
+    it('includes actionable hint for ECONNREFUSED', async () => {
+      expect.assertions(2);
+      try {
+        await indicator.isHealthy('database');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HealthCheckError);
+        const causes = (err as HealthCheckError).causes as Record<
+          string,
+          Record<string, unknown>
+        >;
+        expect(causes.database.hint).toContain(
+          'not accepting connections',
+        );
+      }
+    });
+  });
+
+  describe('when postgres times out', () => {
+    beforeEach(async () => {
+      dataSource = makeMockDataSource({
+        queryError: new Error('Connection timed out'),
+      });
+      const module: TestingModule = await buildModule(dataSource);
+      indicator = module.get(PostgresHealthIndicator);
+    });
+
+    it('includes actionable hint for timeout', async () => {
+      expect.assertions(2);
+      try {
+        await indicator.isHealthy('database');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HealthCheckError);
+        const causes = (err as HealthCheckError).causes as Record<
+          string,
+          Record<string, unknown>
+        >;
+        expect(causes.database.hint).toContain('timed out');
+      }
+    });
+  });
+
+  describe('when postgres authentication fails', () => {
+    beforeEach(async () => {
+      dataSource = makeMockDataSource({
+        queryError: new Error('password authentication failed for user "app"'),
+      });
+      const module: TestingModule = await buildModule(dataSource);
+      indicator = module.get(PostgresHealthIndicator);
+    });
+
+    it('includes actionable hint for auth failure', async () => {
+      expect.assertions(2);
+      try {
+        await indicator.isHealthy('database');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HealthCheckError);
+        const causes = (err as HealthCheckError).causes as Record<
+          string,
+          Record<string, unknown>
+        >;
+        expect(causes.database.hint).toContain('DATABASE_USER');
+      }
+    });
+  });
+
+  describe('when connection pool is exhausted', () => {
+    beforeEach(async () => {
+      dataSource = makeMockDataSource({
+        queryError: new Error(
+          'remaining connection slots are reserved for non-replication superuser connections',
+        ),
+      });
+      const module: TestingModule = await buildModule(dataSource);
+      indicator = module.get(PostgresHealthIndicator);
+    });
+
+    it('includes actionable hint for exhausted pool', async () => {
+      expect.assertions(2);
+      try {
+        await indicator.isHealthy('database');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HealthCheckError);
+        const causes = (err as HealthCheckError).causes as Record<
+          string,
+          Record<string, unknown>
+        >;
+        expect(causes.database.hint).toContain('max_connections');
+      }
+    });
+  });
+
+  describe('error detail structure', () => {
+    it('always includes status=down and error message in failure output', async () => {
+      dataSource = makeMockDataSource({
+        queryError: new Error('unknown db error'),
+      });
+      const module: TestingModule = await buildModule(dataSource);
+      indicator = module.get(PostgresHealthIndicator);
+
+      expect.assertions(3);
+      try {
+        await indicator.isHealthy('database');
+      } catch (err) {
+        const causes = (err as HealthCheckError).causes as Record<
+          string,
+          Record<string, unknown>
+        >;
+        expect(causes.database.status).toBe('down');
+        expect(causes.database.error).toBe('unknown db error');
+        expect(typeof causes.database.hint).toBe('string');
+      }
+    });
+  });
+});

--- a/xconfess-backend/src/health/postgres.health.ts
+++ b/xconfess-backend/src/health/postgres.health.ts
@@ -1,0 +1,100 @@
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+export interface PostgresHealthDetail {
+  status: 'up' | 'down';
+  latencyMs?: number;
+  version?: string;
+  activeConnections?: number;
+  maxConnections?: number;
+  error?: string;
+  hint?: string;
+}
+
+@Injectable()
+export class PostgresHealthIndicator extends HealthIndicator {
+  private readonly logger = new Logger(PostgresHealthIndicator.name);
+
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const detail: PostgresHealthDetail = { status: 'down' };
+
+    try {
+      // Measure connection latency via a simple query
+      const start = Date.now();
+      const versionResult = await this.dataSource.query<
+        { version: string }[]
+      >('SELECT version()');
+      detail.latencyMs = Date.now() - start;
+
+      if (versionResult.length > 0) {
+        // Extract short version label (e.g. "PostgreSQL 16.3")
+        const full = versionResult[0].version;
+        const match = full.match(/^PostgreSQL\s+[\d.]+/);
+        detail.version = match ? match[0] : full.split(',')[0];
+      }
+
+      // Retrieve active and max connection counts
+      const [connResult] = await this.dataSource.query<
+        { active: string; max: string }[]
+      >(`
+        SELECT
+          (SELECT count(*) FROM pg_stat_activity WHERE state = 'active')::text AS active,
+          (SELECT setting FROM pg_settings WHERE name = 'max_connections') AS max
+      `);
+
+      detail.activeConnections = parseInt(connResult.active, 10);
+      detail.maxConnections = parseInt(connResult.max, 10);
+      detail.status = 'up';
+
+      return this.getStatus(key, true, detail);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      this.logger.error(`Postgres health check failed: ${message}`);
+
+      detail.error = message;
+      detail.hint = this.resolveActionableHint(message);
+
+      throw new HealthCheckError(
+        'Postgres is unreachable',
+        this.getStatus(key, false, detail),
+      );
+    }
+  }
+
+  private resolveActionableHint(errorMessage: string): string {
+    const lower = errorMessage.toLowerCase();
+
+    if (lower.includes('econnrefused')) {
+      return 'Database server is not accepting connections. Verify the host and port in DATABASE_HOST / DATABASE_PORT, and ensure PostgreSQL is running.';
+    }
+    if (lower.includes('timeout') || lower.includes('timed out')) {
+      return 'Connection timed out. Check network connectivity and PostgreSQL pg_hba.conf rules for the application host.';
+    }
+    if (
+      lower.includes('password authentication failed') ||
+      lower.includes('role') ||
+      lower.includes('does not exist')
+    ) {
+      return 'Authentication failed. Verify DATABASE_USER and DATABASE_PASSWORD environment variables.';
+    }
+    if (lower.includes('too many connections') || lower.includes('remaining connection slots are reserved')) {
+      return 'Connection pool exhausted. Increase max_connections in postgresql.conf or reduce pool size in the application.';
+    }
+    if (lower.includes('ssl')) {
+      return 'SSL negotiation failed. Check DATABASE_SSL configuration and the server certificate.';
+    }
+
+    return 'Check backend logs for the full error. Verify DATABASE_HOST, DATABASE_PORT, DATABASE_USER, and DATABASE_PASSWORD.';
+  }
+}

--- a/xconfess-backend/src/health/redis.health.spec.ts
+++ b/xconfess-backend/src/health/redis.health.spec.ts
@@ -2,12 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { RedisHealthIndicator } from './redis.health';
 import { HealthCheckError } from '@nestjs/terminus';
-import Redis from 'ioredis';
 
 // Shared mocks for ioredis instance methods
 const mockConnect = jest.fn();
 const mockPing = jest.fn();
 const mockDisconnect = jest.fn();
+const mockInfo = jest.fn();
 
 // Mock ioredis constructor
 jest.mock('ioredis', () => {
@@ -16,6 +16,7 @@ jest.mock('ioredis', () => {
       connect: mockConnect,
       ping: mockPing,
       disconnect: mockDisconnect,
+      info: mockInfo,
     };
   });
 });
@@ -50,11 +51,17 @@ describe('RedisHealthIndicator', () => {
     mockConnect.mockReset();
     mockPing.mockReset();
     mockDisconnect.mockReset();
+    mockInfo.mockReset();
   });
 
-  it('should return up if Redis ping is successful', async () => {
+  it('should return up with latency, version, and connectedClients on success', async () => {
     mockConnect.mockResolvedValue(undefined);
     mockPing.mockResolvedValue('PONG');
+    mockInfo.mockImplementation((section: string) => {
+      if (section === 'server') return Promise.resolve('redis_version:7.2.0\r\n');
+      if (section === 'clients') return Promise.resolve('connected_clients:5\r\n');
+      return Promise.resolve('');
+    });
 
     const result = await indicator.isHealthy('redis');
 
@@ -63,6 +70,9 @@ describe('RedisHealthIndicator', () => {
         status: 'up',
         host: 'localhost',
         port: 6379,
+        latencyMs: expect.any(Number),
+        version: '7.2.0',
+        connectedClients: 5,
       },
     });
     expect(mockConnect).toHaveBeenCalled();
@@ -70,7 +80,7 @@ describe('RedisHealthIndicator', () => {
     expect(mockDisconnect).toHaveBeenCalled();
   });
 
-  it('should throw HealthCheckError if Redis ping fails', async () => {
+  it('should throw HealthCheckError with hint if Redis ping fails', async () => {
     mockConnect.mockResolvedValue(undefined);
     mockPing.mockRejectedValue(new Error('Connection lost'));
 
@@ -80,13 +90,52 @@ describe('RedisHealthIndicator', () => {
     expect(mockDisconnect).toHaveBeenCalled();
   });
 
-  it('should throw HealthCheckError if Redis connection fails', async () => {
-    mockConnect.mockRejectedValue(new Error('ECONNREFUSED'));
+  it('should throw HealthCheckError with ECONNREFUSED hint', async () => {
+    mockConnect.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:6379'));
 
-    await expect(indicator.isHealthy('redis')).rejects.toThrow(
-      HealthCheckError,
-    );
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect.assertions(2);
+    try {
+      await indicator.isHealthy('redis');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HealthCheckError);
+      const causes = (err as HealthCheckError).causes as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(causes.redis.hint).toContain('not running');
+    }
+  });
+
+  it('should throw HealthCheckError with timeout hint', async () => {
+    mockConnect.mockRejectedValue(new Error('Connection timed out'));
+
+    expect.assertions(2);
+    try {
+      await indicator.isHealthy('redis');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HealthCheckError);
+      const causes = (err as HealthCheckError).causes as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(causes.redis.hint).toContain('timed out');
+    }
+  });
+
+  it('should throw HealthCheckError with auth hint on NOAUTH', async () => {
+    mockConnect.mockRejectedValue(new Error('NOAUTH Authentication required'));
+
+    expect.assertions(2);
+    try {
+      await indicator.isHealthy('redis');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HealthCheckError);
+      const causes = (err as HealthCheckError).causes as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(causes.redis.hint).toContain('REDIS_PASSWORD');
+    }
   });
 
   it('should return disabled mode when ENABLE_BACKGROUND_JOBS is not true', async () => {
@@ -114,5 +163,21 @@ describe('RedisHealthIndicator', () => {
       },
     });
     expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it('includes generic hint for unknown errors', async () => {
+    mockConnect.mockRejectedValue(new Error('some weird error'));
+
+    expect.assertions(2);
+    try {
+      await indicator.isHealthy('redis');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HealthCheckError);
+      const causes = (err as HealthCheckError).causes as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(causes.redis.hint).toContain('REDIS_HOST');
+    }
   });
 });

--- a/xconfess-backend/src/health/redis.health.ts
+++ b/xconfess-backend/src/health/redis.health.ts
@@ -17,6 +17,22 @@ function resolveDisabledReason(rawValue: unknown): string {
   return `ENABLE_BACKGROUND_JOBS is set to "${String(rawValue)}" (expected "true" to enable)`;
 }
 
+function resolveActionableHint(errorMessage: string): string {
+  const lower = errorMessage.toLowerCase();
+
+  if (lower.includes('econnrefused')) {
+    return 'Redis server is not running or not accepting connections. Verify REDIS_HOST and REDIS_PORT, and ensure Redis is started.';
+  }
+  if (lower.includes('timeout') || lower.includes('timed out')) {
+    return 'Connection timed out. Check network connectivity between the application and Redis host.';
+  }
+  if (lower.includes('noauth') || lower.includes('auth')) {
+    return 'Authentication failed. If Redis requires a password, set the REDIS_PASSWORD environment variable.';
+  }
+
+  return 'Check backend logs for the full error. Verify REDIS_HOST and REDIS_PORT environment variables.';
+}
+
 @Injectable()
 export class RedisHealthIndicator extends HealthIndicator {
   private readonly logger = new Logger(RedisHealthIndicator.name);
@@ -53,15 +69,41 @@ export class RedisHealthIndicator extends HealthIndicator {
 
     try {
       await client.connect();
+
+      const start = Date.now();
       await client.ping();
-      return this.getStatus(key, true, { host, port });
+      const latencyMs = Date.now() - start;
+
+      // Retrieve server version and connected client count
+      const infoRaw = await client.info('server');
+      const versionMatch = infoRaw.match(/redis_version:([\d.]+)/);
+      const version = versionMatch ? versionMatch[1] : undefined;
+
+      const clientsRaw = await client.info('clients');
+      const clientsMatch = clientsRaw.match(/connected_clients:(\d+)/);
+      const connectedClients = clientsMatch
+        ? parseInt(clientsMatch[1], 10)
+        : undefined;
+
+      return this.getStatus(key, true, {
+        host,
+        port,
+        latencyMs,
+        version,
+        connectedClients,
+      });
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : String(error);
       this.logger.error(`Redis health check failed: ${message}`);
       throw new HealthCheckError(
         'Redis is unreachable',
-        this.getStatus(key, false, { host, port, error: message }),
+        this.getStatus(key, false, {
+          host,
+          port,
+          error: message,
+          hint: resolveActionableHint(message),
+        }),
       );
     } finally {
       try {


### PR DESCRIPTION
## Summary
- Replace basic TypeORM `pingCheck` with a custom `PostgresHealthIndicator` that reports connection latency, server version, and active/max connection counts
- Enhance `RedisHealthIndicator` with latency measurement, server version, and connected client count
- Add actionable error hints for common failure scenarios (ECONNREFUSED, timeout, auth failure, pool exhaustion, SSL) to both Postgres and Redis indicators
- Include a `subsystems` summary array in readiness responses so operators can immediately see which dependency is degraded

## Test plan
- [x] All 42 health module unit tests pass (`src/health/*.spec.ts`)
- [x] New `PostgresHealthIndicator` tests cover: healthy state, ECONNREFUSED, timeout, auth failure, pool exhaustion, error detail structure
- [x] Updated `RedisHealthIndicator` tests cover: latency/version/clients on success, ECONNREFUSED hint, timeout hint, NOAUTH hint, generic error hint
- [x] Updated `HealthController` tests verify subsystems summary array, disabled subsystem marking

Closes #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)