### PR TITLE
test(frontend): add login page register navigation tests (Fixes #1716)

### DIFF
--- a/xconfess-frontend/app/(auth)/login/__tests__/page.register.test.tsx
+++ b/xconfess-frontend/app/(auth)/login/__tests__/page.register.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/app/lib/hooks/useAuth", () => ({
+  useAuth: () => ({
+    login: jest.fn(),
+  }),
+}));
+
+// Import after mocks are set up
+import LoginPage from "../page";
+
+describe("LoginPage — Create account navigation", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it("navigates to /register when the Create account button is clicked", () => {
+    render(<LoginPage />);
+
+    const createAccountButton = screen.getByRole("button", {
+      name: "Create account",
+    });
+    expect(createAccountButton).toBeInTheDocument();
+
+    fireEvent.click(createAccountButton);
+
+    expect(mockPush).toHaveBeenCalledWith("/register");
+  });
+
+  it("renders the Create account button with the register destination", () => {
+    render(<LoginPage />);
+
+    const createAccountButton = screen.getByRole("button", {
+      name: "Create account",
+    });
+    expect(createAccountButton).toBeInTheDocument();
+    expect(createAccountButton).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds regression tests for the login page's **Create account button** as described in issue #1716.

## Changes

- Created `xconfess-frontend/app/(auth)/login/__tests__/page.register.test.tsx` with two tests:
  1. **Navigates to /register when the Create account button is clicked** — verifies the button exists and clicking it calls `router.push('/register')`
  2. **Renders the Create account button with the register destination** — asserts the button is present and not disabled

## Why

Follows the same pattern as the register page sign-in navigation tests (PR #1747, Fixes #1717). The login page's "Create account" button was missing focused regression coverage.

## Validation

```bash
NODE_ENV=test npx jest --no-coverage --runInBand -- login
```

Both tests pass. Tests mock `next/navigation` and `useAuth` so they require no real backend.