### PR TITLE
test(frontend): add register page sign-in navigation tests (Closes #1717)

### DIFF
--- a/xconfess-frontend/app/(auth)/register/__tests__/page.signin.test.tsx
+++ b/xconfess-frontend/app/(auth)/register/__tests__/page.signin.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/app/lib/hooks/useAuth", () => ({
+  useAuth: () => ({
+    register: jest.fn(),
+  }),
+}));
+
+// Import after mocks are set up
+import RegisterPage from "../page";
+
+describe("RegisterPage — Sign in navigation", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it("navigates to /login when the Sign in button is clicked", () => {
+    render(<RegisterPage />);
+
+    const signInButton = screen.getByRole("button", { name: "Sign in" });
+    expect(signInButton).toBeInTheDocument();
+
+    fireEvent.click(signInButton);
+
+    expect(mockPush).toHaveBeenCalledWith("/login");
+  });
+
+  it("renders an inline Sign in link that points to /login", () => {
+    render(<RegisterPage />);
+
+    const signInLink = screen.getByRole("link", { name: "Sign in" });
+    expect(signInLink).toBeInTheDocument();
+    expect(signInLink).toHaveAttribute("href", "/login");
+  });
+});


### PR DESCRIPTION
## Summary

Adds regression tests for the register page's **Sign in button** as described in issue #1717.

## Changes

- Created `xconfess-frontend/app/(auth)/register/__tests__/page.signin.test.tsx` with two tests:
  1. **Navigates to /login when the Sign in button is clicked** — verifies the button-style sign-in calls `router.push('/login')`
  2. **Renders an inline Sign in link that points to /login** — verifies the inline link has `href="/login"`

## Verification

All register-related tests pass:

```
npm run test --workspace=xconfess-frontend -- register --runInBand

PASS app/lib/api/__tests__/authService.register.test.ts
PASS app/api/users/register/__tests__/route.test.ts
PASS app/(auth)/register/__tests__/page.signin.test.tsx

Test Suites: 3 passed, 3 total
Tests:       8 passed, 8 total
```

## Closes

Closes #1717