### PR TITLE
test(frontend): add auth page navigation regression tests (Fixes #1716, #1717)

### DIFF
--- a/xconfess-frontend/app/(auth)/login/__tests__/page.test.tsx
+++ b/xconfess-frontend/app/(auth)/login/__tests__/page.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock environment variables
+process.env.NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock useAuth
+const mockLogin = jest.fn();
+jest.mock("@/app/lib/hooks/useAuth", () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+// Import the component after mocks
+import LoginPage from "../page";
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the Create account navigation button that routes to /register", async () => {
+    render(<LoginPage />);
+
+    // Find the "Create account" button
+    const createAccountButton = screen.getByRole("button", { name: /create account/i });
+    expect(createAccountButton).toBeInTheDocument();
+
+    // Click the button
+    await userEvent.click(createAccountButton);
+
+    // Verify it navigates to /register
+    expect(mockPush).toHaveBeenCalledWith("/register");
+  });
+});

--- a/xconfess-frontend/app/(auth)/register/__tests__/page.test.tsx
+++ b/xconfess-frontend/app/(auth)/register/__tests__/page.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock environment variables
+process.env.NEXT_PUBLIC_API_URL = "http://localhost:3000";
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock useAuth
+const mockRegister = jest.fn();
+jest.mock("@/app/lib/hooks/useAuth", () => ({
+  useAuth: () => ({ register: mockRegister }),
+}));
+
+// Mock error utilities
+jest.mock("@/app/lib/utils/errorHandler", () => ({
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "Unknown error"),
+}));
+
+jest.mock("@/app/lib/api/authService", () => ({
+  getAuthFieldError: () => null,
+}));
+
+// Import the component after mocks
+import RegisterPage from "../page";
+
+describe("RegisterPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the Sign in navigation button that routes to /login", async () => {
+    render(<RegisterPage />);
+
+    // Find the "Sign in" button (the button-style one, not the inline Link)
+    const signInButton = screen.getByRole("button", { name: /sign in/i });
+    expect(signInButton).toBeInTheDocument();
+
+    // Click the button
+    await userEvent.click(signInButton);
+
+    // Verify it navigates to /login
+    expect(mockPush).toHaveBeenCalledWith("/login");
+  });
+
+  it("renders the inline Sign in link that points to /login", () => {
+    render(<RegisterPage />);
+
+    // Find the inline link (the <Link> component)
+    const signInLink = screen.getByRole("link", { name: /sign in/i });
+    expect(signInLink).toBeInTheDocument();
+    expect(signInLink).toHaveAttribute("href", "/login");
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused regression tests for the cross-navigation buttons on the auth pages:

- **Register page** (`app/(auth)/register/`): verifies the button-style "Sign in" navigation calls `router.push('/login')`, and that the inline "Sign in" link points to `/login` (Closes #1717).
- **Login page** (`app/(auth)/login/`): verifies the "Create account" button calls `router.push('/register')` (Closes #1716).

## Why

Both navigation paths are key first-impression flows. Without tests, a future refactor could silently break the buttons (wrong route, removed handler) without any CI signal.

## Acceptance criteria

- [x] Test fails if the Sign in button is removed or points to the wrong route (register page)
- [x] Test fails if the register navigation disappears (login page)
- [x] Tests do not call the backend (router/useAuth are mocked)

## Validation

```
npm run test --workspace=xconfess-frontend -- login --runInBand
npm run test --workspace=xconfess-frontend -- register --runInBand
```

Both suites pass (8 tests across auth-related suites, 3 new tests in this PR).

Fixes #1716, Fixes #1717