### PR TITLE
Clarify offline page copy

### DIFF
--- a/xconfess-frontend/app/offline/page.tsx
+++ b/xconfess-frontend/app/offline/page.tsx
@@ -1,10 +1,10 @@
 export default function OfflinePage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-8 text-center">
-      <h1 className="mb-4 font-editorial text-4xl text-[var(--foreground)]">You&apos;re offline</h1>
+      <h1 className="mb-4 font-editorial text-4xl text-[var(--foreground)]">You&apos;re currently offline</h1>
       <p className="max-w-md text-sm leading-7 text-[var(--secondary)]">
-        xConfess needs a connection to load the feed. Your pending confessions are
-        saved locally and will sync automatically when you reconnect.
+        We can&apos;t load the feed right now. Check your internet connection and try again.
+        Any confessions you save while offline will sync automatically when you&apos;re back online.
       </p>
     </main>
   );


### PR DESCRIPTION
## Closes

Closes #1765

---

## What changed

I updated the offline page heading and short copy to state the current connection problem clearly, tell users to check their internet connection, and explain that offline confessions sync when the connection returns.

## Why

The offline page should give users a clearer status and a direct next step while preserving the existing offline sync guidance.

## How to test

1. Start the frontend with the repository environment configured.
2. Open `/offline` in a desktop browser and confirm the updated heading and copy are readable.
3. Resize the browser to a mobile viewport and confirm the copy wraps without overlap.

## Scope check

- [x] This PR touches only the files needed to resolve the linked issue
- [x] I have not included unrelated refactors, style fixes, or dependency upgrades
- [x] Changed lines ≤ 400 and files touched ≤ 8 (excluding lockfiles and generated files)

## Evidence

### Tests

- [ ] Added or updated unit tests
- [ ] Added or updated integration / e2e tests
- [x] Change is not testable — manual steps provided above
- [ ] No runtime behaviour changed (docs / config only)

Test run output:

```text
npm run ci:apps                                      passed
npm run ci:contract                                  passed
npm run backend:test                                 passed: 133 suites, 1287 tests; 1 suite skipped
npm run frontend:lint                                passed with existing warnings
npm run frontend:typecheck                           passed
npm run frontend:build                               passed
npm run audit:ci                                     passed
npm run secret-scan:self-test && npm run secret-scan passed
```

The frontend Jest suite has 58 passing suites and 2 existing failing suites unrelated to this change: the auth accessibility mock is missing exported icons, and privacy settings tests expect older toast messages. The release workflow marks this frontend test step advisory. The changed offline page has no test failures.

### Screenshots (UI changes only)

| | Before | After |
|---|---|---|
| Desktop (≥ 1280 px) | ![Before desktop](https://raw.githubusercontent.com/dotmantissa/Xconfess/evidence/issue1765/evidence/issue-1765/before-desktop.png) | ![After desktop](https://raw.githubusercontent.com/dotmantissa/Xconfess/evidence/issue1765/evidence/issue-1765/after-desktop.png) |
| Mobile (≤ 390 px) | ![Before mobile](https://raw.githubusercontent.com/dotmantissa/Xconfess/evidence/issue1765/evidence/issue-1765/before-mobile.png) | ![After mobile](https://raw.githubusercontent.com/dotmantissa/Xconfess/evidence/issue1765/evidence/issue-1765/after-mobile.png) |

## Checklist

- [x] Branch is up to date with `main`
- [x] All blocking CI-equivalent checks pass locally
- [x] PR description is complete (no empty sections)
- [x] I have read the [small PR policy](https://github.com/Xconfess/Xconfess/blob/main/docs/SMALL_PR_POLICY.md)
