### PR TITLE
fix: deterministic conflict handling for offline draft sync (#1823)

### DIFF
--- a/xconfess-backend/src/confession-draft/confession-draft.controller.integration.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.controller.integration.spec.ts
@@ -157,4 +157,96 @@ describe('ConfessionDraftController (integration)', () => {
       }),
     );
   });
+
+  describe('versioned updates (offline sync conflict handling)', () => {
+    const auth = (req: request.Test) =>
+      req.set('Authorization', 'Bearer test-token');
+
+    const seedDraft = async () => {
+      const res = await auth(
+        request(app.getHttpServer()).post('/api/confessions/drafts'),
+      )
+        .send({ content: 'base content' })
+        .expect(201);
+      return res.body as { id: string; version: number };
+    };
+
+    it('applies a version-matched update and bumps the version', async () => {
+      const draft = await seedDraft();
+
+      const res = await auth(
+        request(app.getHttpServer()).patch(
+          `/api/confessions/drafts/${draft.id}`,
+        ),
+      )
+        .send({ content: 'synced edit', version: draft.version })
+        .expect(200);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          id: draft.id,
+          content: 'synced edit',
+          version: draft.version + 1,
+        }),
+      );
+    });
+
+    it('rejects a stale update with a remote_updated conflict and returns the current draft', async () => {
+      const draft = await seedDraft();
+
+      await auth(
+        request(app.getHttpServer()).patch(
+          `/api/confessions/drafts/${draft.id}`,
+        ),
+      )
+        .send({ content: 'first writer wins', version: draft.version })
+        .expect(200);
+
+      const res = await auth(
+        request(app.getHttpServer()).patch(
+          `/api/confessions/drafts/${draft.id}`,
+        ),
+      )
+        .send({ content: 'stale offline edit', version: draft.version })
+        .expect(409);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          reason: 'remote_updated',
+          currentVersion: draft.version + 1,
+          currentDraft: expect.objectContaining({
+            id: draft.id,
+            content: 'first writer wins',
+          }),
+        }),
+      );
+    });
+
+    it('reports a remote_deleted conflict when a versioned update targets a missing draft', async () => {
+      const res = await auth(
+        request(app.getHttpServer()).patch(
+          '/api/confessions/drafts/00000000-0000-0000-0000-000000000000',
+        ),
+      )
+        .send({ content: 'offline edit for a deleted draft', version: 4 })
+        .expect(409);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          reason: 'remote_deleted',
+          draftId: '00000000-0000-0000-0000-000000000000',
+        }),
+      );
+    });
+
+    it('still 404s an unversioned update to a missing draft', async () => {
+      await auth(
+        request(app.getHttpServer()).patch(
+          '/api/confessions/drafts/00000000-0000-0000-0000-000000000000',
+        ),
+      )
+        .send({ content: 'no version supplied' })
+        .expect(404);
+    });
+  });
 });

--- a/xconfess-backend/src/confession-draft/confession-draft.service.spec.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
@@ -127,6 +128,58 @@ describe('ConfessionDraftService', () => {
           version: 1,
         }),
       ).rejects.toThrow('Conflict detected');
+    });
+
+    it('version-mismatch conflict carries reason, currentVersion and remote content', async () => {
+      const draft = {
+        id: 'draft1',
+        userId: 1,
+        content: encryptConfession('server content', AES_KEY),
+        version: 2,
+        revisions: [],
+        status: ConfessionDraftStatus.DRAFT,
+      } as any;
+
+      repo.findOne.mockResolvedValue(draft);
+
+      expect.assertions(4);
+      try {
+        await service.updateDraft(1, 'draft1', {
+          content: 'stale client content',
+          version: 1,
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(ConflictException);
+        const body = (err as ConflictException).getResponse() as any;
+        expect(body.reason).toBe('remote_updated');
+        expect(body.currentVersion).toBe(2);
+        expect(body.currentDraft.content).toBe('server content');
+      }
+    });
+
+    it('throws a remote_deleted conflict when a versioned update targets a missing draft', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      expect.assertions(3);
+      try {
+        await service.updateDraft(1, 'gone', {
+          content: 'offline edit',
+          version: 3,
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(ConflictException);
+        const body = (err as ConflictException).getResponse() as any;
+        expect(body.reason).toBe('remote_deleted');
+        expect(body.draftId).toBe('gone');
+      }
+    });
+
+    it('still throws a plain NotFoundException for an unversioned update to a missing draft', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateDraft(1, 'gone', { content: 'no version' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it('allows autosave updates without a version', async () => {

--- a/xconfess-backend/src/confession-draft/confession-draft.service.ts
+++ b/xconfess-backend/src/confession-draft/confession-draft.service.ts
@@ -127,7 +127,21 @@ export class ConfessionDraftService {
 
   async updateDraft(userId: number, id: string, dto: UpdateConfessionDraftDto) {
     const draft = await this.draftRepo.findOne({ where: { id } });
-    if (!draft) throw new NotFoundException('Draft not found');
+    if (!draft) {
+      // A versioned update targets a specific remote revision the client
+      // previously synced. If that draft no longer exists, this is an
+      // offline-sync conflict (deleted elsewhere while the client was
+      // offline), not a generic "unknown id" 404 — the caller still holds
+      // recoverable local content and must be told the remote copy is gone.
+      if (dto.version !== undefined) {
+        throw new ConflictException({
+          reason: 'remote_deleted',
+          message: 'The draft was deleted remotely while you were offline.',
+          draftId: id,
+        });
+      }
+      throw new NotFoundException('Draft not found');
+    }
     if (draft.userId !== userId) throw new ForbiddenException();
 
     if (draft.status === ConfessionDraftStatus.POSTED) {
@@ -136,8 +150,10 @@ export class ConfessionDraftService {
 
     if (dto.version !== undefined && draft.version !== dto.version) {
       throw new ConflictException({
+        reason: 'remote_updated',
         message:
           'Conflict detected: draft has been modified by another session',
+        currentVersion: draft.version,
         currentDraft: this.sanitizeForResponse(draft),
       });
     }

--- a/xconfess-frontend/app/components/confession/DraftManager.tsx
+++ b/xconfess-frontend/app/components/confession/DraftManager.tsx
@@ -31,6 +31,8 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
     isLoading,
     error: draftsError,
     isRemote,
+    conflicts,
+    resolveConflict,
     saveDraft,
     updateDraft,
     deleteDraft,
@@ -42,12 +44,15 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
   const [currentDraftId, setCurrentDraftId] = useState<string | null>(null);
   const [clearDraftsOpen, setClearDraftsOpen] = useState(false);
   const [saveStatus, setSaveStatus] = useState<
-    "saved" | "saving" | "unsaved" | "failed"
+    "saved" | "saving" | "unsaved" | "failed" | "conflict"
   >("saved");
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastSavedRef = useRef<string>("");
   const toast = useGlobalToast();
+
+  const activeConflict =
+    conflicts.find((c) => c.draftId === currentDraftId) ?? null;
 
   const didAttemptRestoreRef = useRef(false);
   useEffect(() => {
@@ -75,7 +80,26 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [drafts]);
 
+  // Surface a detected conflict on the inline status line.
+  useEffect(() => {
+    if (activeConflict) {
+      setSaveStatus("conflict");
+      setSaveMessage(null);
+    } else if (saveStatus === "conflict") {
+      setSaveStatus("saved");
+      setSaveMessage(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeConflict]);
+
   const persistDraft = async () => {
+    // An unresolved offline-sync conflict is holding this draft. Stop
+    // auto-saving so we never re-send (and never blindly overwrite the
+    // newer remote copy) until the user resolves it.
+    if (currentDraftId && conflicts.some((c) => c.draftId === currentDraftId)) {
+      return false;
+    }
+
     const currentContent = JSON.stringify(currentDraft);
     if (currentContent === lastSavedRef.current) {
       return true;
@@ -186,6 +210,36 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
     toast.success("All drafts cleared.");
   };
 
+  const handleResolveConflict = async (
+    resolution: "keep-local" | "keep-remote" | "discard-local",
+  ) => {
+    if (!activeConflict) return;
+    const { draftId, reason, remote } = activeConflict;
+    const ok = await resolveConflict(draftId, resolution);
+    if (!ok) return;
+
+    if (resolution === "keep-remote" && reason === "remote_updated" && remote) {
+      onLoadDraft(remote);
+      lastSavedRef.current = JSON.stringify({
+        title: remote.title,
+        body: remote.body,
+        gender: remote.gender,
+      });
+    }
+
+    if (resolution === "keep-remote" && reason === "remote_deleted") {
+      setCurrentDraftId(null);
+    }
+
+    if (resolution === "keep-local") {
+      // The retained local content is now the synced baseline.
+      lastSavedRef.current = JSON.stringify(currentDraft);
+    }
+
+    setSaveStatus("saved");
+    setSaveMessage(resolution === "discard-local" ? null : "Draft saved.");
+  };
+
   return (
     <>
       <ConfirmDialog
@@ -233,7 +287,57 @@ export const DraftManager: React.FC<DraftManagerProps> = ({
               </button>
             </span>
           )}
+          {saveStatus === "conflict" && activeConflict && (
+            <span className="text-amber-300">
+              {activeConflict.reason === "remote_deleted"
+                ? "This draft was deleted remotely while you were offline."
+                : "This draft was changed elsewhere while you were offline."}
+            </span>
+          )}
         </div>
+
+        {activeConflict && (
+          <div
+            role="alert"
+            className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100"
+          >
+            <p className="font-medium">
+              {activeConflict.reason === "remote_deleted"
+                ? "This draft was deleted remotely while you were offline."
+                : "This draft was changed elsewhere while you were offline."}
+            </p>
+            <p className="mt-1 text-amber-200/80">
+              Your local version is kept in the editor. Choose how to resolve:
+            </p>
+            <div className="mt-2 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => void handleResolveConflict("keep-local")}
+                className="underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 rounded"
+              >
+                {activeConflict.reason === "remote_deleted"
+                  ? "Save mine as a new draft"
+                  : "Keep my version"}
+              </button>
+              {activeConflict.reason === "remote_updated" && (
+                <button
+                  type="button"
+                  onClick={() => void handleResolveConflict("keep-remote")}
+                  className="underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 rounded"
+                >
+                  Use the newer version
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => void handleResolveConflict("discard-local")}
+                className="underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 rounded"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
       <Modal

--- a/xconfess-frontend/app/lib/api/drafts.ts
+++ b/xconfess-frontend/app/lib/api/drafts.ts
@@ -1,4 +1,10 @@
-import { Draft, DraftDTO, DraftInput, DraftUpdate } from "@/app/lib/types/draft";
+import {
+  Draft,
+  DraftConflictReason,
+  DraftDTO,
+  DraftInput,
+  DraftUpdate,
+} from "@/app/lib/types/draft";
 
 /**
  * REST contract for Drafts with revision/version safety & conflict handling:
@@ -10,7 +16,15 @@ import { Draft, DraftDTO, DraftInput, DraftUpdate } from "@/app/lib/types/draft"
 
 export interface DraftConflictErrorData {
   message: string;
-  currentDraft: DraftDTO;
+  /**
+   * Machine-readable cause. Absent on older backends — callers should
+   * default to "remote_updated" when a 409 carries no reason.
+   */
+  reason?: DraftConflictReason;
+  /** Present for "remote_updated"; absent when the remote draft was deleted. */
+  currentDraft?: DraftDTO;
+  currentVersion?: number;
+  draftId?: string;
 }
 
 export class DraftApiError extends Error {
@@ -24,7 +38,7 @@ export class DraftApiError extends Error {
   }
 }
 
-function toDraft(dto: DraftDTO): Draft {
+export function toDraft(dto: DraftDTO): Draft {
   const body = dto.content ?? "";
   const savedAt = dto.updatedAt ?? dto.savedAt ?? dto.createdAt ?? new Date().toISOString();
   return {

--- a/xconfess-frontend/app/lib/hooks/__tests__/useDrafts.conflict.test.tsx
+++ b/xconfess-frontend/app/lib/hooks/__tests__/useDrafts.conflict.test.tsx
@@ -1,0 +1,214 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useDrafts } from "@/app/lib/hooks/useDrafts";
+import {
+  fetchDrafts,
+  patchDraft,
+  createDraft,
+} from "@/app/lib/api/drafts";
+
+jest.mock("@/app/lib/hooks/useAuth", () => ({
+  useAuth: () => ({ token: "test-token", isAuthenticated: true }),
+}));
+
+const mockEnqueueWrite = jest.fn().mockResolvedValue(undefined);
+jest.mock("@/app/lib/utils/syncQueue", () => ({
+  enqueueWrite: (...args: unknown[]) => mockEnqueueWrite(...args),
+}));
+
+jest.mock("@/app/lib/api/drafts", () => {
+  const actual = jest.requireActual("@/app/lib/api/drafts");
+  return {
+    __esModule: true,
+    ...actual,
+    fetchDrafts: jest.fn(),
+    patchDraft: jest.fn(),
+    createDraft: jest.fn(),
+    deleteDraftRemote: jest.fn(),
+    clearDraftsRemote: jest.fn(),
+  };
+});
+
+const { DraftApiError } = jest.requireActual("@/app/lib/api/drafts");
+
+const mockFetchDrafts = fetchDrafts as jest.MockedFunction<typeof fetchDrafts>;
+const mockPatchDraft = patchDraft as jest.MockedFunction<typeof patchDraft>;
+const mockCreateDraft = createDraft as jest.MockedFunction<typeof createDraft>;
+
+const LOCAL_DRAFT = {
+  id: "d1",
+  body: "local text",
+  version: 5,
+  savedAt: 1000,
+  characterCount: 10,
+};
+
+async function mountWithOneDraft() {
+  const view = renderHook(() => useDrafts());
+  await waitFor(() => expect(view.result.current.isLoading).toBe(false));
+  await waitFor(() => expect(view.result.current.drafts).toHaveLength(1));
+  return view;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetchDrafts.mockResolvedValue([{ ...LOCAL_DRAFT }]);
+});
+
+describe("useDrafts – offline sync conflict handling", () => {
+  it("sends the last-observed version and applies a matched update", async () => {
+    mockPatchDraft.mockResolvedValue({
+      ...LOCAL_DRAFT,
+      body: "edited",
+      version: 6,
+      savedAt: 2000,
+    });
+
+    const { result } = await mountWithOneDraft();
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.updateDraft("d1", { body: "edited" });
+    });
+
+    expect(ok).toBe(true);
+    expect(mockPatchDraft).toHaveBeenCalledWith(
+      "test-token",
+      "d1",
+      expect.objectContaining({ body: "edited", version: 5 }),
+    );
+    expect(result.current.drafts[0].body).toBe("edited");
+    expect(result.current.conflicts).toHaveLength(0);
+  });
+
+  it("represents a remote_updated 409 as a conflict without overwriting local content or retrying", async () => {
+    mockPatchDraft.mockRejectedValue(
+      new DraftApiError("changed elsewhere", 409, {
+        reason: "remote_updated",
+        currentVersion: 7,
+        currentDraft: { id: "d1", content: "their text", version: 7 },
+      }),
+    );
+
+    const { result } = await mountWithOneDraft();
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.updateDraft("d1", { body: "my offline text" });
+    });
+
+    expect(ok).toBe(false);
+    expect(mockPatchDraft).toHaveBeenCalledTimes(1); // no automatic retry
+    expect(result.current.drafts[0].body).toBe("local text"); // not overwritten
+
+    expect(result.current.conflicts).toHaveLength(1);
+    const conflict = result.current.conflicts[0];
+    expect(conflict.reason).toBe("remote_updated");
+    expect(conflict.local.body).toBe("my offline text"); // recoverable
+    expect(conflict.remote?.body).toBe("their text");
+    expect(result.current.error).toMatch(/changed elsewhere while you were offline/i);
+  });
+
+  it("represents a remote_deleted 409 as a conflict and keeps the local draft", async () => {
+    mockPatchDraft.mockRejectedValue(
+      new DraftApiError("deleted remotely", 409, {
+        reason: "remote_deleted",
+        draftId: "d1",
+      }),
+    );
+
+    const { result } = await mountWithOneDraft();
+
+    await act(async () => {
+      await result.current.updateDraft("d1", { body: "my offline text" });
+    });
+
+    expect(result.current.conflicts).toHaveLength(1);
+    expect(result.current.conflicts[0].reason).toBe("remote_deleted");
+    expect(result.current.conflicts[0].remote).toBeUndefined();
+    expect(result.current.conflicts[0].local.body).toBe("my offline text");
+    expect(result.current.drafts.find((d) => d.id === "d1")?.body).toBe(
+      "local text",
+    );
+  });
+
+  it("resolveConflict('keep-remote') adopts the server copy and clears the conflict", async () => {
+    mockPatchDraft.mockRejectedValue(
+      new DraftApiError("changed elsewhere", 409, {
+        reason: "remote_updated",
+        currentVersion: 7,
+        currentDraft: { id: "d1", content: "their text", version: 7 },
+      }),
+    );
+
+    const { result } = await mountWithOneDraft();
+    await act(async () => {
+      await result.current.updateDraft("d1", { body: "my offline text" });
+    });
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.resolveConflict("d1", "keep-remote");
+    });
+
+    expect(ok).toBe(true);
+    expect(result.current.conflicts).toHaveLength(0);
+    expect(result.current.drafts[0].body).toBe("their text");
+    expect(result.current.drafts[0].version).toBe(7);
+  });
+
+  it("resolveConflict('keep-local') re-creates a remotely deleted draft from the local content", async () => {
+    mockPatchDraft.mockRejectedValue(
+      new DraftApiError("deleted remotely", 409, {
+        reason: "remote_deleted",
+        draftId: "d1",
+      }),
+    );
+    mockCreateDraft.mockResolvedValue({
+      id: "d2",
+      body: "my offline text",
+      version: 1,
+      savedAt: 3000,
+      characterCount: 15,
+    });
+
+    const { result } = await mountWithOneDraft();
+    await act(async () => {
+      await result.current.updateDraft("d1", { body: "my offline text" });
+    });
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.resolveConflict("d1", "keep-local");
+    });
+
+    expect(ok).toBe(true);
+    expect(mockCreateDraft).toHaveBeenCalledWith(
+      "test-token",
+      expect.objectContaining({ body: "my offline text" }),
+    );
+    expect(result.current.conflicts).toHaveLength(0);
+    expect(result.current.drafts.some((d) => d.id === "d2")).toBe(true);
+  });
+
+  it("keeps a transient network failure retryable and queues it instead of raising a conflict", async () => {
+    mockPatchDraft.mockRejectedValue(new Error("network down"));
+
+    const { result } = await mountWithOneDraft();
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.updateDraft("d1", { body: "offline edit" });
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.conflicts).toHaveLength(0);
+    expect(mockEnqueueWrite).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/confessions/drafts/d1",
+        method: "PATCH",
+      }),
+    );
+    expect(result.current.error).toMatch(/offline/i);
+  });
+});

--- a/xconfess-frontend/app/lib/hooks/useDrafts.ts
+++ b/xconfess-frontend/app/lib/hooks/useDrafts.ts
@@ -2,7 +2,13 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "@/app/lib/hooks/useAuth";
-import { Draft, DraftInput, DraftUpdate } from "@/app/lib/types/draft";
+import {
+  Draft,
+  DraftConflict,
+  DraftConflictReason,
+  DraftInput,
+  DraftUpdate,
+} from "@/app/lib/types/draft";
 export type { Draft } from "@/app/lib/types/draft";
 import {
   fetchDrafts,
@@ -10,8 +16,22 @@ import {
   patchDraft,
   deleteDraftRemote,
   clearDraftsRemote,
+  toDraft,
   DraftApiError,
+  type DraftConflictErrorData,
 } from "@/app/lib/api/drafts";
+import { enqueueWrite } from "@/app/lib/utils/syncQueue";
+
+export type ConflictResolution = "keep-local" | "keep-remote" | "discard-local";
+
+const REMOTE_UPDATED_MSG =
+  "This draft was changed elsewhere while you were offline. Your local copy is kept.";
+const REMOTE_DELETED_MSG =
+  "This draft was deleted remotely while you were offline. Your local copy is kept.";
+
+function conflictMessage(reason: DraftConflictReason): string {
+  return reason === "remote_deleted" ? REMOTE_DELETED_MSG : REMOTE_UPDATED_MSG;
+}
 
 const STORAGE_KEY = "xconfess-drafts";
 const MAX_DRAFTS = 10;
@@ -50,11 +70,54 @@ export function useDrafts() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * Unresolved offline-sync conflicts, keyed by draft id. A conflict never
+   * mutates `drafts` — the local copy stays exactly as the user left it —
+   * and is never retried automatically. It clears only via `resolveConflict`
+   * or a subsequent successful write to the same id.
+   */
+  const [conflicts, setConflicts] = useState<DraftConflict[]>([]);
+
   // Avoid stale closures in the async fetch-on-mount effect.
   const draftsRef = useRef<Draft[]>(drafts);
   useEffect(() => {
     draftsRef.current = drafts;
   }, [drafts]);
+
+  const conflictsRef = useRef<DraftConflict[]>(conflicts);
+  useEffect(() => {
+    conflictsRef.current = conflicts;
+  }, [conflicts]);
+
+  const clearConflict = useCallback((id: string) => {
+    setConflicts((prev) => prev.filter((c) => c.draftId !== id));
+  }, []);
+
+  const recordConflict = useCallback(
+    (
+      id: string,
+      local: DraftConflict["local"],
+      data: DraftConflictErrorData | undefined,
+    ) => {
+      const reason: DraftConflictReason =
+        data?.reason === "remote_deleted" ? "remote_deleted" : "remote_updated";
+      const remote = data?.currentDraft ? toDraft(data.currentDraft) : undefined;
+
+      setConflicts((prev) => [
+        ...prev.filter((c) => c.draftId !== id),
+        {
+          draftId: id,
+          reason,
+          detectedAt: Date.now(),
+          local,
+          baseVersion: data?.currentVersion,
+          remote,
+        },
+      ]);
+      setError(conflictMessage(reason));
+    },
+    [],
+  );
 
   // ---- Guest mode: cross-tab sync (unchanged from prior behavior) ----
   useEffect(() => {
@@ -103,6 +166,52 @@ export function useDrafts() {
       cancelled = true;
     };
   }, [isAuthenticated, token]);
+
+  // ---- Conflicts reported by the service worker while replaying the ----
+  // ---- offline write queue (edits made fully offline, synced later). ----
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    if (typeof navigator === "undefined" || !navigator.serviceWorker) return;
+
+    const onMessage = (event: MessageEvent) => {
+      const msg = event.data as
+        | {
+            type?: string;
+            draftId?: string;
+            reason?: DraftConflictReason;
+            baseVersion?: number;
+            localBody?: string;
+            remote?: Parameters<typeof toDraft>[0];
+          }
+        | undefined;
+      if (!msg || msg.type !== "draft-sync-conflict" || !msg.draftId) return;
+
+      const reason: DraftConflictReason =
+        msg.reason === "remote_deleted" ? "remote_deleted" : "remote_updated";
+      const local = draftsRef.current.find((d) => d.id === msg.draftId);
+
+      setConflicts((prev) => [
+        ...prev.filter((c) => c.draftId !== msg.draftId),
+        {
+          draftId: msg.draftId!,
+          reason,
+          detectedAt: Date.now(),
+          local: {
+            body: msg.localBody ?? local?.body ?? "",
+            title: local?.title,
+            gender: local?.gender,
+          },
+          baseVersion: msg.baseVersion,
+          remote: msg.remote ? toDraft(msg.remote) : undefined,
+        },
+      ]);
+      setError(conflictMessage(reason));
+    };
+
+    navigator.serviceWorker.addEventListener("message", onMessage);
+    return () =>
+      navigator.serviceWorker.removeEventListener("message", onMessage);
+  }, [isAuthenticated]);
 
   const persistLocal = useCallback((newDrafts: Draft[]) => {
     const sorted = [...newDrafts]
@@ -173,19 +282,63 @@ export function useDrafts() {
   const updateDraft = useCallback(
     async (id: string, updates: DraftUpdate): Promise<boolean> => {
       if (isAuthenticated && token) {
+        const existing = draftsRef.current.find((d) => d.id === id);
+        // Carry the last-observed server revision so the backend can reject
+        // a stale write (optimistic concurrency) instead of clobbering a
+        // newer remote draft.
+        const baseVersion = updates.version ?? existing?.version;
+        const localSnapshot = {
+          body: updates.body ?? existing?.body ?? "",
+          title: updates.title ?? existing?.title,
+          gender: updates.gender ?? existing?.gender,
+        };
+
         try {
-          const updatedDraft = await patchDraft(token, id, updates);
+          const updatedDraft = await patchDraft(token, id, {
+            ...updates,
+            version: baseVersion,
+          });
           setDrafts((prev) =>
             prev.map((d) => (d.id === id ? updatedDraft : d)),
           );
+          clearConflict(id);
           setError(null);
           return true;
         } catch (err) {
-          setError(
-            err instanceof DraftApiError
-              ? err.message
-              : "Failed to save draft.",
-          );
+          if (err instanceof DraftApiError && err.status === 409) {
+            // Remote copy moved on (edited elsewhere or deleted) while this
+            // edit was offline. Preserve the local copy untouched, surface
+            // the conflict, and do NOT retry.
+            recordConflict(id, localSnapshot, err.data);
+            return false;
+          }
+
+          if (!(err instanceof DraftApiError)) {
+            // Network failure / offline: queue the write for background
+            // replay, tagged with the base version so replay still gets
+            // deterministic conflict handling.
+            void enqueueWrite({
+              url: `/api/confessions/drafts/${id}`,
+              method: "PATCH",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+              },
+              body: JSON.stringify({
+                content: localSnapshot.body,
+                category: localSnapshot.gender,
+                version: baseVersion,
+              }),
+            }).catch(() => {
+              /* best effort — nothing more we can do here */
+            });
+            setError(
+              "You're offline. This draft will sync when you reconnect.",
+            );
+            return false;
+          }
+
+          setError(err.message || "Failed to save draft.");
           return false;
         }
       }
@@ -204,7 +357,7 @@ export function useDrafts() {
       );
       return persistLocal(updated);
     },
-    [isAuthenticated, token, persistLocal],
+    [isAuthenticated, token, persistLocal, clearConflict, recordConflict],
   );
 
   const deleteDraft = useCallback(
@@ -213,6 +366,7 @@ export function useDrafts() {
         try {
           await deleteDraftRemote(token, id);
           setDrafts((prev) => prev.filter((d) => d.id !== id));
+          clearConflict(id);
         } catch (err) {
           setError(
             err instanceof DraftApiError
@@ -225,7 +379,88 @@ export function useDrafts() {
       const updated = draftsRef.current.filter((d) => d.id !== id);
       persistLocal(updated);
     },
-    [isAuthenticated, token, persistLocal],
+    [isAuthenticated, token, persistLocal, clearConflict],
+  );
+
+  /**
+   * Explicit conflict resolution. Never automatic.
+   *  - keep-local:  push the retained local content to the server. For
+   *                 "remote_updated" this rebases onto the current remote
+   *                 version; for "remote_deleted" it re-creates the draft.
+   *  - keep-remote: adopt the server copy (or drop the draft if it was
+   *                 deleted remotely), discarding the local edit.
+   *  - discard-local: just dismiss the conflict banner, leaving the editor
+   *                 contents untouched for the user to copy out manually.
+   */
+  const resolveConflict = useCallback(
+    async (draftId: string, resolution: ConflictResolution): Promise<boolean> => {
+      const conflict = conflictsRef.current.find((c) => c.draftId === draftId);
+      if (!conflict) return false;
+
+      if (resolution === "discard-local" || !isAuthenticated || !token) {
+        clearConflict(draftId);
+        if (resolution === "keep-remote" && conflict.reason === "remote_deleted") {
+          setDrafts((prev) => prev.filter((d) => d.id !== draftId));
+        }
+        setError(null);
+        return true;
+      }
+
+      if (resolution === "keep-remote") {
+        setDrafts((prev) => {
+          if (conflict.reason === "remote_deleted") {
+            return prev.filter((d) => d.id !== draftId);
+          }
+          return conflict.remote
+            ? prev.map((d) => (d.id === draftId ? conflict.remote! : d))
+            : prev;
+        });
+        clearConflict(draftId);
+        setError(null);
+        return true;
+      }
+
+      // keep-local
+      try {
+        if (conflict.reason === "remote_deleted") {
+          const created = await createDraft(token, {
+            body: conflict.local.body,
+            title: conflict.local.title,
+            gender: conflict.local.gender,
+          });
+          setDrafts((prev) =>
+            [created, ...prev.filter((d) => d.id !== draftId && d.id !== created.id)]
+              .sort((a, b) => b.savedAt - a.savedAt)
+              .slice(0, MAX_DRAFTS),
+          );
+        } else {
+          const updated = await patchDraft(token, draftId, {
+            body: conflict.local.body,
+            title: conflict.local.title,
+            gender: conflict.local.gender,
+            version: conflict.remote?.version,
+          });
+          setDrafts((prev) => prev.map((d) => (d.id === draftId ? updated : d)));
+        }
+        clearConflict(draftId);
+        setError(null);
+        return true;
+      } catch (err) {
+        if (err instanceof DraftApiError && err.status === 409) {
+          // Remote moved again between detection and resolution — refresh
+          // the conflict with the newer remote state rather than looping.
+          recordConflict(draftId, conflict.local, err.data);
+          return false;
+        }
+        setError(
+          err instanceof DraftApiError
+            ? err.message
+            : "Could not resolve the draft conflict.",
+        );
+        return false;
+      }
+    },
+    [isAuthenticated, token, clearConflict, recordConflict],
   );
 
   const clearDrafts = useCallback(async () => {
@@ -260,6 +495,8 @@ export function useDrafts() {
     isLoading,
     error,
     isRemote: isAuthenticated,
+    conflicts,
+    resolveConflict,
     saveDraft,
     updateDraft,
     deleteDraft,

--- a/xconfess-frontend/app/lib/types/draft.ts
+++ b/xconfess-frontend/app/lib/types/draft.ts
@@ -42,3 +42,44 @@ export interface DraftDTO {
   timezone?: string;
   version?: number;
 }
+
+/**
+ * Synchronization state of a single draft relative to the server.
+ *  - synced:   local copy matches the last known server revision
+ *  - pending:  local edit is queued for the server (offline / not yet sent)
+ *  - syncing:  a write is in flight
+ *  - failed:   a write failed for a transient reason and is retryable
+ *  - conflict: the server copy moved on (edited elsewhere or deleted) while
+ *              this client held an offline edit; needs explicit resolution
+ */
+export type DraftSyncState =
+  | "synced"
+  | "pending"
+  | "syncing"
+  | "failed"
+  | "conflict";
+
+export type DraftConflictReason = "remote_updated" | "remote_deleted";
+
+/**
+ * A local draft edit that could not be reconciled with the server because
+ * the remote copy changed ("remote_updated") or was deleted
+ * ("remote_deleted") while this client was offline. The local content is
+ * retained verbatim so the user can recover it — see `resolveConflict` in
+ * `useDrafts`.
+ */
+export interface DraftConflict {
+  draftId: string;
+  reason: DraftConflictReason;
+  detectedAt: number; // epoch ms
+  /** The local edit that lost the race — always recoverable from here. */
+  local: {
+    body: string;
+    title?: string;
+    gender?: Gender;
+  };
+  /** Server revision the local edit was based on, when known. */
+  baseVersion?: number;
+  /** Current server copy. Undefined when `reason === "remote_deleted"`. */
+  remote?: Draft;
+}

--- a/xconfess-frontend/app/lib/utils/syncQueue.ts
+++ b/xconfess-frontend/app/lib/utils/syncQueue.ts
@@ -1,5 +1,7 @@
 const DB_NAME = 'xconfess-sync';
+const DB_VERSION = 2;
 const STORE = 'pending-writes';
+const CONFLICT_STORE = 'sync-conflicts';
 const SYNC_TAG = 'xconfess-sync-writes';
 
 interface PendingWrite {
@@ -10,11 +12,36 @@ interface PendingWrite {
   body: string | null;
 }
 
+/**
+ * A queued write the service worker replayed and the server rejected with
+ * 409 (the remote draft moved on or was deleted while offline). Kept so the
+ * UI can surface it even if the client wasn't running when the replay
+ * happened; the corresponding pending write is removed so it is not
+ * retried forever.
+ */
+export interface SyncConflict {
+  id?: number;
+  draftId: string;
+  reason: 'remote_updated' | 'remote_deleted';
+  baseVersion?: number;
+  localBody?: string;
+  remote?: unknown;
+  detectedAt: number;
+}
+
+function upgrade(db: IDBDatabase) {
+  if (!db.objectStoreNames.contains(STORE)) {
+    db.createObjectStore(STORE, { keyPath: 'id', autoIncrement: true });
+  }
+  if (!db.objectStoreNames.contains(CONFLICT_STORE)) {
+    db.createObjectStore(CONFLICT_STORE, { keyPath: 'id', autoIncrement: true });
+  }
+}
+
 function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, 1);
-    req.onupgradeneeded = () =>
-      req.result.createObjectStore(STORE, { keyPath: 'id', autoIncrement: true });
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => upgrade(req.result);
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
   });
@@ -33,4 +60,25 @@ export async function enqueueWrite(write: Omit<PendingWrite, 'id'>): Promise<voi
     const reg = await navigator.serviceWorker.ready;
     await (reg as ServiceWorkerRegistration & { sync: { register(tag: string): Promise<void> } }).sync.register(SYNC_TAG);
   }
+}
+
+/** Conflicts recorded by the service worker during offline-queue replay. */
+export async function readSyncConflicts(): Promise<SyncConflict[]> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(CONFLICT_STORE, 'readonly');
+    const req = tx.objectStore(CONFLICT_STORE).getAll();
+    req.onsuccess = () => resolve(req.result as SyncConflict[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function clearSyncConflict(id: number): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(CONFLICT_STORE, 'readwrite');
+    const req = tx.objectStore(CONFLICT_STORE).delete(id);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
 }

--- a/xconfess-frontend/public/sw.js
+++ b/xconfess-frontend/public/sw.js
@@ -3,7 +3,9 @@
 const SHELL_CACHE = 'xconfess-shell-v3';
 const API_CACHE = 'xconfess-api-v3';
 const SYNC_DB_NAME = 'xconfess-sync';
+const SYNC_DB_VERSION = 2;
 const SYNC_STORE = 'pending-writes';
+const CONFLICT_STORE = 'sync-conflicts';
 
 const SHELL_URLS = ['/', '/offline', '/manifest.webmanifest'];
 
@@ -113,38 +115,121 @@ self.addEventListener('sync', (event) => {
 
 async function openSyncDb() {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open(SYNC_DB_NAME, 1);
-    req.onupgradeneeded = () =>
-      req.result.createObjectStore(SYNC_STORE, { keyPath: 'id', autoIncrement: true });
+    const req = indexedDB.open(SYNC_DB_NAME, SYNC_DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(SYNC_STORE)) {
+        db.createObjectStore(SYNC_STORE, { keyPath: 'id', autoIncrement: true });
+      }
+      if (!db.objectStoreNames.contains(CONFLICT_STORE)) {
+        db.createObjectStore(CONFLICT_STORE, {
+          keyPath: 'id',
+          autoIncrement: true,
+        });
+      }
+    };
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
   });
 }
 
-async function replaySyncQueue() {
-  const db = await openSyncDb();
-  const items = await new Promise((resolve, reject) => {
-    const tx = db.transaction(SYNC_STORE, 'readonly');
-    const req = tx.objectStore(SYNC_STORE).getAll();
+function idbRequest(store, run) {
+  return new Promise((resolve, reject) => {
+    const req = run(store);
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
   });
+}
+
+function extractDraftId(url) {
+  const match = /\/confessions\/drafts\/([^/?]+)/.exec(url || '');
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+function parseBody(body) {
+  try {
+    return body ? JSON.parse(body) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function notifyClients(message) {
+  const clients = await self.clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true,
+  });
+  for (const client of clients) {
+    client.postMessage(message);
+  }
+}
+
+async function replaySyncQueue() {
+  const db = await openSyncDb();
+  const items = await idbRequest(db.transaction(SYNC_STORE, 'readonly').objectStore(SYNC_STORE), (s) => s.getAll());
 
   for (const item of items) {
+    let response;
     try {
-      await fetch(item.url, {
+      response = await fetch(item.url, {
         method: item.method,
         headers: item.headers,
         body: item.body,
       });
-      await new Promise((resolve, reject) => {
-        const tx = db.transaction(SYNC_STORE, 'readwrite');
-        const req = tx.objectStore(SYNC_STORE).delete(item.id);
-        req.onsuccess = resolve;
-        req.onerror = reject;
-      });
     } catch {
-      // Will retry on the next sync event.
+      // Offline / network error - leave queued, retry on the next sync event.
+      continue;
     }
+
+    if (response.status === 409) {
+      // The remote draft moved on (edited elsewhere or deleted) while this
+      // write was queued offline. Record the conflict, tell any open client,
+      // and drop the write so it is not replayed forever - the local copy
+      // is never silently overwritten and never silently lost.
+      let payload = null;
+      try {
+        payload = await response.clone().json();
+      } catch {
+        payload = null;
+      }
+
+      const sent = parseBody(item.body);
+      const draftId =
+        (payload && payload.draftId) || extractDraftId(item.url) || 'unknown';
+      const reason =
+        payload && payload.reason === 'remote_deleted'
+          ? 'remote_deleted'
+          : 'remote_updated';
+
+      const conflict = {
+        draftId,
+        reason,
+        baseVersion: sent.version,
+        localBody: sent.content,
+        remote: payload && payload.currentDraft ? payload.currentDraft : undefined,
+        detectedAt: Date.now(),
+      };
+
+      await idbRequest(
+        db.transaction(CONFLICT_STORE, 'readwrite').objectStore(CONFLICT_STORE),
+        (s) => s.add(conflict),
+      );
+      await idbRequest(
+        db.transaction(SYNC_STORE, 'readwrite').objectStore(SYNC_STORE),
+        (s) => s.delete(item.id),
+      );
+      await notifyClients({ type: 'draft-sync-conflict', ...conflict });
+      continue;
+    }
+
+    if (response.ok) {
+      await idbRequest(
+        db.transaction(SYNC_STORE, 'readwrite').objectStore(SYNC_STORE),
+        (s) => s.delete(item.id),
+      );
+      continue;
+    }
+
+    // Other failures (auth, 5xx, ...) - leave queued for a later retry.
   }
 }


### PR DESCRIPTION
Summary

Closes #1823

Improves offline confession draft synchronization so that remote updates and deletions are treated as explicit conflicts instead of silently overwriting or discarding local draft content.

What changed
Added explicit draft sync conflict handling.
Detects when a remote draft has changed since the local version was created.
Detects when a remotely synchronized draft has been deleted.
Preserves local draft content when a conflict occurs.
Prevents conflicted queue operations from being retried indefinitely.
Keeps transient network failures retryable.
Surfaces conflict state through the existing frontend/API mechanisms.
Added regression tests for remote update conflicts.
Added regression tests for remote deletion conflicts.
Preserved the existing successful draft synchronization flow.
Conflict behavior
Remote update

When the remote draft has changed since the local client last synchronized:

the stale update is rejected;
the local draft is preserved;
the operation enters a conflict state;
the user is informed rather than silently losing content.
Remote deletion

When the remote draft no longer exists:

the queued update is not treated as successful;
the local draft content remains recoverable;
the operation enters an explicit conflict state.
Testing

The following areas were tested:

successful draft synchronization
remote update conflict
remote deletion conflict
local content preservation
conflict queue behavior
transient network retry behavior
conflict idempotency
relevant frontend/backend integration behavior
Scope

This PR is limited to offline draft synchronization conflict handling for Issue #1823.

No unrelated confession, authentication, WebSocket, or application functionality has been modified.