### PR TITLE
feat(frontend): surface request ID on auth errors with copy affordance (Fixes #1729)

### DIFF
--- a/xconfess-frontend/app/(auth)/login/page.tsx
+++ b/xconfess-frontend/app/(auth)/login/page.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/app/components/ui/button';
 import { Input } from '@/app/components/ui/input';
 import { BrandLogo } from '@/app/components/brand/BrandLogo';
 import { useAuth } from '@/app/lib/hooks/useAuth';
+import { extractRequestId } from '@/app/lib/utils/errorHandler';
+import { RequestIdBadge } from '@/app/components/common/RequestIdBadge';
 import {
   validateLoginForm,
   parseLoginForm,
@@ -25,6 +27,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState<ValidationErrors>({});
   const [loading, setLoading] = useState(false);
+  const [requestId, setRequestId] = useState<string | null>(null);
 
   const doMockAdminLogin = async () => {
     setLoading(true);
@@ -62,6 +65,7 @@ export default function LoginPage() {
 
     setLoading(true);
     setErrors({});
+    setRequestId(null);
     try {
       const user = await login({
         email: parsed.data.email,
@@ -71,6 +75,8 @@ export default function LoginPage() {
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Login failed';
       setErrors({ password: message });
+      const rid = extractRequestId(e);
+      if (rid) setRequestId(rid);
     } finally {
       setLoading(false);
     }
@@ -106,12 +112,14 @@ export default function LoginPage() {
             {errors.email && (
               <div className="mt-5 rounded-[20px] border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                 {errors.email}
+                {requestId && <RequestIdBadge requestId={requestId} />}
               </div>
             )}
 
             {errors.password && !errors.email && (
               <div className="mt-5 rounded-[20px] border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                 {errors.password}
+                {requestId && <RequestIdBadge requestId={requestId} />}
               </div>
             )}
 

--- a/xconfess-frontend/app/(auth)/register/page.tsx
+++ b/xconfess-frontend/app/(auth)/register/page.tsx
@@ -9,8 +9,9 @@ import { Button } from '@/app/components/ui/button';
 import { Input } from '@/app/components/ui/input';
 import { BrandLogo } from '@/app/components/brand/BrandLogo';
 import { useAuth } from '@/app/lib/hooks/useAuth';
-import { getErrorMessage } from '@/app/lib/utils/errorHandler';
+import { getErrorMessage, extractRequestId } from '@/app/lib/utils/errorHandler';
 import { getAuthFieldError } from '@/app/lib/api/authService';
+import { RequestIdBadge } from '@/app/components/common/RequestIdBadge';
 import {
   validateRegisterForm,
   parseRegisterForm,
@@ -40,6 +41,7 @@ export default function RegisterPage() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [errors, setErrors] = useState<ValidationErrors>({});
   const [submitError, setSubmitError] = useState('');
+  const [requestId, setRequestId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -68,6 +70,7 @@ export default function RegisterPage() {
     const validationErrors = validateRegisterForm(formData);
     setErrors(validationErrors);
     setSubmitError('');
+    setRequestId(null);
 
     if (hasErrors(validationErrors)) {
       return;
@@ -96,6 +99,8 @@ export default function RegisterPage() {
       } else {
         setSubmitError(message);
       }
+      const rid = extractRequestId(error);
+      if (rid) setRequestId(rid);
     } finally {
       setLoading(false);
     }
@@ -147,6 +152,16 @@ export default function RegisterPage() {
                 role="alert"
               >
                 {submitError}
+                {requestId && <RequestIdBadge requestId={requestId} />}
+              </div>
+            )}
+
+            {requestId && !submitError && (
+              <div className="mt-4 flex items-center gap-2 rounded-[16px] border border-red-200 bg-red-50 px-3 py-2">
+                <span className="text-xs text-red-600/80">
+                  Auth failed — include the request ID below when reporting the issue:
+                </span>
+                <RequestIdBadge requestId={requestId} />
               </div>
             )}
 

--- a/xconfess-frontend/app/api/auth/session/__tests__/route.test.ts
+++ b/xconfess-frontend/app/api/auth/session/__tests__/route.test.ts
@@ -91,4 +91,25 @@ describe("GET /api/auth/session", () => {
 
     expect(mockCookieStore.delete).toHaveBeenCalledWith("xconfess_session");
   });
+
+  it("should include x-request-id header and requestId body on errors", async () => {
+    const requestWithId = new Request(
+      "https://xconfess.vercel.app/api/auth/session",
+      { headers: { "x-request-id": "req-abc-123" } },
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    const response = await GET(requestWithId);
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("x-request-id")).toBe("req-abc-123");
+    await expect(response.json()).resolves.toMatchObject({
+      type: "TERMINAL",
+      requestId: "req-abc-123",
+    });
+  });
 });

--- a/xconfess-frontend/app/api/auth/session/route.ts
+++ b/xconfess-frontend/app/api/auth/session/route.ts
@@ -122,7 +122,7 @@ export async function POST(request: Request) {
                 message: "Email and password are required",
                 status: 400,
             });
-            return createErrorResponse(normalized);
+            return createErrorResponse(normalized, requestId);
         }
 
         const backend = resolveBackendRoute(request, "/auth/login");
@@ -132,7 +132,7 @@ export async function POST(request: Request) {
         }, backend.requestId);
 
         if (!result.success) {
-            return createErrorResponse(result.normalized!);
+            return createErrorResponse(result.normalized!, requestId);
         }
 
         const data = result.data as Record<string, unknown>;
@@ -156,7 +156,7 @@ export async function POST(request: Request) {
         return res;
     } catch (error) {
         const normalized = normalizeAuthError(error);
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 }
 
@@ -171,7 +171,7 @@ export async function GET(request: Request) {
             message: "Not authenticated",
             status: 401,
         });
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 
     try {
@@ -200,7 +200,7 @@ export async function GET(request: Request) {
             if (result.normalized?.originalStatus === 401) {
                 cookieStore.delete(SESSION_COOKIE_NAME);
             }
-            return createErrorResponse(result.normalized!);
+            return createErrorResponse(result.normalized!, requestId);
         }
 
         const user = result.data as Record<string, unknown>;
@@ -209,7 +209,7 @@ export async function GET(request: Request) {
         return response;
     } catch (error) {
         const normalized = normalizeAuthError(error);
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 }
 
@@ -227,7 +227,7 @@ export async function PUT() {
  * Convert normalized auth error to JSON response.
  * Output shape matches NormalizedAuthError so AuthProvider can consume it directly.
  */
-function createErrorResponse(normalized: NormalizedAuthError): Response {
+function createErrorResponse(normalized: NormalizedAuthError, requestId?: string): Response {
   const isExpectedMissingSession =
     normalized.code === "INVALID_SESSION" && normalized.originalStatus === 401;
 
@@ -244,6 +244,9 @@ function createErrorResponse(normalized: NormalizedAuthError): Response {
 
   const status = normalized.originalStatus || 500;
 
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (requestId) headers["x-request-id"] = requestId;
+
   return new Response(
     JSON.stringify({
       type: normalized.type,
@@ -251,10 +254,11 @@ function createErrorResponse(normalized: NormalizedAuthError): Response {
       message: normalized.message,
       retryable: normalized.retryable,
       originalStatus: normalized.originalStatus,
+      requestId: requestId || undefined,
     }),
     {
       status,
-      headers: { "Content-Type": "application/json" },
+      headers,
     }
   );
 }

--- a/xconfess-frontend/app/components/common/RequestIdBadge.tsx
+++ b/xconfess-frontend/app/components/common/RequestIdBadge.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+/**
+ * RequestIdBadge — compact request ID display with a copy affordance.
+ * Shown alongside auth error messages so users/maintainers can trace logs.
+ * Stays compact on mobile (truncated ID + copy button).
+ */
+export function RequestIdBadge({ requestId }: { requestId: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(requestId);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — select text instead
+      setCopied(false);
+    }
+  }, [requestId]);
+
+  const shortId =
+    requestId.length > 16 ? `${requestId.slice(0, 8)}…${requestId.slice(-6)}` : requestId;
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <span className="text-xs text-red-600/80">Request ID:</span>
+      <code
+        className="min-w-0 select-all truncate rounded bg-red-50 px-1.5 py-0.5 font-mono text-xs text-red-700"
+        title={requestId}
+      >
+        {shortId}
+      </code>
+      <button
+        type="button"
+        aria-label={copied ? 'Request ID copied' : 'Copy request ID'}
+        title={copied ? 'Copied!' : 'Copy request ID'}
+        onClick={copy}
+        className="inline-flex shrink-0 items-center gap-1 rounded-md border border-red-200 bg-white px-1.5 py-0.5 text-xs text-red-700 transition-colors hover:bg-red-100"
+      >
+        {copied ? <Check className="h-3 w-3" aria-hidden="true" /> : <Copy className="h-3 w-3" aria-hidden="true" />}
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}

--- a/xconfess-frontend/app/lib/api/authService.ts
+++ b/xconfess-frontend/app/lib/api/authService.ts
@@ -88,6 +88,9 @@ export const authApi = {
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
         
+        // Extract request ID from response headers or body
+        const requestId = response.headers.get("x-request-id") || (body as any)?.requestId;
+        
         // Check if response is a normalized auth error from the proxy route
         if (isNormalizedAuthError(body)) {
           const normalized = body as NormalizedAuthError;
@@ -96,6 +99,7 @@ export const authApi = {
             responseBody: body,
             path: '/api/auth/session',
             normalized,
+            ...(requestId ? { requestId } : {}),
           });
           logError(appError, 'authApi.login', { status: response.status });
           throw appError;
@@ -117,6 +121,7 @@ export const authApi = {
           path: '/api/auth/session',
           upstreamMessage:
             typeof rawApi === 'string' ? rawApi : undefined,
+          ...(requestId ? { requestId } : {}),
         });
         logError(apiError, 'authApi.login', { status, url: '/api/auth/session' });
         throw apiError;
@@ -149,10 +154,12 @@ export const authApi = {
         const message =
           (body as any)?.message ?? `Registration failed (${response.status})`;
         const field = extractAuthFieldError(body);
+        const requestId = response.headers.get("x-request-id") || (body as any)?.requestId;
         throw new AppError(message, (body as any)?.code ?? 'REGISTER_FAILED', response.status, {
           responseBody: body,
           path: '/api/users/register',
           field,
+          ...(requestId ? { requestId } : {}),
         });
       }
 


### PR DESCRIPTION
## Summary

Surface the request ID on failed login/register attempts so users and maintainers can trace logs.

## Changes

- **`app/api/auth/session/route.ts`**: error responses now include an `x-request-id` header and `requestId` in the JSON body.
- **`app/lib/api/authService.ts`**: login/register extract the request ID from response headers/body into `AppError.details.requestId`.
- **New `RequestIdBadge` component** (`app/components/common/RequestIdBadge.tsx`): compact truncated request ID with a copy button. Truncation + inline layout keep it usable on mobile.
- **login/register pages**: request ID shown alongside auth error messages (both field-level and submit-level errors).

## Acceptance Criteria

- [x] Failed login/register errors include a request ID when present
- [x] Copy button + selectable request ID text
- [x] UI remains compact on mobile (truncated ID + small copy button)

## Validation

```bash
NODE_ENV=test npx jest --no-coverage --runInBand auth
# 7 tests passed — including new assertion: error responses carry x-request-id header + requestId body
```