### PR TITLE
fix(frontend): add profile privacy controls UI

### DIFF
--- a/xconfess-frontend/app/(dashboard)/settings/privacy/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/settings/privacy/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from 'react';
-import { Shield, Eye, MessageSquare, Database, Save, Sun, Moon, Laptop } from 'lucide-react';
+import { Shield, Eye, EyeOff, MessageSquare, Database, Save, Sun, Moon, Laptop, Lock, Globe, Bell, BellOff } from 'lucide-react';
 import { useGlobalToast } from '@/app/components/common/Toast';
 import { useTheme } from '@/app/lib/hooks/useTheme';
 
@@ -12,12 +12,81 @@ interface PrivacySettings {
   dataProcessingConsent: boolean;
 }
 
+interface ToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  id: string;
+}
+
+function ToggleSwitch({ checked, onChange, id }: ToggleProps) {
+  return (
+    <button
+      id={id}
+      role="switch"
+      type="button"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+        checked ? 'bg-purple-600' : 'bg-gray-600'
+      }`}
+    >
+      <span
+        aria-hidden="true"
+        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+          checked ? 'translate-x-5' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  );
+}
+
+const TOGGLE_CONFIGS: {
+  key: keyof PrivacySettings;
+  label: string;
+  description: string;
+  effect: string;
+  icon: React.ReactNode;
+  iconOff?: React.ReactNode;
+}[] = [
+  {
+    key: 'isDiscoverable',
+    label: 'Profile Discovery',
+    description: 'Allow others to find your profile in search and the user directory.',
+    effect: 'When off, your profile is hidden from search results and the public directory. Direct links to your profile will still work.',
+    icon: <Globe className="h-5 w-5 text-purple-400" />,
+    iconOff: <Lock className="h-5 w-5 text-gray-500" />,
+  },
+  {
+    key: 'canReceiveReplies',
+    label: 'Allow Replies',
+    description: 'Let other users reply to your confessions.',
+    effect: 'When off, the reply button is disabled on all your confessions. Existing replies remain visible.',
+    icon: <MessageSquare className="h-5 w-5 text-blue-400" />,
+  },
+  {
+    key: 'showReactions',
+    label: 'Show Reactions',
+    description: 'Display emoji reactions on your confessions.',
+    effect: 'When off, reaction counts and buttons are hidden on your confessions. Others can still react, but counts are not shown.',
+    icon: <Bell className="h-5 w-5 text-yellow-400" />,
+    iconOff: <BellOff className="h-5 w-5 text-gray-500" />,
+  },
+  {
+    key: 'dataProcessingConsent',
+    label: 'Data Processing Consent',
+    description: 'Allow processing of your data for service improvement and analytics.',
+    effect: 'When off, your usage data is excluded from analytics aggregation. Core functionality is not affected.',
+    icon: <Database className="h-5 w-5 text-green-400" />,
+  },
+];
+
 export default function PrivacySettingsPage() {
   const { theme, setTheme } = useTheme();
   const [settings, setSettings] = useState<PrivacySettings | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
   const toast = useGlobalToast();
 
   const loadSettings = React.useCallback(async () => {
@@ -35,6 +104,7 @@ export default function PrivacySettingsPage() {
 
       const data: PrivacySettings = await response.json();
       setSettings(data);
+      setDirty(false);
     } catch {
       setLoadError('Failed to load privacy settings.');
       toast.error('Failed to load privacy settings');
@@ -46,6 +116,12 @@ export default function PrivacySettingsPage() {
   useEffect(() => {
     void loadSettings();
   }, [loadSettings]);
+
+  const handleToggle = (key: keyof PrivacySettings, value: boolean) => {
+    if (!settings) return;
+    setSettings({ ...settings, [key]: value });
+    setDirty(true);
+  };
 
   const handleSave = async () => {
     if (!settings) return;
@@ -67,6 +143,7 @@ export default function PrivacySettingsPage() {
 
       const updated: PrivacySettings = await response.json();
       setSettings(updated);
+      setDirty(false);
       toast.success('Privacy settings saved successfully');
     } catch {
       toast.error('Failed to save privacy settings');
@@ -109,7 +186,7 @@ export default function PrivacySettingsPage() {
           Privacy Settings
         </h1>
         <p className="text-gray-400 mt-1">
-          Manage your visibility and consent controls
+          Control your visibility, interactions, and data preferences. Each setting maps directly to how your profile behaves across the platform.
         </p>
       </div>
 
@@ -164,113 +241,86 @@ export default function PrivacySettingsPage() {
         <div className="p-4 border-b border-gray-700">
           <h2 className="font-semibold text-white flex items-center gap-2">
             <Eye className="h-4 w-4" />
-            Discoverability
+            Privacy Controls
           </h2>
-          <p className="text-sm text-gray-400">Control your profile visibility</p>
+          <p className="text-sm text-gray-400">
+            Manage how your profile and content are visible to others
+          </p>
         </div>
-        <div className="p-4">
-          <label className="flex items-center justify-between">
-            <div>
-              <div className="font-medium text-white">Profile Discovery</div>
-              <div className="text-sm text-gray-400">
-                Allow others to find your profile in search and directory
+        <div className="divide-y divide-gray-700">
+          {TOGGLE_CONFIGS.map((config) => {
+            const isOn = settings[config.key];
+            return (
+              <div key={config.key} className="p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-start gap-3 min-w-0">
+                    <div className="mt-0.5 flex-shrink-0">
+                      {isOn
+                        ? config.icon
+                        : config.iconOff ?? config.icon}
+                    </div>
+                    <div className="min-w-0">
+                      <label
+                        htmlFor={`toggle-${config.key}`}
+                        className="font-medium text-white cursor-pointer"
+                      >
+                        {config.label}
+                      </label>
+                      <p className="text-sm text-gray-400 mt-0.5">
+                        {config.description}
+                      </p>
+                      <p className="text-xs text-gray-500 mt-1 italic">
+                        {config.effect}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex-shrink-0 pt-0.5">
+                    <ToggleSwitch
+                      id={`toggle-${config.key}`}
+                      checked={isOn}
+                      onChange={(val) => handleToggle(config.key, val)}
+                    />
+                  </div>
+                </div>
+                <div className="ml-8 mt-2">
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+                      isOn
+                        ? 'bg-green-900/50 text-green-400'
+                        : 'bg-gray-700 text-gray-400'
+                    }`}
+                  >
+                    {isOn ? (
+                      <>
+                        <Eye className="h-3 w-3" /> Enabled
+                      </>
+                    ) : (
+                      <>
+                        <EyeOff className="h-3 w-3" /> Disabled
+                      </>
+                    )}
+                  </span>
+                </div>
               </div>
-            </div>
-            <input
-              type="checkbox"
-              checked={settings.isDiscoverable}
-              onChange={(e) =>
-                setSettings({ ...settings, isDiscoverable: e.target.checked })
-              }
-              className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:ring-blue-500"
-            />
-          </label>
-        </div>
-      </div>
-
-      <div className="bg-gray-800 rounded-lg mb-4">
-        <div className="p-4 border-b border-gray-700">
-          <h2 className="font-semibold text-white flex items-center gap-2">
-            <MessageSquare className="h-4 w-4" />
-            Interaction Controls
-          </h2>
-          <p className="text-sm text-gray-400">Manage replies and reactions</p>
-        </div>
-        <div className="p-4 space-y-4">
-          <label className="flex items-center justify-between">
-            <div>
-              <div className="font-medium text-white">Allow Replies</div>
-              <div className="text-sm text-gray-400">
-                Let users reply to your confessions
-              </div>
-            </div>
-            <input
-              type="checkbox"
-              checked={settings.canReceiveReplies}
-              onChange={(e) =>
-                setSettings({ ...settings, canReceiveReplies: e.target.checked })
-              }
-              className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:ring-blue-500"
-            />
-          </label>
-          <label className="flex items-center justify-between">
-            <div>
-              <div className="font-medium text-white">Show Reactions</div>
-              <div className="text-sm text-gray-400">
-                Display reactions on your confessions
-              </div>
-            </div>
-            <input
-              type="checkbox"
-              checked={settings.showReactions}
-              onChange={(e) =>
-                setSettings({ ...settings, showReactions: e.target.checked })
-              }
-              className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:ring-blue-500"
-            />
-          </label>
-        </div>
-      </div>
-
-      <div className="bg-gray-800 rounded-lg mb-6">
-        <div className="p-4 border-b border-gray-700">
-          <h2 className="font-semibold text-white flex items-center gap-2">
-            <Database className="h-4 w-4" />
-            Data Handling
-          </h2>
-          <p className="text-sm text-gray-400">Control data processing consent</p>
-        </div>
-        <div className="p-4">
-          <label className="flex items-center justify-between">
-            <div>
-              <div className="font-medium text-white">Data Processing Consent</div>
-              <div className="text-sm text-gray-400">
-                Allow processing of your data for service improvement
-              </div>
-            </div>
-            <input
-              type="checkbox"
-              checked={settings.dataProcessingConsent}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  dataProcessingConsent: e.target.checked,
-                })
-              }
-              className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:ring-blue-500"
-            />
-          </label>
+            );
+          })}
         </div>
       </div>
 
       <button
         onClick={handleSave}
-        disabled={saving}
-        className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2 px-4 rounded flex items-center justify-center gap-2 transition-colors"
+        disabled={saving || !dirty}
+        className="w-full bg-purple-600 hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2.5 px-4 rounded-lg flex items-center justify-center gap-2 transition-colors font-medium"
       >
         <Save className="h-4 w-4" />
         {saving ? 'Saving...' : 'Save Settings'}
       </button>
+
+      {dirty && (
+        <p className="text-center text-xs text-yellow-500 mt-2">
+          You have unsaved changes.
+        </p>
+      )}
     </div>
   );
 }

--- a/xconfess-frontend/tests/settings/privacy-controls.spec.tsx
+++ b/xconfess-frontend/tests/settings/privacy-controls.spec.tsx
@@ -1,0 +1,223 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock useTheme before importing the component
+jest.mock("@/app/lib/hooks/useTheme", () => ({
+  useTheme: () => ({ theme: "dark", setTheme: jest.fn() }),
+}));
+
+// Mock the toast hook
+const mockToast = { success: jest.fn(), error: jest.fn(), info: jest.fn() };
+jest.mock("@/app/components/common/Toast", () => ({
+  useGlobalToast: () => mockToast,
+}));
+
+import PrivacySettingsPage from "@/app/(dashboard)/settings/privacy/page";
+
+const defaultSettings = {
+  isDiscoverable: true,
+  canReceiveReplies: true,
+  showReactions: true,
+  dataProcessingConsent: false,
+};
+
+function mockFetch(settings = defaultSettings) {
+  return jest.fn().mockImplementation((url: string, opts?: RequestInit) => {
+    if (opts?.method === "PATCH") {
+      const body = JSON.parse(opts.body as string);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(body),
+      });
+    }
+    // GET
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(settings),
+    });
+  });
+}
+
+describe("PrivacySettingsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch() as unknown as typeof fetch;
+  });
+
+  it("renders all four privacy toggle controls", async () => {
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile Discovery")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Allow Replies")).toBeInTheDocument();
+    expect(screen.getByText("Show Reactions")).toBeInTheDocument();
+    expect(screen.getByText("Data Processing Consent")).toBeInTheDocument();
+  });
+
+  it("shows the effect description for each toggle", async () => {
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile Discovery")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/hidden from search results/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/reply button is disabled/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/reaction counts and buttons are hidden/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/excluded from analytics/),
+    ).toBeInTheDocument();
+  });
+
+  it("loads settings from the API on mount", async () => {
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/users/privacy-settings",
+        expect.objectContaining({ credentials: "include" }),
+      );
+    });
+  });
+
+  it("renders toggle switches with correct initial state", async () => {
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile Discovery")).toBeInTheDocument();
+    });
+
+    const switches = screen.getAllByRole("switch");
+    // isDiscoverable=true, canReceiveReplies=true, showReactions=true, dataProcessingConsent=false
+    expect(switches[0]).toHaveAttribute("aria-checked", "true");
+    expect(switches[1]).toHaveAttribute("aria-checked", "true");
+    expect(switches[2]).toHaveAttribute("aria-checked", "true");
+    expect(switches[3]).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("toggles a setting and enables the save button", async () => {
+    const user = userEvent.setup();
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile Discovery")).toBeInTheDocument();
+    });
+
+    const saveButton = screen.getByRole("button", { name: /save settings/i });
+    // Save should be disabled initially (no changes)
+    expect(saveButton).toBeDisabled();
+
+    // Click the first toggle to disable discovery
+    const discoveryToggle = screen.getAllByRole("switch")[0];
+    await user.click(discoveryToggle);
+
+    expect(discoveryToggle).toHaveAttribute("aria-checked", "false");
+    // Save button should now be enabled
+    expect(saveButton).toBeEnabled();
+    // Unsaved changes text should appear
+    expect(screen.getByText("You have unsaved changes.")).toBeInTheDocument();
+  });
+
+  it("saves settings when the save button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile Discovery")).toBeInTheDocument();
+    });
+
+    // Toggle a setting to enable save
+    const dataToggle = screen.getAllByRole("switch")[3];
+    await user.click(dataToggle);
+
+    const saveButton = screen.getByRole("button", { name: /save settings/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/users/privacy-settings",
+        expect.objectContaining({
+          method: "PATCH",
+          body: expect.stringContaining('"dataProcessingConsent":true'),
+        }),
+      );
+    });
+
+    expect(mockToast.success).toHaveBeenCalledWith(
+      "Privacy settings saved successfully",
+    );
+  });
+
+  it("shows an error toast when loading fails", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch;
+
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith(
+        "Failed to load privacy settings",
+      );
+    });
+
+    expect(screen.getByText(/Failed to load/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("shows an error toast when saving fails", async () => {
+    const user = userEvent.setup();
+
+    const fetchMock = jest.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (opts?.method === "PATCH") {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(defaultSettings),
+      });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile Discovery")).toBeInTheDocument();
+    });
+
+    // Toggle and save
+    await user.click(screen.getAllByRole("switch")[0]);
+    await user.click(screen.getByRole("button", { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith(
+        "Failed to save privacy settings",
+      );
+    });
+  });
+
+  it("displays enabled/disabled badges for each toggle", async () => {
+    render(<PrivacySettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile Discovery")).toBeInTheDocument();
+    });
+
+    // 3 enabled (isDiscoverable, canReceiveReplies, showReactions), 1 disabled (dataProcessingConsent)
+    const enabledBadges = screen.getAllByText("Enabled");
+    const disabledBadges = screen.getAllByText("Disabled");
+
+    expect(enabledBadges).toHaveLength(3);
+    expect(disabledBadges).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace basic HTML checkboxes with accessible toggle switches (`role="switch"`, `aria-checked`)
- Add effect descriptions for each toggle explaining the backend behavior (e.g., "When off, your profile is hidden from search results")
- Add enabled/disabled status badges, unsaved-changes indicator, and dirty-state tracking
- Four privacy toggles: Profile Discovery, Allow Replies, Show Reactions, Data Processing Consent

## Test plan
- [x] Unit tests for toggle rendering and initial state loading
- [x] Unit tests for toggle interaction enabling save button
- [x] Unit tests for save flow (PATCH API call, success toast)
- [x] Unit tests for error handling on load and save failures
- [x] Unit tests for retry button on load failure
- [x] Unit tests for enabled/disabled badge display

Closes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)