### PR TITLE
feat(frontend): Add websocket reconnect behavior tests in frontend

### DIFF
--- a/xconfess-frontend/app/lib/hooks/__tests__/useWebSocket.test.ts
+++ b/xconfess-frontend/app/lib/hooks/__tests__/useWebSocket.test.ts
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { getReconnectDelay } from '../useWebSocket';
+import { renderHook, act } from '@testing-library/react';
+import { getReconnectDelay, useWebSocket } from '../useWebSocket';
 
 describe('getReconnectDelay', () => {
   it('returns base delay on attempt 0', () => {
@@ -39,9 +40,356 @@ describe('getReconnectDelay', () => {
 });
 
 describe('WebSocket reconnection constants', () => {
-  it('default max attempts is 10', async () => {
-    const { useWebSocket } = await import('../useWebSocket');
-    // Verify that the export compiles; the runtime constant is tested via integration
+  it('default max attempts is 10', () => {
     expect(typeof useWebSocket).toBe('function');
+  });
+});
+
+class MockWebSocket {
+  url: string;
+  readyState: number = 0; // CONNECTING
+  onopen: (() => void) | null = null;
+  onclose: ((event: any) => void) | null = null;
+  onerror: ((error: any) => void) | null = null;
+  onmessage: ((event: any) => void) | null = null;
+  send = jest.fn();
+  close = jest.fn();
+
+  static instances: MockWebSocket[] = [];
+
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  CONNECTING = 0;
+  OPEN = 1;
+  CLOSING = 2;
+  CLOSED = 3;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  triggerOpen() {
+    this.readyState = 1; // OPEN
+    if (this.onopen) {
+      act(() => {
+        this.onopen!();
+      });
+    }
+  }
+
+  triggerClose(code = 1000, reason = '', wasClean = true) {
+    this.readyState = 3; // CLOSED
+    if (this.onclose) {
+      act(() => {
+        this.onclose!({ code, reason, wasClean } as CloseEvent);
+      });
+    }
+  }
+
+  triggerError(error: any = new Event('error')) {
+    if (this.onerror) {
+      act(() => {
+        this.onerror!(error);
+      });
+    }
+  }
+
+  triggerMessage(data: any) {
+    if (this.onmessage) {
+      const dataStr = typeof data === 'string' ? data : JSON.stringify(data);
+      act(() => {
+        this.onmessage!({ data: dataStr } as MessageEvent);
+      });
+    }
+  }
+}
+
+describe('useWebSocket hook behavior', () => {
+  let originalWebSocket: any;
+
+  beforeAll(() => {
+    originalWebSocket = global.WebSocket;
+    global.WebSocket = MockWebSocket as any;
+  });
+
+  afterAll(() => {
+    global.WebSocket = originalWebSocket;
+  });
+
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('1. Initial connection lifecycle', () => {
+    const onOpen = jest.fn();
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        onOpen,
+      })
+    );
+
+    // Initial check
+    expect(result.current.state).toBe('connecting');
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const mockWs = MockWebSocket.instances[0];
+    expect(mockWs.url).toBe('ws://example.com');
+
+    // Transition to connected
+    mockWs.triggerOpen();
+    expect(result.current.state).toBe('connected');
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('2. Disconnect behavior (unexpected close)', () => {
+    const onClose = jest.fn();
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        onClose,
+        reconnect: true,
+        reconnectBaseDelay: 1000,
+      })
+    );
+
+    const mockWs = MockWebSocket.instances[0];
+    mockWs.triggerOpen();
+
+    // Trigger unexpected close
+    mockWs.triggerClose(1006, 'Abnormal Closure');
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toBe('reconnecting');
+    expect(result.current.reconnectAttempts).toBe(1);
+  });
+
+  it('3. Reconnect behavior (successive attempts and successful reconnect)', () => {
+    const onOpen = jest.fn();
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        onOpen,
+        reconnect: true,
+        reconnectBaseDelay: 1000,
+        reconnectMaxDelay: 5000,
+      })
+    );
+
+    const ws1 = MockWebSocket.instances[0];
+    ws1.triggerOpen();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    // Disconnect
+    ws1.triggerClose(1006);
+    expect(result.current.state).toBe('reconnecting');
+
+    // Advance timer for 1st reconnect (delay = 1000ms)
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Verify 2nd WebSocket was created
+    expect(MockWebSocket.instances).toHaveLength(2);
+    const ws2 = MockWebSocket.instances[1];
+    expect(result.current.state).toBe('connecting');
+
+    // Open second socket
+    ws2.triggerOpen();
+    expect(result.current.state).toBe('connected');
+    expect(result.current.reconnectAttempts).toBe(0);
+    expect(onOpen).toHaveBeenCalledTimes(2);
+  });
+
+  it('4. Duplicate listener / stale socket cleanup', () => {
+    const onMessage = jest.fn();
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        onMessage,
+        reconnect: true,
+        reconnectBaseDelay: 1000,
+      })
+    );
+
+    const ws1 = MockWebSocket.instances[0];
+    ws1.triggerOpen();
+
+    // Trigger close on ws1, scheduling reconnect
+    ws1.triggerClose(1006);
+
+    // Advance timers to trigger reconnect
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const ws2 = MockWebSocket.instances[1];
+    ws2.triggerOpen();
+
+    // Send message on active socket ws2
+    ws2.triggerMessage({ data: 'hello' });
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenLastCalledWith({ data: 'hello' }, undefined);
+
+    // Send message on stale socket ws1 (should be ignored)
+    ws1.triggerMessage({ data: 'stale' });
+    expect(onMessage).toHaveBeenCalledTimes(1); // Still 1
+  });
+
+  it('5. Manual disconnect behavior', () => {
+    const onClose = jest.fn();
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        onClose,
+        reconnect: true,
+      })
+    );
+
+    const ws1 = MockWebSocket.instances[0];
+    ws1.triggerOpen();
+
+    // Call disconnect
+    act(() => {
+      result.current.disconnect();
+    });
+
+    expect(ws1.close).toHaveBeenCalledTimes(1);
+    // Explicit close triggered
+    ws1.triggerClose(1000);
+
+    expect(result.current.state).toBe('disconnected');
+    // Ensure no reconnect timer is scheduled
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(1); // No new instance
+  });
+
+  it('6. Reconnect disabled behavior', () => {
+    const onClose = jest.fn();
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        onClose,
+        reconnect: false,
+      })
+    );
+
+    const ws1 = MockWebSocket.instances[0];
+    ws1.triggerOpen();
+    ws1.triggerClose(1006);
+
+    expect(result.current.state).toBe('disconnected');
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it('7. Maximum reconnect attempts configuration', () => {
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        reconnect: true,
+        maxReconnectAttempts: 2,
+        reconnectBaseDelay: 1000,
+      })
+    );
+
+    const ws1 = MockWebSocket.instances[0];
+    ws1.triggerOpen();
+
+    // 1st close
+    ws1.triggerClose(1006);
+    expect(result.current.state).toBe('reconnecting');
+
+    // 1st reconnect
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+    const ws2 = MockWebSocket.instances[1];
+    // Fail 2nd connection
+    ws2.triggerClose(1006);
+
+    // 2nd reconnect
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(3);
+    const ws3 = MockWebSocket.instances[2];
+    // Fail 3rd connection (which reached attempt 2 limit)
+    ws3.triggerClose(1006);
+
+    // Should stop reconnecting now
+    expect(result.current.state).toBe('disconnected');
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(3); // No 4th instance
+  });
+
+  it('8. Authentication failure handling', () => {
+    const onError = jest.fn();
+    const onClose = jest.fn();
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        onError,
+        onClose,
+        reconnect: true,
+        reconnectBaseDelay: 1000,
+      })
+    );
+
+    const ws1 = MockWebSocket.instances[0];
+    
+    // Simulate auth error (unauthorized close / connection error)
+    ws1.triggerError(new Event('error'));
+    ws1.triggerClose(4401, 'Unauthorized');
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    
+    // According to current implementation design, it is surfaced and schedules normal reconnect
+    expect(result.current.state).toBe('reconnecting');
+  });
+
+  it('9. Cleanup/unmount prevents state updates and timers', () => {
+    const { result, unmount } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://example.com',
+        reconnect: true,
+        reconnectBaseDelay: 1000,
+      })
+    );
+
+    const ws1 = MockWebSocket.instances[0];
+    ws1.triggerOpen();
+
+    // Trigger close to schedule reconnect
+    ws1.triggerClose(1006);
+    expect(result.current.state).toBe('reconnecting');
+
+    // Unmount hook
+    unmount();
+
+    // Advance timers to trigger the reconnect callback
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Verify no new WebSocket is created after unmount
+    expect(MockWebSocket.instances).toHaveLength(1);
   });
 });

--- a/xconfess-frontend/app/lib/hooks/useWebSocket.ts
+++ b/xconfess-frontend/app/lib/hooks/useWebSocket.ts
@@ -39,6 +39,8 @@ export function useWebSocket(options: WebSocketOptions) {
   const wsRef = useRef<WebSocket | null>(null);
   const attemptRef = useRef(0);
   const lastEventIdRef = useRef<string | undefined>(initialLastEventId);
+  const timeoutRef = useRef<NodeJS.Timeout | number | null>(null);
+  const isMountedRef = useRef(true);
 
   const buildUrl = useCallback(() => {
     if (!lastEventIdRef.current) return url;
@@ -50,10 +52,16 @@ export function useWebSocket(options: WebSocketOptions) {
   const connect = useCallback(() => {
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
 
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current as NodeJS.Timeout);
+      timeoutRef.current = null;
+    }
+
     setState('connecting');
     const ws = new WebSocket(buildUrl());
 
     ws.onopen = () => {
+      if (!isMountedRef.current || wsRef.current !== ws) return;
       attemptRef.current = 0;
       setReconnectAttempts(0);
       setState('connected');
@@ -61,6 +69,7 @@ export function useWebSocket(options: WebSocketOptions) {
     };
 
     ws.onmessage = (event) => {
+      if (!isMountedRef.current || wsRef.current !== ws) return;
       try {
         const data = JSON.parse(event.data as string);
         // Track lastEventId if the server sends it
@@ -74,6 +83,7 @@ export function useWebSocket(options: WebSocketOptions) {
     };
 
     ws.onclose = () => {
+      if (!isMountedRef.current || wsRef.current !== ws) return;
       setState('disconnected');
       onClose?.();
 
@@ -85,11 +95,12 @@ export function useWebSocket(options: WebSocketOptions) {
           reconnectMaxDelay,
         );
         setState('reconnecting');
-        setTimeout(connect, delay);
+        timeoutRef.current = setTimeout(connect, delay);
       }
     };
 
     ws.onerror = (error) => {
+      if (!isMountedRef.current || wsRef.current !== ws) return;
       onError?.(error);
     };
 
@@ -98,6 +109,10 @@ export function useWebSocket(options: WebSocketOptions) {
 
   const disconnect = useCallback(() => {
     attemptRef.current = maxReconnectAttempts + 1;
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current as NodeJS.Timeout);
+      timeoutRef.current = null;
+    }
     wsRef.current?.close();
     setState('disconnected');
   }, [maxReconnectAttempts]);
@@ -109,12 +124,22 @@ export function useWebSocket(options: WebSocketOptions) {
   }, []);
 
   useEffect(() => {
+    isMountedRef.current = true;
     connect();
     return () => {
+      isMountedRef.current = false;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current as NodeJS.Timeout);
+        timeoutRef.current = null;
+      }
       wsRef.current?.close();
     };
   }, [connect]);
 
+  // Note: Authentication failures on raw WebSockets are currently indistinguishable
+  // from ordinary network failures. They will trigger standard onError/onClose
+  // events and attempt to reconnect unless maxReconnectAttempts is reached or
+  // reconnect is disabled.
   return { state, reconnectAttempts, connect, disconnect, send };
 }
 


### PR DESCRIPTION
Closes #1818 

### Primary task

Extend the existing `useWebSocket.test.ts` with behavior-level tests.

Focus on these scenarios:

#### 1. Initial connection

Verify that mounting the hook:

* creates a WebSocket using the supplied URL
* enters the expected connecting state
* transitions to `connected` when the socket opens
* invokes `onOpen`

#### 2. Disconnect behavior

Simulate the WebSocket closing unexpectedly.

Verify that:

* `onClose` is called
* connection state reflects the disconnect/reconnect lifecycle
* reconnect attempts are incremented
* a reconnect is scheduled when `reconnect: true`

Use fake timers so the tests do not actually wait for the configured reconnect delay.

#### 3. Reconnect behavior

Simulate:

1. initial connection
2. socket closes
3. reconnect timer fires
4. a new WebSocket is created
5. the new WebSocket opens

Verify that:

* a second WebSocket is created
* the hook returns to `connected`
* reconnect attempts reset after a successful connection
* `onOpen` is called for the successful reconnect

Test the configured delay behavior without introducing real sleeps.

#### 4. Duplicate listener / duplicate connection cleanup

This is important for the issue.

Verify that reconnecting does NOT cause duplicate event handlers or duplicate callback execution.

For example:

* establish the initial socket
* force a disconnect
* trigger reconnect
* open the new socket
* emit a message through the active socket
* verify `onMessage` is called exactly once

Also verify that stale/old sockets cannot cause duplicate callback behavior after a reconnect.

If the current implementation makes this difficult or exposes a genuine listener/connection lifecycle bug, identify the minimal implementation change required to make the behavior correct. Do not refactor unrelated code.

#### 5. Manual disconnect

Test `disconnect()` separately.

Verify that:

* the active WebSocket is closed
* state becomes `disconnected`
* automatic reconnect is not scheduled after a deliberate disconnect

Do not accidentally count the expected `close` event from the manual disconnect as an unexpected reconnect trigger.

#### 6. Reconnect disabled

Test:

```ts
reconnect: false
```

After an unexpected socket close:

* `onClose` should still be called
* the state should become disconnected
* no new WebSocket should be created
* no reconnect timer should be scheduled

#### 7. Maximum reconnect attempts

Use a very small value such as:

```ts
maxReconnectAttempts: 2
```

Simulate repeated connection failures.

Verify that:

* attempts increment correctly
* reconnect stops once the configured maximum is reached
* no additional WebSocket is created after the maximum attempt count

#### 8. Authentication failure handling

Inspect the existing Xconfess WebSocket authentication implementation before deciding how this should be represented.

Do NOT invent a new authentication error protocol.

Determine how an authentication failure is surfaced by the current WebSocket implementation/backend.

Then add a test that verifies the frontend handles that existing failure behavior correctly.

The expected behavior should be one of:

* reconnect attempts stop for an authentication failure, OR
* the authentication failure is surfaced through the existing error/callback/state mechanism

Choose the behavior that matches the current implementation/design rather than changing application semantics solely to make the test pass.

If authentication failures are currently indistinguishable from ordinary network failures, document that finding in the implementation and make only the smallest justified change needed by the issue.

#### 9. Cleanup/unmount

Verify that unmounting the hook:

* closes the active WebSocket if appropriate
* does not leave reconnect timers running
* does not create a new connection after unmount
* does not produce state updates from stale sockets

This is particularly important because the current reconnect implementation schedules `setTimeout(connect, delay)` from `onclose`.

Use fake timers and explicitly clean them up.

### Testing requirements

Use the repository's existing test stack and conventions.

Prefer:

* Jest
* React hook testing utilities already present in the repository
* native `WebSocket` mocks implemented inside the test file or existing test utilities

Do not install a new WebSocket mocking library unless one is already used elsewhere in the repository.

Use fake timers for reconnect delays.

Make every test deterministic.

Avoid real network connections.

### Important edge cases

Test that:

* only the current socket drives the current connection lifecycle
* reconnect attempts reset after successful reconnect
* manual disconnect does not trigger automatic reconnect
* reconnect disabled means no retry
* maximum attempts are respected
* callbacks are not invoked more than once for one event
* stale sockets cannot cause duplicate message handling
* timers are cleaned up between tests
* test state does not leak between cases

### Scope control

Keep the PR focused on issue #1818.

Do NOT:

* rewrite `useWebSocket`
* introduce a new WebSocket abstraction
* change unrelated frontend components
* modify backend behavior unless absolutely required to test existing auth semantics
* change reconnect timing semantics without a clear test/bug justification
* update unrelated documentation
* add unnecessary dependencies

If the current implementation already satisfies the desired behavior, add tests only.

If a test exposes a real bug, make the smallest production-code change necessary and add a regression test proving the fix.

### Validation

After implementation, run the focused frontend WebSocket test first.

Then run the frontend test suite and frontend lint/build checks according to the repository's existing scripts.

At minimum, determine the correct commands from `xconfess-frontend/package.json` and run the relevant checks.

Before finishing:

1. Review `git diff`.
2. Ensure only issue-related files changed.
3. Ensure no `.env`, secrets, generated files, or unrelated formatting changes are included.
4. Report exactly which tests/checks were run and their results.

### Acceptance criteria

The implementation must demonstrate:

* disconnect triggers the expected reconnect state/lifecycle
* reconnect creates a new connection and returns to connected state
* duplicate event handlers/listeners are not registered after reconnect
* stale sockets cannot duplicate message/callback handling
* authentication failure follows the existing designed behavior
* reconnect attempts stop at the configured maximum
* manual disconnect does not trigger another reconnect
* timers and socket resources are cleaned up correctly

Do not stop after merely writing the tests. Run them and fix any legitimate failures caused by the implementation.
