### PR TITLE
Normalize auth link hover colors

### DIFF
--- a/xconfess-frontend/app/(auth)/login/page.tsx
+++ b/xconfess-frontend/app/(auth)/login/page.tsx
@@ -164,8 +164,13 @@ export default function LoginPage() {
                 />
               </div>
 
-              <div className="text-sm text-[var(--primary-deep)] hover:text-[var(--primary)]">
-                <Link href="/forgot-password">Forgot password?</Link>
+              <div className="text-sm">
+                <Link
+                  href="/forgot-password"
+                  className="text-[var(--primary-deep)] hover:text-[var(--primary)]"
+                >
+                  Forgot password?
+                </Link>
               </div>
 
               <Button


### PR DESCRIPTION
## Closes

Closes #1764

---

## What changed

I moved the shared primary theme color and hover token classes from the login page forgot password wrapper onto the actual link. The register page already follows this pattern, so both auth secondary links now apply the shared tokens directly to their interactive elements.

## Why

The login link should own its theme colors and hover state instead of making the entire full width wrapper interactive.

## How to test

1. Start the frontend with the repository environment configured.
2. Open `/login` and inspect the `Forgot password?` link.
3. Hover the link and confirm the shared primary theme color changes.
4. Open `/register` and confirm the existing `Sign in` secondary link remains consistent.

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

## Evidence

### Tests

- [ ] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [x] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output:

```text
npm run ci:apps                                   passed
npm run test --workspace=xconfess-backend         passed: 133 suites, 1287 tests; 1 suite skipped
npm run test:smoke --workspace=xconfess-frontend -- --grep "Public pages smoke"
                                                 passed: 5 tests
cargo fmt --all -- --check                      passed
cargo clippy --workspace --all-targets -- -D warnings passed
cargo test --workspace                         passed
cargo build --target wasm32-unknown-unknown    passed
cargo build --release --target wasm32-unknown-unknown passed
```

Frontend Jest remains advisory in the repository workflow. Its existing accessibility suite still fails because the test lucide-react mock omits `UserPlus` and `LogIn`, which are unrelated to this one-line class ownership change; the workflow marks that suite advisory.

### Screenshots (UI changes only)

The resting page is intentionally unchanged. The evidence overlays identify the hover target: the old wrapper versus the fixed link.

| | Before | After |
|---|---|---|
| Desktop (≥ 1280 px) | ![Before desktop](https://raw.githubusercontent.com/dotmantissa/Xconfess/issue1764evidence/evidence/issue-1764/before-desktop.png) | ![After desktop](https://raw.githubusercontent.com/dotmantissa/Xconfess/issue1764evidence/evidence/issue-1764/after-desktop.png) |
| Mobile (≤ 390 px) | ![Before mobile](https://raw.githubusercontent.com/dotmantissa/Xconfess/issue1764evidence/evidence/issue-1764/before-mobile.png) | ![After mobile](https://raw.githubusercontent.com/dotmantissa/Xconfess/issue1764evidence/evidence/issue-1764/after-mobile.png) |

## Checklist

- [x] Branch is up to date with `main`
- [x] All required CI-equivalent checks pass locally
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](https://github.com/Xconfess/Xconfess/blob/main/docs/SMALL_PR_POLICY.md)
