### PR TITLE
End-to-End Anonymous Identity Ownership Hardening and Audit Matrix

### DIFF
--- a/docs/anonymous-identity-ownership-audit.md
+++ b/docs/anonymous-identity-ownership-audit.md
@@ -1,0 +1,61 @@
+# Anonymous Identity and Ownership Security Audit
+
+Issue: #1694
+
+## Threat Model
+
+XConfess separates real account identity from anonymous identities. Any anonymous identity linked through `user_anonymous_users` is private account state. A caller must not be able to infer, use, mutate, export, message, report as, or moderate through another account's linked anonymous identity.
+
+The default rule is:
+
+- Linked anonymous identity: usable only by the linked authenticated account.
+- Unlinked anonymous identity: usable by public anonymous surfaces that intentionally do not require login.
+- Missing or forged linked identity: return `404` so the response does not confirm whether the identity exists.
+- Admin exception: admin-only moderation/report/audit endpoints may cross ownership boundaries when protected by `JwtAuthGuard` and `AdminGuard`.
+
+## Endpoint Ownership Matrix
+
+| Surface | Endpoint | IDs accepted | Ownership rule | Failure |
+| --- | --- | --- | --- | --- |
+| Confessions public feed | `GET /confessions`, `GET /confessions/:id`, search/tag/trending routes | `confessionId`, tag/search query | Public approved, non-deleted surface. No user ownership required. | `404` for missing/deleted item paths |
+| Confession create | `POST /confessions` | body only | Creates a fresh anonymous confession through service rules. No linked identity is accepted from caller. | `400` validation |
+| Confession mutate | `PUT /confessions/:id`, `DELETE /confessions/:id`, `PATCH /confessions/:id/restore`, schedule routes | `confessionId` | High-risk legacy surface. Must be treated as owner/admin-only before production exposure. | Should be `403`/`404` |
+| Comments public read | `GET /confessions/:confessionId/comments` | `confessionId` | Public approved comments only. | Empty/`404` via confession filtering |
+| Comments create/edit/delete | `POST/PATCH/DELETE /confessions/:confessionId/comments...` | `confessionId`, `commentId`, `anonymousContextId` | JWT required. Edit/delete compares comment anonymous user to authenticated request anonymous user. | `403`/`404` depending path |
+| Reactions | `POST /reactions` | `confessionId`, `anonymousUserId` | Optional JWT. Linked `anonymousUserId` must belong to authenticated caller; unlinked IDs remain public. | `404` for forged/missing anonymous identity |
+| Reports | `POST /confessions/:id/report` | `confessionId`, `x-anonymous-user-id`, idempotency key | Optional JWT. Authenticated reports use real `reporterId`; anonymous reports may use only unlinked anonymous identities. Linked IDs cannot be used without owner auth. | `400` missing anon header, `404` forged/missing linked identity |
+| Messages | `POST /messages`, reply/thread/inbox routes | `confessionId`, `messageId`, `threadId`, sender anonymous ID in thread | JWT required. Service resolves sender from caller session and verifies thread participant via caller's anonymous links. | `404` for non-participant thread reads |
+| Data export | `/data-export/*`, `/export/*` | `exportId`, `jobId`, signed token | JWT endpoints bind requests by `req.user.id`. Signed downloads require the stored token, not only ID. | `401` invalid token, `404` missing owner-bound job |
+| User history/profile private | `GET /users/:userId/activities`, `confessions`, settings/delete | `userId` | `OwnershipGuard` requires `req.user.id === :userId`; delete allows admin bypass. | `403` |
+| Admin reports/moderation/users | `/admin/*`, comment admin, moderation, email, key rotation, DLQ admin | report/confession/comment/user IDs | Admin-only exception. Must be protected by `JwtAuthGuard` + `AdminGuard`. | `403` for non-admin |
+| Tips | `/confessions/:id/tips*`, tip verification | `confessionId`, `tipId`, `txId` | Public tip stats by confession; verification is idempotent by `(confessionId, txId)` and does not accept anonymous account identity. | `404` missing confession, `409` replay/conflict |
+
+## Hardened Endpoints
+
+- `POST /reactions`
+  - Now uses `OptionalJwtAuthGuard`.
+  - Linked `anonymousUserId` requires the authenticated linked account.
+  - Public unlinked anonymous identities continue to work.
+
+- `POST /confessions/:id/report`
+  - Anonymous reports now verify the supplied `x-anonymous-user-id`.
+  - Linked anonymous identities are rejected for anonymous callers with `404`.
+  - Authenticated reports continue to bind to `reporterId`, not a body/header identity.
+
+## Regression Coverage
+
+- `src/common/security/anonymous-identity-ownership.spec.ts`
+  - Shared anonymous identity assertion tests.
+- `src/reaction/reaction.service.spec.ts`
+  - Owner linked identity allowed.
+  - Another user's linked identity rejected with `404`.
+  - Public unlinked anonymous identity still works.
+- `src/report/reports.service.spec.ts`
+  - Anonymous report with forged linked identity rejected before report creation.
+
+## Review Evidence Commands
+
+```bash
+npm run test --workspace=xconfess-backend -- src/common/security/anonymous-identity-ownership.spec.ts src/reaction/reaction.service.spec.ts src/report/reports.service.spec.ts
+npm run build --workspace=xconfess-backend
+```

--- a/xconfess-backend/src/common/security/anonymous-identity-ownership.spec.ts
+++ b/xconfess-backend/src/common/security/anonymous-identity-ownership.spec.ts
@@ -1,0 +1,41 @@
+import { NotFoundException } from '@nestjs/common';
+import { assertCanUseAnonymousIdentity } from './anonymous-identity-ownership';
+import { createAnonymousOwnershipFixture } from '../../../test/utils/anonymous-ownership.factory';
+
+describe('assertCanUseAnonymousIdentity', () => {
+  it('allows public use of unlinked anonymous identities', () => {
+    const fixture = createAnonymousOwnershipFixture();
+
+    expect(() =>
+      assertCanUseAnonymousIdentity(fixture.publicAnon),
+    ).not.toThrow();
+  });
+
+  it('allows linked anonymous identity use by the owning user', () => {
+    const fixture = createAnonymousOwnershipFixture();
+
+    expect(() =>
+      assertCanUseAnonymousIdentity(fixture.ownerLinkedAnon, {
+        userId: fixture.ownerUserId,
+      }),
+    ).not.toThrow();
+  });
+
+  it('returns 404 for linked anonymous identity use by another user', () => {
+    const fixture = createAnonymousOwnershipFixture();
+
+    expect(() =>
+      assertCanUseAnonymousIdentity(fixture.otherLinkedAnon, {
+        userId: fixture.ownerUserId,
+      }),
+    ).toThrow(NotFoundException);
+  });
+
+  it('returns 404 for unauthenticated use of linked anonymous identities', () => {
+    const fixture = createAnonymousOwnershipFixture();
+
+    expect(() =>
+      assertCanUseAnonymousIdentity(fixture.ownerLinkedAnon),
+    ).toThrow(NotFoundException);
+  });
+});

--- a/xconfess-backend/src/common/security/anonymous-identity-ownership.ts
+++ b/xconfess-backend/src/common/security/anonymous-identity-ownership.ts
@@ -1,0 +1,32 @@
+import { NotFoundException } from '@nestjs/common';
+import { AnonymousUser } from '../../user/entities/anonymous-user.entity';
+
+export interface AnonymousIdentityActor {
+  userId?: number | string | null;
+}
+
+/**
+ * Anonymous identity ownership is intentionally fail-closed for linked
+ * identities. Returning 404 keeps callers from enumerating whether a linked
+ * anonymous identity exists or which account owns it.
+ */
+export function assertCanUseAnonymousIdentity(
+  anonymousUser: AnonymousUser | null,
+  actor?: AnonymousIdentityActor,
+): asserts anonymousUser is AnonymousUser {
+  if (!anonymousUser) {
+    throw new NotFoundException('Anonymous user not found');
+  }
+
+  const linkedUserIds =
+    anonymousUser.userLinks?.map((link) => String(link.userId)) ?? [];
+
+  if (linkedUserIds.length === 0) {
+    return;
+  }
+
+  const actorUserId = actor?.userId;
+  if (!actorUserId || !linkedUserIds.includes(String(actorUserId))) {
+    throw new NotFoundException('Anonymous identity not found');
+  }
+}

--- a/xconfess-backend/src/reaction/reaction.controller.ts
+++ b/xconfess-backend/src/reaction/reaction.controller.ts
@@ -1,15 +1,20 @@
-import { Controller, Post, Get, Param, Body, Query } from '@nestjs/common';
+import { Controller, Post, Body, Req, UseGuards } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiBody,
-  ApiParam,
   ApiResponse,
-  ApiQuery,
 } from '@nestjs/swagger';
+import { Request } from 'express';
 import { ReactionService } from './reaction.service';
 import { CreateReactionDto } from './dto/create-reaction.dto';
 import { Reaction } from './entities/reaction.entity';
+import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
+import { RequestUser } from '../auth/interfaces/jwt-payload.interface';
+
+interface OptionalAuthRequest extends Request {
+  user?: RequestUser | null;
+}
 
 @ApiTags('Reactions')
 @Controller('reactions')
@@ -17,11 +22,15 @@ export class ReactionController {
   constructor(private readonly reactionService: ReactionService) {}
 
   @Post()
+  @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({ summary: 'Add or update an emoji reaction on a confession' })
   @ApiBody({ type: CreateReactionDto })
   @ApiResponse({ status: 201, description: 'Reaction recorded.' })
   @ApiResponse({ status: 404, description: 'Confession or user not found.' })
-  async addReaction(@Body() dto: CreateReactionDto): Promise<Reaction> {
-    return this.reactionService.createReaction(dto);
+  async addReaction(
+    @Body() dto: CreateReactionDto,
+    @Req() req: OptionalAuthRequest,
+  ): Promise<Reaction> {
+    return this.reactionService.createReaction(dto, req.user?.id ?? null);
   }
 }

--- a/xconfess-backend/src/reaction/reaction.service.spec.ts
+++ b/xconfess-backend/src/reaction/reaction.service.spec.ts
@@ -9,6 +9,7 @@ import { AnonymousUser } from '../user/entities/anonymous-user.entity';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { ReactionsGateway } from './reactions.gateway';
+import { createAnonymousOwnershipFixture } from '../../test/utils/anonymous-ownership.factory';
 
 // ─── Factories ───────────────────────────────────────────────────────────────
 
@@ -239,6 +240,59 @@ describe('ReactionService', () => {
       );
 
       expect(reactionRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('allows an authenticated user to react with their linked anonymous identity', async () => {
+      const fixture = createAnonymousOwnershipFixture();
+      const user = fixture.ownerLinkedAnon;
+      const reaction = makeReaction({ anonymousUser: user });
+
+      confessionRepo.findOne.mockResolvedValue(makeConfession());
+      anonymousUserRepo.findOne.mockResolvedValue(user);
+      managerReactionRepo.findOne.mockResolvedValue(null);
+      managerReactionRepo.create.mockReturnValue(reaction);
+      managerReactionRepo.save.mockResolvedValue(reaction);
+
+      const result = await service.createReaction(
+        { ...dto, anonymousUserId: fixture.ownerLinkedAnonId },
+        fixture.ownerUserId,
+      );
+
+      expect(result).toBe(reaction);
+    });
+
+    it('returns 404 when a user forges another account linked anonymous identity', async () => {
+      const fixture = createAnonymousOwnershipFixture();
+
+      confessionRepo.findOne.mockResolvedValue(makeConfession());
+      anonymousUserRepo.findOne.mockResolvedValue(fixture.otherLinkedAnon);
+
+      await expect(
+        service.createReaction(
+          { ...dto, anonymousUserId: fixture.otherLinkedAnonId },
+          fixture.ownerUserId,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+
+      expect(managerReactionRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('keeps public reactions working for unlinked anonymous identities', async () => {
+      const fixture = createAnonymousOwnershipFixture();
+      const reaction = makeReaction({ anonymousUser: fixture.publicAnon });
+
+      confessionRepo.findOne.mockResolvedValue(makeConfession());
+      anonymousUserRepo.findOne.mockResolvedValue(fixture.publicAnon);
+      managerReactionRepo.findOne.mockResolvedValue(null);
+      managerReactionRepo.create.mockReturnValue(reaction);
+      managerReactionRepo.save.mockResolvedValue(reaction);
+
+      const result = await service.createReaction({
+        ...dto,
+        anonymousUserId: fixture.publicAnonId,
+      });
+
+      expect(result).toBe(reaction);
     });
 
     // ── Schema alignment guard ──────────────────────────────────────────────

--- a/xconfess-backend/src/reaction/reaction.service.ts
+++ b/xconfess-backend/src/reaction/reaction.service.ts
@@ -12,6 +12,7 @@ import { CreateReactionDto } from './dto/create-reaction.dto';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { Reaction } from './entities/reaction.entity';
 import { AnonymousUser } from '../user/entities/anonymous-user.entity';
+import { assertCanUseAnonymousIdentity } from '../common/security/anonymous-identity-ownership';
 import {
   OutboxEvent,
   OutboxStatus,
@@ -37,7 +38,10 @@ export class ReactionService {
     private readonly reactionsGateway: ReactionsGateway,
   ) {}
 
-  async createReaction(dto: CreateReactionDto): Promise<Reaction> {
+  async createReaction(
+    dto: CreateReactionDto,
+    actorUserId?: number | string | null,
+  ): Promise<Reaction> {
     if (!dto.anonymousUserId) {
       throw new BadRequestException('Anonymous user id is required');
     }
@@ -67,11 +71,10 @@ export class ReactionService {
     // 2. Verify the reacting anonymous user exists.
     const anonymousUser = await this.anonymousUserRepo.findOne({
       where: { id: anonymousUserId },
+      relations: ['userLinks'],
     });
 
-    if (!anonymousUser) {
-      throw new NotFoundException('Anonymous user not found');
-    }
+    assertCanUseAnonymousIdentity(anonymousUser, { userId: actorUserId });
 
     return this.dataSource
       .transaction(async (manager) => {

--- a/xconfess-backend/src/report/report.module.ts
+++ b/xconfess-backend/src/report/report.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Report } from '../admin/entities/report.entity';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
+import { AnonymousUser } from '../user/entities/anonymous-user.entity';
 import { AuditLogModule } from '../audit-log/audit-log.module';
 import { AuthModule } from '../auth/auth.module';
 import { ReportsService } from './reports.service';
@@ -10,7 +11,12 @@ import { ReportsController } from './reports.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Report, AnonymousConfession, OutboxEvent]),
+    TypeOrmModule.forFeature([
+      Report,
+      AnonymousConfession,
+      AnonymousUser,
+      OutboxEvent,
+    ]),
     AuditLogModule,
     AuthModule,
   ],

--- a/xconfess-backend/src/report/reports.module.spec.ts
+++ b/xconfess-backend/src/report/reports.module.spec.ts
@@ -7,6 +7,7 @@ import { ReportsController } from './reports.controller';
 import { Report } from '../admin/entities/report.entity';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
 import { OutboxEvent } from '../common/entities/outbox-event.entity';
+import { AnonymousUser } from '../user/entities/anonymous-user.entity';
 import { AuditLogService } from '../audit-log/audit-log.service';
 import { AuditLogModule } from '../audit-log/audit-log.module';
 import { AuthModule } from '../auth/auth.module';
@@ -29,6 +30,7 @@ async function compileReportTestingModule() {
         provide: getRepositoryToken(AnonymousConfession),
         useValue: mockRepository(),
       },
+      { provide: getRepositoryToken(AnonymousUser), useValue: mockRepository() },
       { provide: getRepositoryToken(OutboxEvent), useValue: mockRepository() },
       {
         provide: AuditLogService,
@@ -76,6 +78,7 @@ describe('ReportModule', () => {
       providers: [
         ReportsService,
         { provide: getRepositoryToken(Report), useValue: mockRepository() },
+        { provide: getRepositoryToken(AnonymousUser), useValue: mockRepository() },
         { provide: getRepositoryToken(OutboxEvent), useValue: mockRepository() },
         { provide: AuditLogService, useValue: {} },
       ],
@@ -104,6 +107,7 @@ describe('ReportModule', () => {
       expect.arrayContaining([
         getRepositoryToken(Report),
         getRepositoryToken(AnonymousConfession),
+        getRepositoryToken(AnonymousUser),
         getRepositoryToken(OutboxEvent),
       ]),
     );

--- a/xconfess-backend/src/report/reports.service.spec.ts
+++ b/xconfess-backend/src/report/reports.service.spec.ts
@@ -6,6 +6,7 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ReportsService } from './reports.service';
 import { ReportStatus, ReportType } from '../admin/entities/report.entity';
 import { AuditActionType } from '../audit-log/audit-log.entity';
+import { createAnonymousOwnershipFixture } from '../../test/utils/anonymous-ownership.factory';
 
 // Minimal stub factory for chained query-builder
 function makeQb(result: any = null) {
@@ -29,6 +30,9 @@ describe('ReportsService — idempotency & replay safety (#780)', () => {
   };
 
   const confessionRepository: any = {};
+  const anonymousUserRepository: any = {
+    findOne: jest.fn(),
+  };
   const outboxRepository: any = {};
 
   const auditLogService: any = {
@@ -40,8 +44,12 @@ describe('ReportsService — idempotency & replay safety (#780)', () => {
     service = new ReportsService(
       reportRepository,
       confessionRepository,
+      anonymousUserRepository,
       outboxRepository,
       auditLogService,
+    );
+    anonymousUserRepository.findOne.mockResolvedValue(
+      createAnonymousOwnershipFixture().publicAnon,
     );
   });
 
@@ -223,6 +231,22 @@ describe('ReportsService — idempotency & replay safety (#780)', () => {
     await expect(
       service.createReport(confessionId, reporterId, dto, context)
     ).rejects.toThrow();
+  });
+
+  it('returns 404 when anonymous report forges a linked account identity', async () => {
+    const fixture = createAnonymousOwnershipFixture();
+    anonymousUserRepository.findOne.mockResolvedValue(fixture.ownerLinkedAnon);
+
+    await expect(
+      service.createReport(
+        'conf-123',
+        null,
+        { type: ReportType.SPAM },
+        { anonymousUserId: fixture.ownerLinkedAnonId },
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(reportRepository.manager.transaction).not.toHaveBeenCalled();
   });
 
   // ── New report (no duplicate) — happy path ────────────────────────────────

--- a/xconfess-backend/src/report/reports.service.ts
+++ b/xconfess-backend/src/report/reports.service.ts
@@ -16,6 +16,7 @@ import { PaginatedReportsResponseDto } from './dto/get-reports-response.dto';
 import { AuditLogService } from '../audit-log/audit-log.service';
 import { User, UserRole } from '../user/entities/user.entity';
 import { AnonymousUser } from '../user/entities/anonymous-user.entity';
+import { assertCanUseAnonymousIdentity } from '../common/security/anonymous-identity-ownership';
 import { RequestUser } from '../auth/interfaces/jwt-payload.interface';
 import {
   OutboxEvent,
@@ -41,6 +42,8 @@ export class ReportsService {
     private readonly reportRepository: Repository<Report>,
     @InjectRepository(AnonymousConfession)
     private readonly confessionRepository: Repository<AnonymousConfession>,
+    @InjectRepository(AnonymousUser)
+    private readonly anonymousUserRepository: Repository<AnonymousUser>,
     @InjectRepository(OutboxEvent)
     private readonly outboxRepository: Repository<OutboxEvent>,
     private readonly auditLogService: AuditLogService,
@@ -61,6 +64,14 @@ export class ReportsService {
       throw new BadRequestException(
         'Anonymous reports require a valid anonymous identity',
       );
+    }
+
+    if (reporterId === null && context?.anonymousUserId) {
+      const anonymousReporter = await this.anonymousUserRepository.findOne({
+        where: { id: context.anonymousUserId },
+        relations: ['userLinks'],
+      });
+      assertCanUseAnonymousIdentity(anonymousReporter);
     }
 
     // ── Idempotency replay ────────────────────────────────────────────────────

--- a/xconfess-backend/test/utils/anonymous-ownership.factory.ts
+++ b/xconfess-backend/test/utils/anonymous-ownership.factory.ts
@@ -1,0 +1,60 @@
+import { AnonymousUser } from '../../src/user/entities/anonymous-user.entity';
+import { UserAnonymousUser } from '../../src/user/entities/user-anonymous-link.entity';
+
+export interface AnonymousOwnershipFixture {
+  ownerUserId: number;
+  otherUserId: number;
+  ownerLinkedAnonId: string;
+  otherLinkedAnonId: string;
+  publicAnonId: string;
+  ownerLinkedAnon: AnonymousUser;
+  otherLinkedAnon: AnonymousUser;
+  publicAnon: AnonymousUser;
+}
+
+export function createAnonymousOwnershipFixture(
+  overrides: Partial<AnonymousOwnershipFixture> = {},
+): AnonymousOwnershipFixture {
+  const ownerUserId = overrides.ownerUserId ?? 101;
+  const otherUserId = overrides.otherUserId ?? 202;
+  const ownerLinkedAnonId =
+    overrides.ownerLinkedAnonId ?? '11111111-1111-4111-8111-111111111111';
+  const otherLinkedAnonId =
+    overrides.otherLinkedAnonId ?? '22222222-2222-4222-8222-222222222222';
+  const publicAnonId =
+    overrides.publicAnonId ?? '33333333-3333-4333-8333-333333333333';
+
+  return {
+    ownerUserId,
+    otherUserId,
+    ownerLinkedAnonId,
+    otherLinkedAnonId,
+    publicAnonId,
+    ownerLinkedAnon:
+      overrides.ownerLinkedAnon ??
+      makeAnonymousUser(ownerLinkedAnonId, ownerUserId),
+    otherLinkedAnon:
+      overrides.otherLinkedAnon ??
+      makeAnonymousUser(otherLinkedAnonId, otherUserId),
+    publicAnon:
+      overrides.publicAnon ?? makeAnonymousUser(publicAnonId, null),
+  };
+}
+
+export function makeAnonymousUser(
+  id: string,
+  linkedUserId: number | null,
+): AnonymousUser {
+  return {
+    id,
+    userLinks:
+      linkedUserId === null
+        ? []
+        : ([
+            {
+              userId: linkedUserId,
+              anonymousUserId: id,
+            },
+          ] as UserAnonymousUser[]),
+  } as AnonymousUser;
+}


### PR DESCRIPTION
# XConfess Anonymous Identity Ownership Hardening

This PR hardens anonymous identity ownership boundaries for XConfess and adds review-ready documentation for issue #1694.

It introduces a reusable ownership assertion for anonymous identities, applies it to high-risk IDOR paths, and documents the expected authorization model across public, authenticated, and admin-only endpoints.

## Changes

* Added a reusable anonymous identity ownership helper.
* Hardened `POST /reactions` so linked anonymous identities can only be used by their owning authenticated account.
* Hardened anonymous report creation so public callers cannot forge linked anonymous identities through `x-anonymous-user-id`.
* Preserved public anonymous behavior for unlinked anonymous identities.
* Added reusable two-user anonymous ownership test fixtures.
* Added an ownership matrix and threat model documentation in `docs/anonymous-identity-ownership-audit.md`.

## Security Model

* Linked anonymous identities are private account state.
* Unlinked anonymous identities remain valid for intentional public anonymous surfaces.
* Forged or missing linked anonymous identities return `404` to avoid enumeration.
* Admin-only exceptions are documented separately and require admin guards.

## Tests

Passed:

```bash
npm run test --workspace=xconfess-backend -- src/common/security/anonymous-identity-ownership.spec.ts src/reaction/reaction.service.spec.ts src/report/reports.service.spec.ts

npm run test --workspace=xconfess-backend -- src/report/reports.module.spec.ts src/reaction/reaction.controller.spec.ts

npm run build --workspace=xconfess-backend
```

## Review Evidence

* Ownership matrix: `docs/anonymous-identity-ownership-audit.md`
* Hardened endpoints:

  * `POST /reactions`
  * `POST /confessions/:id/report`

## Regression Coverage

* Owner linked anonymous identity allowed.
* Forged linked anonymous identity rejected.
* Unauthenticated use of linked anonymous identity rejected.
* Public unlinked anonymous identity still works.


close #1694 