### PR TITLE
frontend: polish confession card compare label spacing (Closes #1768)

### DIFF
--- a/xconfess-frontend/app/components/confession/ConfessionCard.tsx
+++ b/xconfess-frontend/app/components/confession/ConfessionCard.tsx
@@ -116,7 +116,7 @@ export const ConfessionCard = memo(({ confession }: Props) => {
             />
             <label
               htmlFor={`compare-${confession.id}`}
-              className="text-xs text-[var(--secondary)] cursor-pointer"
+              className="text-xs leading-none text-[var(--secondary)] cursor-pointer"
             >
               Compare
             </label>


### PR DESCRIPTION
## Summary

Added leading-none to the compare checkbox label className so the text baseline aligns with the checkbox center.

Closes #1768