### PR TITLE
fix: normalize settings proxy errors

### DIFF
--- a/docs/frontend-proxy-routes.md
+++ b/docs/frontend-proxy-routes.md
@@ -18,7 +18,7 @@ forward cookies or authorization headers when present, and normalize failures th
 | --- | --- | --- |
 | `/api/auth/session` | `/api/auth/session`, with fallback to `/api/auth/me` and login handling | Cookie/session aware; returns normalized auth errors for `AuthProvider`. |
 | `/api/users/register` | `/api/users/register` | Validates `BACKEND_API_URL` and uses normalized API error responses. |
-| `/api/users/profile`, `/api/users/profile/summary`, `/api/users/privacy-settings`, `/api/users/stats` | Matching `/api/users/...` backend routes | Same-origin browser calls; proxy responses should preserve backend status and user-safe messages. |
+| `/api/users/profile`, `/api/users/profile/summary`, `/api/users/privacy-settings`, `/api/users/notification-preferences`, `/api/users/stats` | Matching `/api/users/...` backend routes | Same-origin browser calls; proxy responses should preserve backend status and user-safe messages. Settings pages must surface failures through `normalizeApiError`. |
 | `/api/users/[id]/public-profile`, `/api/users/[id]/confessions`, `/api/users/[id]/activities` | Matching `/api/users/:id/...` backend routes | Public/profile data proxies; use centralized API error responses. |
 | `/api/confessions`, `/api/confessions/search`, `/api/confessions/[id]` | `/api/confessions...` | Confession list/detail/search proxies; normalize confession payloads where route handlers reshape data. |
 | `/api/confessions/[id]/react`, `/report`, `/anchor`, `/tips/stats`, `/tips/verify` | Matching confession action routes | Action routes forward request bodies and preserve backend validation/rate-limit failures. |

--- a/xconfess-frontend/app/(dashboard)/settings/notifications/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/settings/notifications/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { Bell, Mail, Smartphone, Moon, Save, Clock, RefreshCw } from 'lucide-react';
 import { useGlobalToast } from '@/app/components/common/Toast';
+import { normalizeApiError } from '@/app/lib/api/errors';
 
 interface ChannelPrefs {
   inApp: boolean;
@@ -66,7 +67,10 @@ export default function NotificationSettingsPage() {
     setError(null);
     try {
       const response = await fetch('/api/users/notification-preferences', { credentials: 'include' });
-      if (!response.ok) throw new Error('Failed to load preferences');
+      if (!response.ok) {
+        const error = await normalizeApiError(response);
+        throw new Error(error.message);
+      }
       const data = await response.json();
       setPreferences({
         reactions: { inApp: true, email: true, push: true, ...data.reactions },
@@ -81,7 +85,7 @@ export default function NotificationSettingsPage() {
         timezone: data.timezone ?? null,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load');
+      setError(err instanceof Error ? err.message : 'Failed to load notification preferences');
     } finally {
       setLoading(false);
     }
@@ -122,10 +126,13 @@ export default function NotificationSettingsPage() {
         body: JSON.stringify(body),
       });
 
-      if (!response.ok) throw new Error('Failed to save');
+      if (!response.ok) {
+        const error = await normalizeApiError(response);
+        throw new Error(error.message);
+      }
       toast.success('Notification preferences saved');
-    } catch {
-      toast.error('Failed to save preferences');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save preferences');
     } finally {
       setSaving(false);
     }

--- a/xconfess-frontend/app/(dashboard)/settings/privacy/page.tsx
+++ b/xconfess-frontend/app/(dashboard)/settings/privacy/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { Shield, Eye, EyeOff, MessageSquare, Database, Save, Sun, Moon, Laptop, Lock, Globe, Bell, BellOff } from 'lucide-react';
 import { useGlobalToast } from '@/app/components/common/Toast';
+import { normalizeApiError } from '@/app/lib/api/errors';
 import { useTheme } from '@/app/lib/hooks/useTheme';
 
 interface PrivacySettings {
@@ -104,15 +105,17 @@ export default function PrivacySettingsPage() {
       });
 
       if (!response.ok) {
-        throw new Error('Failed to load settings');
+        const error = await normalizeApiError(response);
+        throw new Error(error.message);
       }
 
       const data: PrivacySettings = await response.json();
       setSettings(data);
       setDirty(false);
-    } catch {
-      setLoadError('Failed to load privacy settings.');
-      toast.error('Failed to load privacy settings');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load privacy settings.';
+      setLoadError(message);
+      toast.error(message);
     } finally {
       setLoading(false);
     }
@@ -138,14 +141,17 @@ export default function PrivacySettingsPage() {
         body: JSON.stringify(settings),
       });
 
-      if (!response.ok) throw new Error('Failed to save');
+      if (!response.ok) {
+        const error = await normalizeApiError(response);
+        throw new Error(error.message);
+      }
 
       const updated: PrivacySettings = await response.json();
       setSettings(updated);
       setDirty(false);
       toast.success('Privacy settings saved successfully');
-    } catch {
-      toast.error('Failed to save privacy settings');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save privacy settings');
     } finally {
       setSaving(false);
     }

--- a/xconfess-frontend/tests/pwa/service-worker-static-assets.spec.ts
+++ b/xconfess-frontend/tests/pwa/service-worker-static-assets.spec.ts
@@ -22,6 +22,8 @@ describe("development service worker cleanup", () => {
 
   it("unregisters service workers outside production", () => {
     expect(layoutSource).toContain("const unregisterServiceWorkerScript");
+    expect(layoutSource).toContain("navigator.serviceWorker");
+    expect(layoutSource).toContain(".getRegistrations()");
     expect(layoutSource).toContain("registration.unregister()");
     expect(layoutSource).toContain('process.env.NODE_ENV === "production"');
     expect(layoutSource).toContain(": unregisterServiceWorkerScript");


### PR DESCRIPTION
## Summary
- add the notification-preferences settings proxy to the frontend proxy inventory
- route privacy and notification settings load/save failures through `normalizeApiError`
- strengthen the dev service-worker cleanup smoke test to assert `getRegistrations()` is used before unregistering

## Validation
- `git diff --check`
- `npm test -- app/lib/api/__tests__/errors.spec.ts tests/pwa/service-worker-static-assets.spec.ts` could not run because npm exited before Jest with `ECOMPROMISED Lock compromised`

Closes #1792
Closes #1793
Closes #1794