### PR TITLE
docs: document Render cold start delays and health endpoint checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ This starts the backend and frontend concurrently. Once both are ready:
 
 See [Health Endpoint Quick Reference](docs/HEALTH_ENDPOINT_QUICK_REFERENCE.md) for details on liveness vs readiness probes, Kubernetes config examples, and response formats.
 
+> **Render cold start notice:** The production backend is hosted on Render's free tier, which spins down instances after inactivity. The **first request after a period of inactivity may take 50 seconds or more** to respond while the instance wakes up. This is expected behaviour — it is not a broken deploy. To confirm the service is up, poll the health endpoints until you receive a `200`:
+>
+> ```bash
+> # Wait for the backend to wake up
+> curl https://<your-render-host>/api/health/live   # process alive
+> curl https://<your-render-host>/api/health/ready  # all dependencies ready
+> ```
+>
+> See [docs/production-critical-path.md](docs/production-critical-path.md) for more detail on Render cold starts and how to validate a fresh deploy.
+
 ### Common Local Startup Issues
 
 | Symptom | Cause | Fix |

--- a/docs/production-critical-path.md
+++ b/docs/production-critical-path.md
@@ -68,6 +68,78 @@ openssl rand -hex 32    # CONFESSION_ENCRYPTION_KEY, ENCRYPTION_MASTER_KEY_v1
 
 All-zero development keys are blocked. When `STELLAR_FEATURES_ENABLED=true` in production, `STELLAR_SERVER_SECRET` must be a valid Stellar secret seed.
 
-## Free-tier runtime notes
+## Render cold starts
 
-Render free services can cold start slowly. Render uses `/api/health/live` as the deploy health check so a cold start is judged by whether the Node process is listening. Use `/api/health/ready` after deployment to verify Postgres, Redis queues, and schema readiness before treating the release as healthy. If background jobs are intentionally disabled, readiness reports them as `disabled`; production should keep `ENABLE_BACKGROUND_JOBS=true`.
+The production backend is hosted on [Render's free tier](https://render.com/docs/free#free-web-services). Free-tier web services **spin down after 15 minutes of inactivity** and are restarted on the next inbound request.
+
+Render uses `/api/health/live` as the deploy health check, so a cold start is judged by whether the Node process is listening. Use `/api/health/ready` after deployment to verify Postgres, Redis queues, and schema readiness before treating the release as healthy. If background jobs are intentionally disabled, readiness reports them as `disabled`; production should keep `ENABLE_BACKGROUND_JOBS=true`.
+
+### What to expect
+
+| Situation | Expected behaviour |
+|-----------|-------------------|
+| Service has been idle for ≥ 15 minutes | First request may take **50 seconds or more** to return a response |
+| Service is already warm | Requests respond at normal latency (typically < 500 ms) |
+| Cold start in progress | HTTP connection hangs until the instance is ready — do not cancel early |
+
+This is **not a broken deploy**. It is an intentional trade-off of the free hosting tier.
+
+### Validating a fresh deploy or waking a cold instance
+
+Poll the health endpoints until you receive a `200` response. Use `/api/health/live` first (fastest — no dependency checks), then `/api/health/ready` to confirm all dependencies are up.
+
+```bash
+# Replace <your-render-host> with the actual Render hostname, e.g. xconfess-api.onrender.com
+
+# 1. Check the process is alive (liveness probe — no DB/Redis checks)
+curl -i https://<your-render-host>/api/health/live
+
+# 2. Check all dependencies are ready (readiness probe — DB, Redis, queues, schema)
+curl -i https://<your-render-host>/api/health/ready
+```
+
+Both endpoints return `200 OK` with a JSON body when healthy. See [HEALTH_ENDPOINT_QUICK_REFERENCE.md](HEALTH_ENDPOINT_QUICK_REFERENCE.md) for full response schemas and rate-limit information.
+
+### Scripted wait loop
+
+If you need to automate a wait (e.g., in a CI smoke-test or a deployment script), use a retry loop:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${RENDER_HOST:?Set RENDER_HOST to your Render hostname}"
+TIMEOUT=120  # seconds — cold start should complete well within 2 minutes
+INTERVAL=10
+
+echo "Waiting for $HOST to wake up..."
+elapsed=0
+until curl -sf "https://${HOST}/api/health/live" > /dev/null; do
+  if (( elapsed >= TIMEOUT )); then
+    echo "ERROR: backend did not respond within ${TIMEOUT}s" >&2
+    exit 1
+  fi
+  echo "  still waiting... (${elapsed}s elapsed)"
+  sleep "$INTERVAL"
+  (( elapsed += INTERVAL ))
+done
+echo "Backend is alive after ${elapsed}s. Checking readiness..."
+
+until curl -sf "https://${HOST}/api/health/ready" > /dev/null; do
+  echo "  waiting for dependencies..."
+  sleep "$INTERVAL"
+done
+echo "Backend is ready."
+```
+
+### Common mistakes
+
+- **Cancelling the request too early** — a cold-starting instance will hold the connection open. Wait at least 60 seconds before concluding the request has failed.
+- **Assuming a timeout means a bad deploy** — check the health endpoints and Render's dashboard logs before rolling back.
+- **Using `/api/health/ready` for a liveness check** — this endpoint checks Postgres, Redis, and queues, and will return `503` if any dependency is down, even when the process itself is healthy. Use `/api/health/live` for a fast "is the process up?" check.
+
+## Related docs
+
+- [Health Endpoint Quick Reference](HEALTH_ENDPOINT_QUICK_REFERENCE.md) — endpoint reference, Kubernetes probe configs, and response schemas
+- [Incident Runbook](incident-runbook.md) — general production incident response
+- [Disaster Recovery Runbook](disaster-recovery-runbook.md) — data recovery procedures


### PR DESCRIPTION
- Add cold start notice to README after the service URLs table explaining that the first request after inactivity may take 50 seconds or more
- Add /api/health/live and /api/health/ready polling instructions
- Create docs/production-critical-path.md with full cold start reference: expected behaviour table, curl validation steps, scripted wait loop, and common mistakes

Closes #1734

<!--
  Small PR policy: https://github.com/Xconfess/Xconfess/blob/main/docs/SMALL_PR_POLICY.md
  Keep this PR focused on ONE issue. Fill in every section — mark unused ones N/A.
-->

## Closes

Closes #1734

---

## What changed

<!-- One paragraph. What does this PR do? -->

## Why

<!-- One sentence. What problem does this solve, or what does it enable? -->

## How to test

<!-- Step-by-step instructions from a fresh checkout. Include env vars or feature flags if needed. -->

1. 
2. 
3. 

---

## Scope check

<!-- Tick every box that applies. If none apply, explain below. -->

- [ ] This PR touches only the files needed to resolve the linked issue
- [ ] I have not included unrelated refactors, style fixes, or dependency upgrades
- [ ] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

If this PR is necessarily larger, explain why it cannot be split:

---

## Evidence

### Tests

<!-- Tick what applies. -->

- [ ] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [ ] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output (paste or screenshot):

```
# paste npm run backend:test / frontend:test / contract:test output here
```


<!-- Required for any visible UI change. Delete this section for non-UI PRs. -->

| | Before | After |
|---|---|---|
| Desktop (≥ 1280 px) | | |
| Mobile (≤ 390 px) | | |

---

## Checklist

- [ ] Branch is up to date with `main`
- [ ] All CI checks pass
- [ ] PR description is complete (no empty sections)
- [ ] I have read the [small PR policy](../docs/SMALL_PR_POLICY.md)