### PR TITLE
Fix notification delivery reliability, idempotency, and reconnect sync

### DIFF
--- a/docs/notification-delivery-reliability.md
+++ b/docs/notification-delivery-reliability.md
@@ -1,0 +1,74 @@
+# Notification Delivery Reliability
+
+Issue #1695 defines notification delivery as an observable state machine rather
+than a best-effort side effect.
+
+## Delivery States
+
+```mermaid
+stateDiagram-v2
+  [*] --> created: notification row saved
+  created --> skipped: user preference, quiet hours, or jobs disabled
+  created --> queued: BullMQ job accepted
+  queued --> sent: worker delivered email/push
+  queued --> retried: transient worker failure
+  retried --> sent: retry succeeds
+  retried --> dead_lettered: attempts exhausted
+  queued --> failed: terminal worker failure
+```
+
+State meanings:
+
+- `created`: the in-app notification exists and can be synced after reconnect.
+- `queued`: Redis/BullMQ accepted async delivery.
+- `sent`: the worker completed delivery.
+- `skipped`: delivery was intentionally not enqueued, for example
+  `ENABLE_BACKGROUND_JOBS=false` or channel preferences disabled.
+- `failed`: processing failed and may be retried.
+- `retried`: BullMQ scheduled another attempt.
+- `dead-lettered`: attempts are exhausted and the DLQ admin endpoint can inspect
+  or replay the job.
+
+## Disabled Background Jobs
+
+When `ENABLE_BACKGROUND_JOBS` is anything other than `"true"`, Redis-backed
+delivery is disabled by design. The app still creates in-app notifications, logs
+explicit skipped delivery, increments `notification_delivery_skipped_total`, and
+marks outbox dispatches `SKIPPED` instead of pretending they were delivered.
+
+Sample readiness excerpt:
+
+```json
+{
+  "backgroundJobMode": "disabled",
+  "subsystems": [
+    { "name": "redis", "status": "disabled" },
+    { "name": "queues", "status": "disabled" }
+  ]
+}
+```
+
+## Idempotency
+
+Notification rows use a nullable `sourceKey` generated from
+`userId:type:sourceId`, where `sourceId` comes from `sourceEventId`,
+`messageId`, `commentId`, or `reactionId`. The database has a partial unique
+index on non-null source keys, and the service returns the existing notification
+when a duplicate source event is replayed.
+
+## Reconnect Sync
+
+The notification gateway joins authenticated clients to `user:<id>` only. On
+connect and subscription confirmation it emits `notifications:sync` with the
+latest unread notifications and unread count, so a websocket reconnect does not
+depend on replaying every missed socket event.
+
+## Diagnostics
+
+Failed async jobs are visible through the existing admin DLQ endpoints:
+
+- `GET /admin/notifications/dlq`
+- `POST /admin/notifications/dlq/:jobId/replay`
+
+Outbox rows now distinguish `PENDING`, `PROCESSING`, `COMPLETED`, `SKIPPED`,
+and `FAILED`.

--- a/xconfess-backend/migrations/1790000000000-NotificationDeliveryReliability.ts
+++ b/xconfess-backend/migrations/1790000000000-NotificationDeliveryReliability.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NotificationDeliveryReliability1790000000000
+  implements MigrationInterface
+{
+  name = 'NotificationDeliveryReliability1790000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."outbox_events_status_enum" ADD VALUE IF NOT EXISTS 'SKIPPED'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "sourceKey" character varying`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "IDX_notifications_sourceKey_unique" ON "notifications" ("sourceKey") WHERE "sourceKey" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_notifications_sourceKey_unique"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notifications" DROP COLUMN IF EXISTS "sourceKey"`,
+    );
+  }
+}

--- a/xconfess-backend/src/common/entities/outbox-event.entity.ts
+++ b/xconfess-backend/src/common/entities/outbox-event.entity.ts
@@ -11,6 +11,7 @@ export enum OutboxStatus {
   PENDING = 'PENDING',
   PROCESSING = 'PROCESSING',
   COMPLETED = 'COMPLETED',
+  SKIPPED = 'SKIPPED',
   FAILED = 'FAILED',
 }
 

--- a/xconfess-backend/src/health/health.controller.spec.ts
+++ b/xconfess-backend/src/health/health.controller.spec.ts
@@ -128,6 +128,22 @@ describe('HealthController', () => {
       );
       expect(redisSub).toEqual({ name: 'redis', status: 'disabled' });
     });
+
+    it('marks queue subsystem degraded when nested queue details are degraded', async () => {
+      queueIndicator.isHealthy.mockResolvedValue({
+        queues: {
+          status: 'down',
+          notifications: { status: 'degraded', latencyMs: 300 },
+          'notifications-dlq': { status: 'up', latencyMs: 10 },
+        },
+      });
+
+      const result = await controller.readiness();
+      const queueSub = result.subsystems.find(
+        (s: { name: string }) => s.name === 'queues',
+      );
+      expect(queueSub).toEqual({ name: 'queues', status: 'degraded' });
+    });
   });
 
   describe('GET /health (backward-compat alias)', () => {

--- a/xconfess-backend/src/health/health.controller.ts
+++ b/xconfess-backend/src/health/health.controller.ts
@@ -17,6 +17,15 @@ interface SubsystemStatus {
   status: 'up' | 'down' | 'degraded' | 'disabled';
 }
 
+function getNestedStatuses(detail: Record<string, unknown>): string[] {
+  return Object.values(detail)
+    .filter((value): value is { status?: string } =>
+      Boolean(value && typeof value === 'object' && 'status' in value),
+    )
+    .map((value) => value.status)
+    .filter((status): status is string => Boolean(status));
+}
+
 function buildSubsystemSummary(
   result: HealthCheckResult,
 ): SubsystemStatus[] {
@@ -34,6 +43,14 @@ function buildSubsystemSummary(
 
     if (detail.mode === 'disabled') {
       subsystems.push({ name: key, status: 'disabled' });
+      continue;
+    }
+
+    const nestedStatuses = getNestedStatuses(detail);
+    if (nestedStatuses.includes('down')) {
+      subsystems.push({ name: key, status: 'down' });
+    } else if (nestedStatuses.includes('degraded')) {
+      subsystems.push({ name: key, status: 'degraded' });
     } else if (detail.status === 'up') {
       subsystems.push({ name: key, status: 'up' });
     } else {

--- a/xconfess-backend/src/notifications/background-jobs-disabled.spec.ts
+++ b/xconfess-backend/src/notifications/background-jobs-disabled.spec.ts
@@ -4,6 +4,7 @@ import { getQueueToken } from '@nestjs/bullmq';
 import { ServiceUnavailableException } from '@nestjs/common';
 import { NotificationService } from './services/notification.service';
 import { NOTIFICATION_QUEUE } from './processors/notification.processor';
+import { NotificationDeliveryState } from './delivery-state';
 
 describe('Background Jobs Disabled Behavior', () => {
   describe('NotificationService.enqueueNotification', () => {
@@ -44,12 +45,18 @@ describe('Background Jobs Disabled Behavior', () => {
     });
 
     it('should not enqueue when ENABLE_BACKGROUND_JOBS is not true', async () => {
-      await service.enqueueNotification('message_notification', {
+      const outcome = await service.enqueueNotification('message_notification', {
         userId: 'user-1',
         requestId: 'req-abc',
       });
 
       expect(mockQueue.add).not.toHaveBeenCalled();
+      expect(outcome).toEqual({
+        state: NotificationDeliveryState.SKIPPED,
+        reason: 'background_jobs_disabled',
+        queue: NOTIFICATION_QUEUE,
+        jobId: undefined,
+      });
     });
 
     it('should log a structured warning with queue name when jobs are disabled', async () => {
@@ -70,7 +77,7 @@ describe('Background Jobs Disabled Behavior', () => {
       mockConfigService.get.mockReturnValue('true');
       (service as any).shouldDeliverEmail = jest.fn().mockResolvedValue(true);
 
-      await service.enqueueNotification('message_notification', {
+      const outcome = await service.enqueueNotification('message_notification', {
         userId: 'user-1',
       });
 
@@ -79,6 +86,12 @@ describe('Background Jobs Disabled Behavior', () => {
         expect.objectContaining({ type: 'message_notification' }),
         expect.anything(),
       );
+      expect(outcome).toEqual({
+        state: NotificationDeliveryState.QUEUED,
+        queue: NOTIFICATION_QUEUE,
+        jobName: 'send-notification',
+        jobId: undefined,
+      });
     });
   });
 });

--- a/xconfess-backend/src/notifications/delivery-state.ts
+++ b/xconfess-backend/src/notifications/delivery-state.ts
@@ -1,0 +1,23 @@
+export enum NotificationDeliveryState {
+  CREATED = 'created',
+  QUEUED = 'queued',
+  SENT = 'sent',
+  SKIPPED = 'skipped',
+  FAILED = 'failed',
+  RETRIED = 'retried',
+  DEAD_LETTERED = 'dead-lettered',
+}
+
+export type NotificationDeliveryOutcome =
+  | {
+      state: NotificationDeliveryState.QUEUED;
+      queue: string;
+      jobName: string;
+      jobId?: string;
+    }
+  | {
+      state: NotificationDeliveryState.SKIPPED;
+      reason: string;
+      queue?: string;
+      jobId?: string;
+    };

--- a/xconfess-backend/src/notifications/dto/notification.dto.ts
+++ b/xconfess-backend/src/notifications/dto/notification.dto.ts
@@ -25,6 +25,10 @@ export class CreateNotificationDto {
 
   @IsOptional()
   metadata?: any;
+
+  @IsOptional()
+  @IsString()
+  sourceKey?: string;
 }
 
 export class UpdateNotificationPreferenceDto {

--- a/xconfess-backend/src/notifications/entities/notification.entity.ts
+++ b/xconfess-backend/src/notifications/entities/notification.entity.ts
@@ -6,6 +6,7 @@
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  Index,
 } from "typeorm";
 import { User } from "src/user/entities/user.entity";
 
@@ -50,9 +51,15 @@ export class Notification {
     messageCount?: number;
     messageIds?: string[];
     commentId?: number;
+    reactionId?: string;
     confessionId?: string;
     mentionedBy?: string;
+    sourceEventId?: string;
   };
+
+  @Column({ nullable: true })
+  @Index({ unique: true })
+  sourceKey: string | null;
 
   @Column({ default: false })
   isRead: boolean;

--- a/xconfess-backend/src/notifications/gateways/notification.gateway.spec.ts
+++ b/xconfess-backend/src/notifications/gateways/notification.gateway.spec.ts
@@ -40,7 +40,11 @@ describe('Notification websocket auth regression coverage', () => {
     const notificationService = {
       markAsRead: jest.fn(),
       markAllAsRead: jest.fn(),
-      getUserNotifications: jest.fn(),
+      getUserNotifications: jest.fn().mockResolvedValue({
+        notifications: [],
+        total: 0,
+        unreadCount: 0,
+      }),
       shouldDeliverRealtime: jest.fn().mockResolvedValue(true),
     };
     const configService = {
@@ -196,6 +200,31 @@ describe('Notification websocket auth regression coverage', () => {
       socketId: 'socket-1',
       userId: 'user-1',
       channel: 'user:user-1',
+    });
+  });
+
+  it('emits unread sync on connection for reconnect-safe notification loading', async () => {
+    const { gateway } = createGateway();
+    const client = createSocket({
+      data: { userId: 'user-1' },
+    });
+    gateway.notificationService.getUserNotifications = jest.fn().mockResolvedValue({
+      notifications: [{ id: 'missed-1' }],
+      total: 1,
+      unreadCount: 1,
+    });
+
+    gateway.handleConnection(client);
+    await Promise.resolve();
+
+    expect(gateway.notificationService.getUserNotifications).toHaveBeenCalledWith(
+      'user-1',
+      { page: 1, limit: 20, unreadOnly: true },
+    );
+    expect(client.emit).toHaveBeenCalledWith('notifications:sync', {
+      notifications: [{ id: 'missed-1' }],
+      unreadCount: 1,
+      timestamp: expect.any(String),
     });
   });
 

--- a/xconfess-backend/src/notifications/gateways/notification.gateway.ts
+++ b/xconfess-backend/src/notifications/gateways/notification.gateway.ts
@@ -130,6 +130,8 @@ export class NotificationGateway
       userId,
       channel: userRoom,
     });
+
+    void this.emitUnreadSync(client, userId);
   }
 
   handleDisconnect(client: Socket) {
@@ -198,6 +200,36 @@ export class NotificationGateway
       channel: userRoom,
       timestamp: new Date().toISOString(),
     });
+
+    void this.emitUnreadSync(client, authenticatedUserId);
+  }
+
+  @SubscribeMessage('join-notifications')
+  handleLegacyJoinNotifications(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() requestedUserId?: string,
+  ) {
+    this.handleSubscribeUserNotifications(client, { userId: requestedUserId });
+  }
+
+  private async emitUnreadSync(client: Socket, userId: string) {
+    try {
+      const result = await this.notificationService.getUserNotifications(
+        userId,
+        { page: 1, limit: 20, unreadOnly: true },
+      );
+      client.emit('notifications:sync', {
+        notifications: result.notifications,
+        unreadCount: result.unreadCount,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      this.logger.error(`Error syncing unread notifications:`, error);
+      client.emit('notifications:sync-failed', {
+        message: 'Failed to sync unread notifications',
+        timestamp: new Date().toISOString(),
+      });
+    }
   }
 
   /**

--- a/xconfess-backend/src/notifications/services/notification.service.spec.ts
+++ b/xconfess-backend/src/notifications/services/notification.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { getQueueToken } from '@nestjs/bull';
+import { getQueueToken } from '@nestjs/bullmq';
 import { NotificationService } from './notification.service';
 import {
   Notification,
@@ -20,8 +20,12 @@ describe('NotificationService', () => {
     create: jest.Mock;
     save: jest.Mock;
   };
-  let notificationRepoMock: { create: jest.Mock; save: jest.Mock };
-  let appLoggerMock: { incrementCounter: jest.Mock };
+  let notificationRepoMock: {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+  };
+  let appLoggerMock: { incrementCounter: jest.Mock; warn: jest.Mock };
   let userRepoMock: { findOne: jest.Mock };
 
   beforeEach(async () => {
@@ -31,6 +35,7 @@ describe('NotificationService', () => {
 
     appLoggerMock = {
       incrementCounter: jest.fn(),
+      warn: jest.fn(),
     };
 
     preferenceRepoMock = {
@@ -42,6 +47,7 @@ describe('NotificationService', () => {
     notificationRepoMock = {
       create: jest.fn().mockImplementation((n) => ({ id: 'notif-1', ...n })),
       save: jest.fn().mockImplementation(async (n) => n),
+      findOne: jest.fn().mockResolvedValue(null),
     };
 
     userRepoMock = {
@@ -69,10 +75,7 @@ describe('NotificationService', () => {
         },
         {
           provide: AppLogger,
-          useValue: {
-            incrementCounter: jest.fn(),
-            warn: jest.fn(),
-          },
+          useValue: appLoggerMock,
         },
         {
           provide: ConfigService,
@@ -177,6 +180,104 @@ describe('NotificationService', () => {
           notificationType: NotificationType.NEW_MESSAGE,
         }),
       );
+    });
+
+    it('suppresses duplicate notifications by deterministic source key', async () => {
+      const existingNotification = {
+        id: 'notif-existing',
+        userId: 'user-1',
+        type: NotificationType.COMMENT_REPLY,
+        sourceKey: 'user-1:comment_reply:42',
+      };
+
+      preferenceRepoMock.findOne.mockResolvedValue({
+        userId: 'user-1',
+        enableInAppNotifications: true,
+        enableEmailNotifications: false,
+        inAppNewMessage: true,
+        enableQuietHours: false,
+      });
+      notificationRepoMock.findOne.mockResolvedValue(existingNotification);
+
+      const result = await service.createNotification({
+        userId: 'user-1',
+        type: NotificationType.COMMENT_REPLY,
+        title: 'New reply',
+        message: 'A comment arrived',
+        metadata: { commentId: 42 },
+      });
+
+      expect(result).toBe(existingNotification);
+      expect(notificationRepoMock.findOne).toHaveBeenCalledWith({
+        where: { sourceKey: 'user-1:comment_reply:42' },
+      });
+      expect(notificationRepoMock.create).not.toHaveBeenCalled();
+      expect(notificationRepoMock.save).not.toHaveBeenCalled();
+      expect(appLoggerMock.incrementCounter).toHaveBeenCalledWith(
+        'notification_duplicate_suppressed_total',
+        1,
+        { notificationType: NotificationType.COMMENT_REPLY },
+      );
+    });
+
+    it('persists sourceKey for message, comment, reaction, and explicit source events', async () => {
+      preferenceRepoMock.findOne.mockResolvedValue({
+        userId: 'user-1',
+        enableInAppNotifications: true,
+        enableEmailNotifications: false,
+        inAppNewMessage: true,
+        enableQuietHours: false,
+      });
+
+      await service.createNotification({
+        userId: 'user-1',
+        type: NotificationType.NEW_MESSAGE,
+        title: 'New message',
+        message: 'Hello',
+        metadata: { messageId: 'message-7' },
+      });
+
+      expect(notificationRepoMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceKey: 'user-1:new_message:message-7',
+        }),
+      );
+    });
+
+    it('returns the existing notification when concurrent sourceKey insert races hit the unique index', async () => {
+      const existingNotification = {
+        id: 'notif-existing',
+        userId: 'user-1',
+        type: NotificationType.NEW_MESSAGE,
+        sourceKey: 'user-1:new_message:message-7',
+      };
+
+      preferenceRepoMock.findOne.mockResolvedValue({
+        userId: 'user-1',
+        enableInAppNotifications: true,
+        enableEmailNotifications: false,
+        inAppNewMessage: true,
+        enableQuietHours: false,
+      });
+      notificationRepoMock.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(existingNotification);
+      notificationRepoMock.save.mockRejectedValueOnce({
+        code: '23505',
+      });
+
+      const result = await service.createNotification({
+        userId: 'user-1',
+        type: NotificationType.NEW_MESSAGE,
+        title: 'New message',
+        message: 'Hello',
+        metadata: { messageId: 'message-7' },
+      });
+
+      expect(result).toBe(existingNotification);
+      expect(notificationRepoMock.findOne).toHaveBeenLastCalledWith({
+        where: { sourceKey: 'user-1:new_message:message-7' },
+      });
     });
   });
 });

--- a/xconfess-backend/src/notifications/services/notification.service.ts
+++ b/xconfess-backend/src/notifications/services/notification.service.ts
@@ -13,6 +13,10 @@ import { Queue } from 'bullmq';
 import { AppLogger } from '../../logger/logger.service';
 import { ConfigService } from '@nestjs/config';
 import { User } from '../../user/entities/user.entity';
+import {
+  NotificationDeliveryOutcome,
+  NotificationDeliveryState,
+} from '../delivery-state';
 
 interface ChannelPreferences {
   inApp?: boolean;
@@ -39,7 +43,7 @@ export class NotificationService {
     type: string,
     payload: any,
     jobId?: string,
-  ): Promise<void> {
+  ): Promise<NotificationDeliveryOutcome> {
     if (this.configService.get<string>('ENABLE_BACKGROUND_JOBS') !== 'true') {
       const requestId =
         payload?.requestId || payload?.messageId || jobId || 'unknown';
@@ -47,7 +51,17 @@ export class NotificationService {
         `[BackgroundJobDisabled] Enqueue skipped for queue "${NOTIFICATION_QUEUE}": type=${type} requestId=${requestId} jobId=${jobId || 'none'}`,
         'NotificationService',
       );
-      return;
+      this.appLogger.incrementCounter('notification_delivery_skipped_total', 1, {
+        queue: NOTIFICATION_QUEUE,
+        notificationType: type,
+        reason: 'background_jobs_disabled',
+      });
+      return {
+        state: NotificationDeliveryState.SKIPPED,
+        reason: 'background_jobs_disabled',
+        queue: NOTIFICATION_QUEUE,
+        jobId,
+      };
     }
 
     const userId = payload?.userId || payload?.recipientId;
@@ -58,7 +72,17 @@ export class NotificationService {
           `enqueueNotification skipped (email preference disabled): type=${type} userId=${userId}`,
           'NotificationService',
         );
-        return;
+        this.appLogger.incrementCounter('notification_delivery_skipped_total', 1, {
+          queue: NOTIFICATION_QUEUE,
+          notificationType: type,
+          reason: 'email_preference_disabled',
+        });
+        return {
+          state: NotificationDeliveryState.SKIPPED,
+          reason: 'email_preference_disabled',
+          queue: NOTIFICATION_QUEUE,
+          jobId,
+        };
       }
     }
 
@@ -76,6 +100,13 @@ export class NotificationService {
       jobName: 'send-notification',
       notificationType: type,
     });
+
+    return {
+      state: NotificationDeliveryState.QUEUED,
+      queue: NOTIFICATION_QUEUE,
+      jobName: 'send-notification',
+      jobId,
+    };
   }
 
   /**
@@ -162,8 +193,41 @@ export class NotificationService {
       return null;
     }
 
-    const notification = this.notificationRepository.create(dto);
-    await this.notificationRepository.save(notification);
+    const sourceKey = dto.sourceKey ?? this.buildSourceKey(dto);
+    if (sourceKey) {
+      const existing = await this.notificationRepository.findOne({
+        where: { sourceKey },
+      });
+      if (existing) {
+        this.appLogger.incrementCounter('notification_duplicate_suppressed_total', 1, {
+          notificationType: dto.type,
+        });
+        return existing;
+      }
+    }
+
+    const notification = this.notificationRepository.create({
+      ...dto,
+      sourceKey: sourceKey ?? undefined,
+    });
+    try {
+      await this.notificationRepository.save(notification);
+    } catch (error) {
+      if (sourceKey && this.isUniqueViolation(error)) {
+        const existing = await this.notificationRepository.findOne({
+          where: { sourceKey },
+        });
+        if (existing) {
+          this.appLogger.incrementCounter(
+            'notification_duplicate_suppressed_total',
+            1,
+            { notificationType: dto.type },
+          );
+          return existing;
+        }
+      }
+      throw error;
+    }
 
     // Queue for email notification if enabled and background jobs are active
     if (
@@ -186,9 +250,45 @@ export class NotificationService {
         jobName: 'send-notification',
         notificationType: dto.type,
       });
+    } else if (this.configService.get<string>('ENABLE_BACKGROUND_JOBS') !== 'true') {
+      this.appLogger.warn(
+        `[BackgroundJobDisabled] Email enqueue skipped for notification ${notification.id}: type=${dto.type} userId=${dto.userId}`,
+        'NotificationService',
+      );
+      this.appLogger.incrementCounter('notification_delivery_skipped_total', 1, {
+        queue: NOTIFICATION_QUEUE,
+        notificationType: dto.type,
+        reason: 'background_jobs_disabled',
+      });
     }
 
     return notification;
+  }
+
+  private buildSourceKey(dto: CreateNotificationDto): string | null {
+    const metadata = dto.metadata || {};
+    const sourceId =
+      metadata.sourceEventId ||
+      metadata.messageId ||
+      metadata.commentId ||
+      metadata.reactionId;
+
+    if (!sourceId) {
+      return null;
+    }
+
+    return `${dto.userId}:${dto.type}:${String(sourceId)}`;
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const driverError = (error as { driverError?: { code?: string } })
+      .driverError;
+    const code = (error as { code?: string }).code || driverError?.code;
+    return code === '23505';
   }
 
   async createMessageNotification(

--- a/xconfess-backend/src/notifications/services/outbox-dispatcher.service.spec.ts
+++ b/xconfess-backend/src/notifications/services/outbox-dispatcher.service.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '../../common/entities/outbox-event.entity';
 import { NotificationService } from './notification.service';
 import { Repository } from 'typeorm';
+import { NotificationDeliveryState } from '../delivery-state';
 
 describe('OutboxDispatcherService', () => {
   let service: OutboxDispatcherService;
@@ -37,7 +38,11 @@ describe('OutboxDispatcherService', () => {
         {
           provide: NotificationService,
           useValue: {
-            enqueueNotification: jest.fn(),
+            enqueueNotification: jest.fn().mockResolvedValue({
+              state: NotificationDeliveryState.QUEUED,
+              queue: 'notifications',
+              jobName: 'send-notification',
+            }),
           },
         },
       ],
@@ -141,5 +146,47 @@ describe('OutboxDispatcherService', () => {
     expect(notificationService.enqueueNotification).not.toHaveBeenCalled();
     expect(duplicateEvent.status).toBe(OutboxStatus.COMPLETED);
     expect(outboxRepo.save).toHaveBeenCalledWith(duplicateEvent);
+  });
+
+  it('marks outbox events as skipped when background jobs are disabled', async () => {
+    const skippedEvent = {
+      id: 'event-skipped',
+      type: 'message_notification',
+      payload: { message: 'hello' },
+      status: OutboxStatus.PENDING,
+      retryCount: 0,
+    } as OutboxEvent;
+
+    (notificationService.enqueueNotification as jest.Mock).mockResolvedValue({
+      state: NotificationDeliveryState.SKIPPED,
+      reason: 'background_jobs_disabled',
+      queue: 'notifications',
+      jobId: 'event-skipped',
+    });
+
+    const transactionManagerMock = {
+      createQueryBuilder: jest.fn().mockReturnThis(),
+      setLock: jest.fn().mockReturnThis(),
+      setOnLocked: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([skippedEvent]),
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      whereInIds: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue({}),
+    };
+
+    (outboxRepo.manager.transaction as jest.Mock).mockImplementation(
+      async (cb) => cb(transactionManagerMock),
+    );
+
+    await service.handleOutbox();
+
+    expect(skippedEvent.status).toBe(OutboxStatus.SKIPPED);
+    expect(skippedEvent.lastError).toBe('background_jobs_disabled');
+    expect(skippedEvent.processedAt).toBeInstanceOf(Date);
+    expect(outboxRepo.save).toHaveBeenCalledWith(skippedEvent);
   });
 });

--- a/xconfess-backend/src/notifications/services/outbox-dispatcher.service.ts
+++ b/xconfess-backend/src/notifications/services/outbox-dispatcher.service.ts
@@ -8,6 +8,7 @@ import {
 } from '../../common/entities/outbox-event.entity';
 import { NotificationService } from './notification.service';
 import * as os from 'os';
+import { NotificationDeliveryState } from '../delivery-state';
 
 @Injectable()
 export class OutboxDispatcherService {
@@ -154,13 +155,21 @@ export class OutboxDispatcherService {
         case 'reply_notification':
         case 'reaction_notification':
         case 'reaction_update':
-        case 'report_notification':
-          await this.notificationService.enqueueNotification(
+        case 'report_notification': {
+          const outcome = await this.notificationService.enqueueNotification(
             event.type,
             event.payload,
             dispatchIdempotencyKey,
           );
+          if (outcome.state === NotificationDeliveryState.SKIPPED) {
+            event.status = OutboxStatus.SKIPPED;
+            event.processedAt = new Date();
+            event.lastError = outcome.reason;
+            await this.outboxRepo.save(event);
+            return;
+          }
           break;
+        }
         default:
           this.logger.warn(`Unknown outbox event type: ${event.type}`);
           event.status = OutboxStatus.COMPLETED;

--- a/xconfess-backend/src/websocket/websocket-health.service.spec.ts
+++ b/xconfess-backend/src/websocket/websocket-health.service.spec.ts
@@ -1,0 +1,35 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebSocketHealthService } from './websocket-health.service';
+
+describe('WebSocketHealthService', () => {
+  it('does not fail websocket health on Redis when background jobs are disabled', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebSocketHealthService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, fallback?: unknown) => {
+              if (key === 'ENABLE_BACKGROUND_JOBS') return 'false';
+              return fallback;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    const service = module.get(WebSocketHealthService);
+    const result = await service.checkHealth();
+
+    expect(result.status).toBe('healthy');
+    expect(result.dependencies?.redis).toMatchObject({
+      status: 'disabled',
+      details: { mode: 'disabled' },
+    });
+    expect(result.dependencies?.notifications).toMatchObject({
+      status: 'up',
+      details: { mode: 'disabled' },
+    });
+  });
+});

--- a/xconfess-backend/src/websocket/websocket-health.service.ts
+++ b/xconfess-backend/src/websocket/websocket-health.service.ts
@@ -5,7 +5,7 @@ import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 
 export interface DependencyStatus {
-  status: 'up' | 'degraded' | 'down';
+  status: 'up' | 'degraded' | 'down' | 'disabled';
   details?: Record<string, any>;
   error?: string;
 }
@@ -58,6 +58,19 @@ export class WebSocketHealthService {
   }
 
   private async checkRedisHealth(): Promise<DependencyStatus> {
+    const jobsEnabled =
+      this.configService.get<string>('ENABLE_BACKGROUND_JOBS') === 'true';
+    if (!jobsEnabled) {
+      return {
+        status: 'disabled',
+        details: {
+          mode: 'disabled',
+          reason:
+            'Redis-backed notification queues are not required while ENABLE_BACKGROUND_JOBS is not "true"',
+        },
+      };
+    }
+
     const redisHost = this.configService.get<string>('REDIS_HOST', 'localhost');
     const redisPort = this.configService.get<number>('REDIS_PORT', 6379);
     const redisPassword = this.configService.get<string>('REDIS_PASSWORD');


### PR DESCRIPTION
# Summary

* Add explicit notification delivery outcomes for queued and skipped delivery.
* Add `SKIPPED` outbox state for intentionally skipped dispatches, including `ENABLE_BACKGROUND_JOBS=false`.
* Add source-key idempotency for notification rows to prevent duplicate comment/reaction/message notifications.
* Add reconnect-safe websocket unread syncing via `notifications:sync`.
* Improve health summaries so Redis/queues distinguish disabled, degraded, and down states.
* Document the delivery state machine, disabled jobs behavior, reconnect sync, and diagnostics.

## Review Evidence

* Delivery state diagram: `docs/notification-delivery-reliability.md`
* Migration: `1790000000000-NotificationDeliveryReliability`
* Sample disabled health response included in the docs.
* Failed notification diagnostics remain visible through existing DLQ admin endpoints.

## Tests

* `npm run ci` passed.
* Backend: **130 suites passed, 1249 tests passed.**
* Frontend: **58 suites passed, 574 tests passed.**
* Contracts: **fmt, clippy, tests, and release WASM build passed.**

close #1695 