### PR TITLE
frontend: improve auth error display with request ID copy affordance

### DIFF
--- a/xconfess-frontend/app/(auth)/login/page.tsx
+++ b/xconfess-frontend/app/(auth)/login/page.tsx
@@ -14,6 +14,8 @@ import {
   hasErrors,
   type ValidationErrors,
 } from '@/app/lib/utils/validation';
+import { extractRequestId, AppError } from '@/app/lib/utils/errorHandler';
+import { RequestIdDisplay } from '@/app/components/request-id/RequestIdDisplay';
 
 const showDevMockAdminLogin =
   process.env.NEXT_PUBLIC_ENABLE_DEV_MOCK_ADMIN_LOGIN === 'true';
@@ -24,6 +26,7 @@ export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState<ValidationErrors>({});
+  const [requestId, setRequestId] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
 
   const doMockAdminLogin = async () => {
@@ -62,6 +65,7 @@ export default function LoginPage() {
 
     setLoading(true);
     setErrors({});
+    setRequestId(undefined);
     try {
       const user = await login({
         email: parsed.data.email,
@@ -71,6 +75,13 @@ export default function LoginPage() {
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Login failed';
       setErrors({ password: message });
+      // Extract request ID from the error for display in the UI
+      const rid = extractRequestId(e);
+      if (rid) {
+        setRequestId(rid);
+      } else if (e instanceof AppError && e.details?.requestId) {
+        setRequestId(e.details.requestId as string);
+      }
     } finally {
       setLoading(false);
     }
@@ -106,12 +117,14 @@ export default function LoginPage() {
             {errors.email && (
               <div className="mt-5 rounded-[20px] border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                 {errors.email}
+                {requestId && <RequestIdDisplay requestId={requestId} />}
               </div>
             )}
 
             {errors.password && !errors.email && (
               <div className="mt-5 rounded-[20px] border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                 {errors.password}
+                {requestId && <RequestIdDisplay requestId={requestId} />}
               </div>
             )}
 

--- a/xconfess-frontend/app/(auth)/register/page.tsx
+++ b/xconfess-frontend/app/(auth)/register/page.tsx
@@ -9,8 +9,9 @@ import { Button } from '@/app/components/ui/button';
 import { Input } from '@/app/components/ui/input';
 import { BrandLogo } from '@/app/components/brand/BrandLogo';
 import { useAuth } from '@/app/lib/hooks/useAuth';
-import { getErrorMessage } from '@/app/lib/utils/errorHandler';
+import { getErrorMessage, extractRequestId } from '@/app/lib/utils/errorHandler';
 import { getAuthFieldError } from '@/app/lib/api/authService';
+import { RequestIdDisplay } from '@/app/components/request-id/RequestIdDisplay';
 import {
   validateRegisterForm,
   parseRegisterForm,
@@ -40,6 +41,7 @@ export default function RegisterPage() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [errors, setErrors] = useState<ValidationErrors>({});
   const [submitError, setSubmitError] = useState('');
+  const [requestId, setRequestId] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -56,6 +58,7 @@ export default function RegisterPage() {
     if (field === 'confirmPassword') setConfirmPassword(value);
 
     setSubmitError('');
+    setRequestId(undefined);
     if (errors[field]) {
       setErrors((prev) => ({ ...prev, [field]: undefined }));
     }
@@ -80,6 +83,8 @@ export default function RegisterPage() {
     }
 
     setLoading(true);
+    setSubmitError('');
+    setRequestId(undefined);
     try {
       await register({
         username: parsed.data.username,
@@ -95,6 +100,10 @@ export default function RegisterPage() {
         setSubmitError('');
       } else {
         setSubmitError(message);
+      }
+      const rid = extractRequestId(error);
+      if (rid) {
+        setRequestId(rid);
       }
     } finally {
       setLoading(false);
@@ -147,6 +156,7 @@ export default function RegisterPage() {
                 role="alert"
               >
                 {submitError}
+                {requestId && <RequestIdDisplay requestId={requestId} />}
               </div>
             )}
 

--- a/xconfess-frontend/app/api/auth/session/route.ts
+++ b/xconfess-frontend/app/api/auth/session/route.ts
@@ -122,7 +122,7 @@ export async function POST(request: Request) {
                 message: "Email and password are required",
                 status: 400,
             });
-            return createErrorResponse(normalized);
+            return createErrorResponse(normalized, requestId);
         }
 
         const backend = resolveBackendRoute(request, "/auth/login");
@@ -132,7 +132,7 @@ export async function POST(request: Request) {
         }, backend.requestId);
 
         if (!result.success) {
-            return createErrorResponse(result.normalized!);
+            return createErrorResponse(result.normalized!, requestId);
         }
 
         const data = result.data as Record<string, unknown>;
@@ -156,7 +156,7 @@ export async function POST(request: Request) {
         return res;
     } catch (error) {
         const normalized = normalizeAuthError(error);
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 }
 
@@ -171,7 +171,7 @@ export async function GET(request: Request) {
             message: "Not authenticated",
             status: 401,
         });
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 
     try {
@@ -200,7 +200,7 @@ export async function GET(request: Request) {
             if (result.normalized?.originalStatus === 401) {
                 cookieStore.delete(SESSION_COOKIE_NAME);
             }
-            return createErrorResponse(result.normalized!);
+            return createErrorResponse(result.normalized!, requestId);
         }
 
         const user = result.data as Record<string, unknown>;
@@ -209,7 +209,7 @@ export async function GET(request: Request) {
         return response;
     } catch (error) {
         const normalized = normalizeAuthError(error);
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 }
 
@@ -227,7 +227,7 @@ export async function PUT() {
  * Convert normalized auth error to JSON response.
  * Output shape matches NormalizedAuthError so AuthProvider can consume it directly.
  */
-function createErrorResponse(normalized: NormalizedAuthError): Response {
+function createErrorResponse(normalized: NormalizedAuthError, requestId?: string): Response {
   const isExpectedMissingSession =
     normalized.code === "INVALID_SESSION" && normalized.originalStatus === 401;
 
@@ -244,6 +244,13 @@ function createErrorResponse(normalized: NormalizedAuthError): Response {
 
   const status = normalized.originalStatus || 500;
 
+  const responseHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (requestId) {
+    responseHeaders["x-request-id"] = requestId;
+  }
+
   return new Response(
     JSON.stringify({
       type: normalized.type,
@@ -254,7 +261,7 @@ function createErrorResponse(normalized: NormalizedAuthError): Response {
     }),
     {
       status,
-      headers: { "Content-Type": "application/json" },
+      headers: responseHeaders,
     }
   );
 }

--- a/xconfess-frontend/app/components/request-id/RequestIdDisplay.tsx
+++ b/xconfess-frontend/app/components/request-id/RequestIdDisplay.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+/**
+ * Displays a `x-request-id` value with a copy affordance.
+ *
+ * Surfacing the request ID lets users and maintainers trace failed auth
+ * requests back to backend logs. Rendered compactly so it stays tidy on
+ * mobile widths — a trimmed monospace value plus a copy button.
+ *
+ * @param requestId - The request correlation ID to display
+ * @param label - Optional microcopy shown above the value (default "Request ID")
+ */
+export function RequestIdDisplay({
+  requestId,
+  label = 'Request ID',
+}: {
+  requestId: string;
+  label?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  if (!requestId || requestId.trim().length === 0) {
+    return null;
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(requestId);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API can be unavailable (e.g. insecure context) — fall back to
+      // selecting the text so the user can copy manually.
+      const element = document.getElementById('auth-request-id-value');
+      if (element) {
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        const selection = window.getSelection();
+        if (selection) {
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+      }
+    }
+  };
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-full border border-[var(--border)] bg-[var(--surface)] px-2.5 py-1 text-left text-xs text-[var(--secondary)] transition-colors hover:border-[var(--accent-border)] hover:text-[var(--foreground)]"
+        aria-label={`Copy ${label} ${requestId}`}
+        title={`${label}: ${requestId}`}
+      >
+        <span className="shrink-0 font-medium">{label}:</span>
+        <span
+          id="auth-request-id-value"
+          className="truncate font-mono text-[11px] tracking-tight"
+        >
+          {requestId}
+        </span>
+        {copied ? (
+          <Check className="h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden="true" />
+        ) : (
+          <Copy
+            className="h-3.5 w-3.5 shrink-0 opacity-60 transition-opacity group-hover:opacity-100"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/xconfess-frontend/app/lib/api/authService.ts
+++ b/xconfess-frontend/app/lib/api/authService.ts
@@ -87,6 +87,7 @@ export const authApi = {
 
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
+        const requestId = response.headers.get("x-request-id") || undefined;
         
         // Check if response is a normalized auth error from the proxy route
         if (isNormalizedAuthError(body)) {
@@ -96,6 +97,7 @@ export const authApi = {
             responseBody: body,
             path: '/api/auth/session',
             normalized,
+            ...(requestId ? { requestId } : {}),
           });
           logError(appError, 'authApi.login', { status: response.status });
           throw appError;
@@ -117,6 +119,7 @@ export const authApi = {
           path: '/api/auth/session',
           upstreamMessage:
             typeof rawApi === 'string' ? rawApi : undefined,
+          ...(requestId ? { requestId } : {}),
         });
         logError(apiError, 'authApi.login', { status, url: '/api/auth/session' });
         throw apiError;
@@ -146,6 +149,7 @@ export const authApi = {
 
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
+        const requestId = response.headers.get("x-request-id") || undefined;
         const message =
           (body as any)?.message ?? `Registration failed (${response.status})`;
         const field = extractAuthFieldError(body);
@@ -153,6 +157,7 @@ export const authApi = {
           responseBody: body,
           path: '/api/users/register',
           field,
+          ...(requestId ? { requestId } : {}),
         });
       }
 


### PR DESCRIPTION
## Summary

Closes #1729 — Surface `x-request-id` on auth errors where available, with a small copy button.

## Problem

When auth requests fail, users and maintainers need the request ID to trace logs. The backend already generates and echoes `x-request-id` via `RequestIdMiddleware`, but the frontend never surfaced it to users.

## Changes

1. **`app/api/auth/session/route.ts`** — `createErrorResponse` now accepts a `requestId` and echoes the `x-request-id` response header on error responses (all POST/GET error paths), so the browser/fetch gets the ID even when the request fails.

2. **`app/lib/api/authService.ts`** — `login()` and `register()` read `x-request-id` from the fetch response headers and attach it to the thrown `AppError` details under `requestId`.

3. **`app/components/request-id/RequestIdDisplay.tsx`** (new) — compact pill showing `Request ID: <truncated UUID>` with a copy button. Truncates with `font-mono` + `truncate` so it stays tidy on mobile widths. Falls back to text selection if `navigator.clipboard` is unavailable.

4. **`app/(auth)/login/page.tsx`** — extracts the request ID from the caught error and renders `RequestIdDisplay` inside the error box after a failed login attempt.

5. **`app/(auth)/register/page.tsx`** — same treatment for registration errors (rendered inside the submit error box; field-level errors still clear the ID).

## Acceptance criteria

- ✅ Failed login/register errors include a request ID when present
- ✅ The UI remains compact on mobile (pill uses `truncate` + small mono text, copy button inline)
- ✅ Request ID is selectable/copyable

## Validation

```bash
npm run test --workspace=xconfess-frontend -- auth --runInBand
```

- 122 tests passed. The only failing suite is `tests/accessibility/auth-feed-admin.a11y.spec.tsx` (10 failures) — **pre-existing on `main`** (verified by stashing changes; the `LoginPage` a11y crashes occur with the unmodified codebase and are unrelated to this PR).
- `tsc --noEmit` reports no new type errors in the touched files.

Signed-off-by: waterWang <water.wang@users.noreply.github.com>