### PR TITLE
Add admin docs, search bounds tests, and cursor pagination tests

### DIFF
--- a/docs/data-export-retention.md
+++ b/docs/data-export-retention.md
@@ -1,0 +1,44 @@
+# Data Export Retention & Expiry
+
+Reference for export job lifecycle, download token behaviour, and retention defaults.
+
+## Defaults
+
+| Parameter | Value | Source |
+|---|---|---|
+| Download TTL | 24 hours after `createdAt` | `app.exportDownloadTtlMs` (fallback: `24 * 60 * 60 * 1000`) |
+| Rate limit | 1 per 7 days per user | Hardcoded in `requestExport()` |
+| Token cleanup | Runs via `expireStaleDownloadTokens()` | `DATA_EXPORT_TTL_MS` env var |
+
+## Export Statuses
+
+| Status | Meaning |
+|---|---|
+| `PENDING` | Queued, waiting for background job |
+| `PROCESSING` | Job picked up, file being generated |
+| `READY` | File available for download |
+| `FAILED` | Job failed (retryable) |
+| `EXPIRED` | Download window elapsed |
+
+## Download Token Rules
+
+1. A one-time random nonce is generated per `generateSignedDownloadUrl()` call.
+2. Only the HMAC-SHA256 hash is stored in `downloadTokenHash`.
+3. On first successful download, `downloadTokenHash` is cleared and `downloadedAt` is stamped.
+4. Replay attempts (same token, or after `downloadedAt` is set) are rejected.
+5. Tokens expire when `createdAt + TTL` elapses, even if never used.
+
+## Redownload Behaviour
+
+| File Available | Token Active | `canRedownload` | `canRequestNewLink` |
+|---|---|---|---|
+| Yes | Yes | `true` | `false` |
+| Yes | No | `false` | `true` |
+| No | - | `false` | `false` |
+
+## Code References
+
+- Service: `src/data-export/data-export.service.ts`
+- Constants: `src/data-export/data-export.constants.ts`
+- Cleanup scheduler: `src/data-export/data-export-cleanup.ts`
+- Tests: `src/data-export/data-export.service.spec.ts`

--- a/docs/moderation-state-machine.md
+++ b/docs/moderation-state-machine.md
@@ -1,0 +1,50 @@
+# Moderation State Machine
+
+Admin reference for content moderation transitions.
+
+## States
+
+| State | Meaning |
+|---|---|
+| `pending` | Awaiting initial review |
+| `approved` | Passes moderation; visible to users |
+| `flagged` | Suspicious; needs human review |
+| `escalated` | Referred to senior moderators |
+| `resolved` | Handled by a moderator |
+| `hidden` | Removed from public view |
+| `rejected` | Permanently denied |
+
+## Allowed Transitions
+
+| From | To | Trigger / Side Effect |
+|---|---|---|
+| `pending` | `approved` | Auto-approval or manual review — content becomes visible |
+| `pending` | `flagged` | AI score above medium threshold — queued for review |
+| `pending` | `rejected` | AI score above high threshold or manual reject |
+| `approved` | `flagged` | Post-approval report or delayed AI flag |
+| `flagged` | `escalated` | Moderator escalates to senior review |
+| `flagged` | `resolved` | Moderator dismisses the flag |
+| `flagged` | `hidden` | Moderator removes content |
+| `flagged` | `rejected` | Moderator rejects content |
+| `escalated` | `resolved` | Senior moderator clears the flag |
+| `escalated` | `hidden` | Senior moderator removes content |
+| `escalated` | `rejected` | Senior moderator rejects content |
+| `resolved` | `flagged` | Re-flagged if new reports arrive |
+| `hidden` | `resolved` | Content restored after review |
+| `rejected` | `pending` | Appeal or manual requeue for re-review |
+
+Self-transitions (`X → X`) are always rejected.
+
+## Side Effects
+
+- **Audit log** — every transition is recorded via `ModerationLog`
+- **Notifications** — users are notified on `approved`, `rejected`, and `hidden` transitions
+- **Event emitter** — `moderation.status.changed` event fired on every valid transition
+
+## Code References
+
+- State machine logic: `src/moderation/moderation-state-machine.ts`
+- State machine tests: `src/moderation/moderation-state-machine.spec.ts`
+- AI moderation service: `src/moderation/ai-moderation.service.ts`
+- Moderation controller: `src/moderation/moderation.controller.ts`
+- Moderation log entity: `src/moderation/entities/moderation-log.entity.ts`

--- a/xconfess-backend/src/common/pagination/cursor.util.spec.ts
+++ b/xconfess-backend/src/common/pagination/cursor.util.spec.ts
@@ -1,0 +1,125 @@
+import { encodeCursor, decodeCursor, CursorObject } from './cursor.util';
+
+describe('cursor.util', () => {
+  describe('encodeCursor / decodeCursor roundtrip', () => {
+    it('roundtrips a simple cursor object', () => {
+      const cursor: CursorObject = { id: 'abc-123', created_at: '2026-01-15T10:00:00.000Z' };
+      const encoded = encodeCursor(cursor);
+      const decoded = decodeCursor<CursorObject>(encoded);
+
+      expect(decoded).toEqual(cursor);
+    });
+
+    it('roundtrips a numeric id', () => {
+      const cursor: CursorObject = { id: 42, created_at: '2026-06-01T00:00:00.000Z' };
+      const encoded = encodeCursor(cursor);
+      const decoded = decodeCursor<CursorObject>(encoded);
+
+      expect(decoded).toEqual(cursor);
+      expect(decoded!.id).toBe(42);
+    });
+
+    it('roundtrips cursor with extra fields', () => {
+      const cursor: CursorObject = { id: 'x', created_at: '2026-01-01', score: 99, tag: 'news' };
+      const encoded = encodeCursor(cursor);
+      const decoded = decodeCursor<CursorObject>(encoded);
+
+      expect(decoded).toEqual(cursor);
+    });
+
+    it('produces valid base64', () => {
+      const encoded = encodeCursor({ id: '1', created_at: '2026-01-01' });
+      // Should not throw when decoded from base64
+      const buf = Buffer.from(encoded, 'base64');
+      expect(buf.toString('utf8')).toContain('"id"');
+    });
+  });
+
+  describe('decodeCursor with invalid input', () => {
+    it('returns undefined for undefined', () => {
+      expect(decodeCursor(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      expect(decodeCursor('')).toBeUndefined();
+    });
+
+    it('returns undefined for invalid base64', () => {
+      expect(decodeCursor('!!!not-base64!!!')).toBeUndefined();
+    });
+
+    it('returns undefined for valid base64 but invalid JSON', () => {
+      const notJson = Buffer.from('this is not json').toString('base64');
+      expect(decodeCursor(notJson)).toBeUndefined();
+    });
+
+    it('returns undefined for totally random base64', () => {
+      const random = Buffer.from(Math.random().toString()).toString('base64');
+      // Might parse as valid JSON (e.g. a number), so just ensure it doesn't throw
+      const result = decodeCursor(random);
+      // Either undefined or a parsed value — no exception
+      expect(typeof result === 'undefined' || typeof result === 'object').toBe(true);
+    });
+  });
+
+  describe('stable ordering with duplicate timestamps', () => {
+    it('different ids produce different cursors', () => {
+      const c1 = encodeCursor({ id: 'item-1', created_at: '2026-01-01T00:00:00.000Z' });
+      const c2 = encodeCursor({ id: 'item-2', created_at: '2026-01-01T00:00:00.000Z' });
+
+      expect(c1).not.toBe(c2);
+    });
+
+    it('decoded cursors preserve id for tiebreaking', () => {
+      const cursor: CursorObject = { id: 'item-5', created_at: '2026-01-01T00:00:00.000Z' };
+      const decoded = decodeCursor<CursorObject>(encodeCursor(cursor));
+
+      expect(decoded!.id).toBe('item-5');
+    });
+  });
+
+  describe('next/previous cursor generation pattern', () => {
+    it('simulates cursor-based pagination through 3 pages', () => {
+      // Simulated dataset
+      const items = [
+        { id: '1', created_at: '2026-01-03' },
+        { id: '2', created_at: '2026-01-02' },
+        { id: '3', created_at: '2026-01-01' },
+      ];
+
+      const limit = 2;
+
+      // Page 1: no cursor
+      const page1 = items.slice(0, limit);
+      const nextCursor1 = encodeCursor({
+        id: page1[page1.length - 1].id,
+        created_at: page1[page1.length - 1].created_at,
+      });
+
+      expect(page1).toHaveLength(2);
+      expect(nextCursor1).toBeTruthy();
+
+      // Page 2: use cursor from page 1
+      const cursor1 = decodeCursor<{ id: string; created_at: string }>(nextCursor1)!;
+      const page2Items = items.filter(
+        (item) => item.created_at < cursor1.created_at ||
+          (item.created_at === cursor1.created_at && item.id < cursor1.id),
+      );
+      const page2 = page2Items.slice(0, limit);
+
+      expect(page2).toHaveLength(1);
+      expect(page2[0].id).toBe('3');
+
+      // Terminal page: no next cursor
+      const nextCursor2 =
+        page2.length < limit
+          ? null
+          : encodeCursor({
+              id: page2[page2.length - 1].id,
+              created_at: page2[page2.length - 1].created_at,
+            });
+
+      expect(nextCursor2).toBeNull();
+    });
+  });
+});

--- a/xconfess-backend/src/search-discovery/search-discovery.service.spec.ts
+++ b/xconfess-backend/src/search-discovery/search-discovery.service.spec.ts
@@ -235,4 +235,91 @@ describe('SearchDiscoveryService', () => {
       expect(searchHistoryRepo.findOne).not.toHaveBeenCalled();
     });
   });
+
+  // ── Issue #1811 — Search query bounds ─────────────────────────────────────
+
+  describe('search query bounds', () => {
+    function makeManager() {
+      return { query: jest.fn().mockResolvedValue([]) };
+    }
+
+    it('empty query returns results without recording history', async () => {
+      const mockManager = makeManager();
+      searchHistoryRepo.manager = mockManager as any;
+
+      await service.executeFullTextSearch(1, { q: '' } as any);
+      await service.executeFullTextSearch(1, { q: '   ' } as any);
+
+      // No history recording for blank queries
+      expect(searchHistoryRepo.findOne).not.toHaveBeenCalled();
+      // Query should still execute (returns all confessions)
+      expect(mockManager.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('very long query does not break the query builder', async () => {
+      const mockManager = makeManager();
+      searchHistoryRepo.manager = mockManager as any;
+      searchHistoryRepo.findOne.mockResolvedValue(null);
+      searchHistoryRepo.create.mockImplementation((x) => x as any);
+      searchHistoryRepo.save.mockResolvedValue({} as any);
+      searchHistoryRepo.count.mockResolvedValue(1);
+
+      const longQuery = 'a'.repeat(5000);
+      await service.executeFullTextSearch(1, { q: longQuery } as any);
+
+      const [query, params] = mockManager.query.mock.calls[0];
+      // Parameterized — no injection risk regardless of length
+      expect(query).toContain('$1');
+      expect(params).toContain(longQuery);
+    });
+
+    it('special characters in query do not break SQL', async () => {
+      const mockManager = makeManager();
+      searchHistoryRepo.manager = mockManager as any;
+      searchHistoryRepo.findOne.mockResolvedValue(null);
+      searchHistoryRepo.create.mockImplementation((x) => x as any);
+      searchHistoryRepo.save.mockResolvedValue({} as any);
+      searchHistoryRepo.count.mockResolvedValue(1);
+
+      const maliciousQuery = "'; DROP TABLE confessions; --";
+      await service.executeFullTextSearch(1, { q: maliciousQuery } as any);
+
+      const [query, params] = mockManager.query.mock.calls[0];
+      // Uses parameterized query — special chars are safe
+      expect(query).toContain('$1');
+      expect(params).toContain(maliciousQuery);
+    });
+
+    it('unicode and emoji queries are handled', async () => {
+      const mockManager = makeManager();
+      searchHistoryRepo.manager = mockManager as any;
+      searchHistoryRepo.findOne.mockResolvedValue(null);
+      searchHistoryRepo.create.mockImplementation((x) => x as any);
+      searchHistoryRepo.save.mockResolvedValue({} as any);
+      searchHistoryRepo.count.mockResolvedValue(1);
+
+      await service.executeFullTextSearch(1, { q: '日本語テスト 🎉' } as any);
+
+      expect(mockManager.query).toHaveBeenCalled();
+    });
+
+    it('limit=0 clamps to minimum of 1', async () => {
+      const mockManager = makeManager();
+      searchHistoryRepo.manager = mockManager as any;
+
+      await service.executeFullTextSearch(1, { q: 'test', limit: 0 } as any);
+      const params = mockManager.query.mock.calls[0][1];
+      expect(params).toContain(1);
+    });
+
+    it('negative page-like values are ignored (service uses limit only)', async () => {
+      const mockManager = makeManager();
+      searchHistoryRepo.manager = mockManager as any;
+
+      await service.executeFullTextSearch(1, { q: 'test', limit: -10 } as any);
+      const params = mockManager.query.mock.calls[0][1];
+      // Clamped to 1
+      expect(params).toContain(1);
+    });
+  });
 });


### PR DESCRIPTION
Closes #1810
Closes #1811
Closes #1812
Closes #1813

## What changed
- Added moderation state machine admin reference doc with all allowed transitions and side effects
- Added data export retention and expiry reference doc covering TTL, token rules, and redownload behaviour
- Added search query bounds tests: empty, long, special characters, unicode, and limit clamping
- Added cursor.util encode/decode roundtrip, invalid cursor, and pagination contract tests

## Why
- Moderation transitions had no admin-facing reference
- Search endpoints lacked edge case coverage for adversarial inputs
- Cursor pagination utilities had no dedicated regression tests

## How to test
- `npx jest search-discovery.service.spec.ts` for search bounds tests
- `npx jest cursor.util.spec.ts` for cursor pagination tests
- Docs are reference-only (no runtime tests needed)