### PR TITLE
feat(backend): add Stellar contract event indexer compatibility layer

### DIFF
--- a/docs/contract-abi-reference.md
+++ b/docs/contract-abi-reference.md
@@ -1281,3 +1281,4 @@ orders against this reference. Keep this section aligned with
 - [Xconfess Project README](../README.md)
 - [Contract Deployment Guide](./SOROBAN_SETUP.md)
 - [Release Runbook](./contract-release-and-upgrade-runbook.md)
+- [Backend Event Parser Compatibility Layer](./contract-event-parser-compatibility.md)

--- a/docs/contract-event-parser-compatibility.md
+++ b/docs/contract-event-parser-compatibility.md
@@ -1,0 +1,147 @@
+# Stellar Contract Event Indexer Compatibility Layer
+
+> Backend module: `xconfess-backend/src/stellar/event-parser/`
+> Source of truth for topics/field order: [`docs/contract-abi-reference.md`](./contract-abi-reference.md#public-event-schema-fixtures)
+
+## Why this exists
+
+The backend indexer parses events emitted by four Soroban contracts
+(`confession-anchor`, `confession-registry`, `anonymous-tipping`,
+`reputation-badges`). Contract upgrades can add fields or bump
+`event_version` independently of backend deploys. Without a durable,
+versioned parser, an upgrade or an unexpected event shape can silently break
+anchoring, tips, reputation, or moderation workflows. This module gives the
+backend a single, pure, dependency-free place to decode events and to fail
+closed — loudly and with a typed, retry-aware error — instead of guessing.
+
+## Module layout
+
+| File | Purpose |
+| --- | --- |
+| `contract-event-parser.types.ts` | `RawContractEvent`, `ParsedContractEvent`, `ContractEventParseError`, `EventParseErrorCode`. |
+| `contract-event-parser.ts` | The versioned registry (`EVENT_SCHEMAS`) and `parseContractEvent()` / `parseGovernanceStreamEvent()` / `getCompatibilityMatrix()`. |
+| `contract-event-fixtures.ts` | One deterministic fixture per registered (topic, version) schema — reused by the fixture-coverage and parity tests. |
+| `contract-event-parser.spec.ts` | Fixture coverage, fixture/registry parity, and error-classification tests. No live Stellar RPC involved — parsing is a pure, synchronous function over already-fetched event data. |
+| `contract-event-parser.doc-parity.spec.ts` | Parses the ABI reference's fixture table and asserts the registry matches it row-for-row — the contract/backend parity test (see below). |
+
+## Compatibility matrix
+
+Generated from `getCompatibilityMatrix()` (also asserted 1:1 against fixtures
+in `contract-event-parser.spec.ts`):
+
+| Event | Category | Topic | Version | Field order |
+| --- | --- | --- | --- | --- |
+| `ConfessionAnchoredEvent` | anchor | `confession_anchor` | 1 | event_version, timestamp, anchor_height |
+| `VersionCompatibilityCheckedEvent` | anchor | `version_compatibility_checked` | 1 | event_version, nonce, timestamp, from_major, from_minor, from_patch, to_major, to_minor, to_patch, compatible |
+| `SettlementEvent` | tip | `tip_settl` | 1 | recipient, event_version, settlement_id, amount, proof_metadata, proof_present, timestamp |
+| `ConfessionEvent` | confession | `confess` | 1 | event_version, confession_id, author, content_hash, nonce, timestamp, correlation_id |
+| `ReactionEvent` | reaction | `react` | 1 | event_version, confession_id, reactor, reaction_type, nonce, timestamp, correlation_id |
+| `PauseChangedEvent` | pause | `tip_pause` | 1 | actor, paused, reason, timestamp |
+| `ReportEvent` | report | `report` | 1 | event_version, confession_id, reporter, reason, nonce, timestamp, correlation_id |
+| `ReportSubmittedLedgerEvent` | report | `report` | 1 | confession_id, actor, reason, event_version, nonce, timestamp |
+| `RoleEvent` | role | `role` | 1 | event_version, user, role, granted, nonce, timestamp, correlation_id |
+| `GovernanceProposedEvent` | governance | `gov_prop` | 1 | proposal_id, proposer |
+| `GovernanceApprovedEvent` | governance | `gov_app` | 1 | proposal_id, approver |
+| `GovernanceApprovalRevokedEvent` | governance | `gov_rev` | 1 | proposal_id, actor |
+| `GovernanceExecutedEvent` | governance | `gov_exec` | 1 | proposal_id, executor |
+| `GovInvariantViolationEvent` | governance | `gov_inv` | 1 | nonce, timestamp, operation, reason, attempted_by |
+| `GovernanceEvent` | governance | *(dynamic per-proposal stream — see below)* | 1 | event_version, metadata, nonce, timestamp |
+| `BadgeEvent` | reputation | `badge` | 1 | event_version, badge_id, badge_type, owner, action, nonce, timestamp |
+| `BadgeEvent` | reputation | `badge_awarded` | 1 | event_version, badge_id, badge_type, owner, action, timestamp |
+| `BadgeEvent` | reputation | `badge_granted` | 1 | event_version, badge_id, badge_type, owner, action, timestamp |
+| `BadgeEvent` | reputation | `badge_revoked` | 1 | event_version, badge_id, badge_type, owner, action, timestamp |
+| `ReputationAdjustedData` | reputation | `reputation_adjusted` | 1 | user, amount, reason, timestamp |
+| `ReputationDecayedData` | reputation | `reputation_decayed` | 1 | user, old_reputation, new_reputation, epochs_applied, timestamp |
+
+**Note on `report`**: two distinct event shapes share the literal topic
+`report`. The parser disambiguates by field count (7 fields → `ReportEvent`,
+6 fields → `ReportSubmittedLedgerEvent`). If a future version introduces a
+third shape with a colliding field count on this topic, it cannot be safely
+disambiguated by count alone — give it a distinct topic instead.
+
+**Note on `GovernanceEvent`**: its topic is a per-proposal stream name
+decided at emission time, not a fixed string, so it isn't in the topic
+registry. Call `parseGovernanceStreamEvent(eventVersion, values)` directly
+for these events rather than routing by topic string.
+
+**Note on events without an `event_version` field** (`PauseChangedEvent`,
+`GovernanceProposedEvent`/`GovernanceApprovedEvent`/`GovernanceApprovalRevokedEvent`/`GovernanceExecutedEvent`,
+`ReputationAdjustedData`, `ReputationDecayedData`): the contract payload
+doesn't carry a version, so callers pass `eventVersion: 1` by convention.
+If any of these payloads changes shape, it must gain a real `event_version`
+field so this convention doesn't become ambiguous.
+
+## Error classification (fail closed)
+
+`parseContractEvent` never guesses. Every failure is a typed
+`ContractEventParseError` with a `code` and a `retryable` flag:
+
+| Code | Meaning | `retryable` |
+| --- | --- | --- |
+| `UNKNOWN_TOPIC` | No registry entry for this topic at all. | `false` — needs a registry entry, not a retry. |
+| `UNSUPPORTED_VERSION` (newer) | `event_version` is higher than any version this backend knows for the topic. | `true` — the contract was upgraded ahead of the backend; reprocessing after deploying the matching parser version can succeed. |
+| `UNSUPPORTED_VERSION` (older/gap) | `event_version` is below the known range for the topic. | `false` — that version was deprecated, not merely unimplemented. |
+| `MALFORMED_PAYLOAD` | Topic and version are known, but the field count doesn't match any registered shape. | `false` — the payload itself is invalid. |
+
+An indexer should park `retryable: true` failures in a dead-letter/replay
+queue to reprocess after the next backend deploy, and alert immediately on
+`retryable: false` failures since those require a code or data fix.
+
+## How to add a new event version safely
+
+1. Update `docs/contract-abi-reference.md` § "Public Event Schema Fixtures"
+   first — add the new row with its topic, version, and field order. This
+   doc is the contract between contract authors and backend consumers, and
+   both sides' tests are pinned to it (see "Contract ⇄ backend parity" below).
+2. Add the matching entry to `PUBLIC_EVENT_SCHEMA_FIXTURES` in
+   `xconfess-contracts/contracts/events.rs`.
+3. Append a **new** entry to `EVENT_SCHEMAS` in `contract-event-parser.ts`
+   with the bumped `eventVersion`. **Never mutate or delete an existing
+   entry** — historical on-chain events emitted under the old schema must
+   keep parsing after the upgrade.
+4. Add a fixture for the new version to `contract-event-fixtures.ts`.
+5. Run the test commands below. The backend fixture-coverage test iterates
+   every fixture, the fixture/registry parity test asserts the registry and
+   fixture set stay 1:1, and the doc-parity test asserts the registry matches
+   the doc table row-for-row — all three fail if anything diverges.
+
+## Contract ⇄ backend parity
+
+There's no cross-language fixture loader (Rust `cargo test` and TypeScript
+`jest` don't share a runtime), so parity is enforced transitively through
+`docs/contract-abi-reference.md` as the single shared source of truth:
+
+- **Contract side**: `xconfess-contracts/contracts/events.rs` defines
+  `PUBLIC_EVENT_SCHEMA_FIXTURES`, and its test
+  `events::tests::public_event_metadata_matches_documented_abi` asserts every
+  entry's event name and fields literally appear in the ABI reference doc.
+- **Backend side**: `contract-event-parser.doc-parity.spec.ts` parses the
+  same "Public Event Schema Fixtures" markdown table and asserts
+  `contract-event-parser.ts`'s registry matches it exactly — same topics,
+  same field order, same row count, in both directions (no undocumented
+  registry entries, no unregistered doc rows).
+
+If both tests pass, the contract registry and the backend registry agree,
+because both are pinned to the same doc. A change to either registry that
+isn't reflected in the doc — or a doc change not reflected in the registry —
+fails on whichever side didn't update.
+
+## Running the tests
+
+```bash
+# Backend — fixture coverage, fixture/registry parity, error classification,
+# and contract/backend parity via the shared ABI doc
+cd xconfess-backend
+npx jest --config jest.config.js src/stellar/event-parser
+
+# Contract — asserts PUBLIC_EVENT_SCHEMA_FIXTURES matches the same doc
+cd xconfess-contracts
+cargo test -p confession-registry --lib public_event_metadata_matches_documented_abi
+```
+
+Current status: **54/54 backend tests passing** (fixture coverage for all 9
+event categories — anchor, tip, confession, reaction, report, role,
+governance, badge, reputation, plus pause under the tipping contract's pause
+control — fixture/registry parity, error-classification for all three typed
+error codes, and 24 doc-parity assertions) and the contract-side
+`public_event_metadata_matches_documented_abi` test passing.

--- a/docs/contract-event-version-bump-checklist.md
+++ b/docs/contract-event-version-bump-checklist.md
@@ -70,12 +70,17 @@ Update backend parsers and these specs in the **same PR** as contract event chan
 |-----------|---------|
 | [`xconfess-backend/src/stellar/__tests__/contract-event-fixtures.spec.ts`](../xconfess-backend/src/stellar/__tests__/contract-event-fixtures.spec.ts) | Anchor event parsing, error classification, `fixture_version` / `event_version` stability |
 | [`xconfess-backend/src/tipping/contract-fixtures.spec.ts`](../xconfess-backend/src/tipping/contract-fixtures.spec.ts) | Tip settlement fixtures and version compatibility |
+| [`xconfess-backend/src/stellar/event-parser/contract-event-parser.spec.ts`](../xconfess-backend/src/stellar/event-parser/contract-event-parser.spec.ts) | Versioned compatibility-layer registry: fixture coverage for every public event category, fixture/registry parity, typed error classification |
+| [`xconfess-backend/src/stellar/event-parser/contract-event-parser.doc-parity.spec.ts`](../xconfess-backend/src/stellar/event-parser/contract-event-parser.doc-parity.spec.ts) | Contract/backend parity — parses this doc's fixture table and diffs it against the compatibility-layer registry |
 
 ```bash
 cd xconfess-backend
 npm test -- contract-event-fixtures.spec.ts
 npm test -- contract-fixtures.spec.ts
+npx jest --config jest.config.js src/stellar/event-parser
 ```
+
+See [`docs/contract-event-parser-compatibility.md`](./contract-event-parser-compatibility.md) for the full compatibility-layer checklist and matrix.
 
 ---
 

--- a/xconfess-backend/src/stellar/event-parser/contract-event-fixtures.ts
+++ b/xconfess-backend/src/stellar/event-parser/contract-event-fixtures.ts
@@ -1,0 +1,128 @@
+/**
+ * Deterministic fixtures for every public event documented in
+ * docs/contract-abi-reference.md § Public Event Schema Fixtures.
+ *
+ * These are the values an on-chain event would carry, in field order,
+ * intended to be shared between contract-side fixture generation and
+ * backend parser tests so both sides drift together rather than apart.
+ */
+import { GOVERNANCE_STREAM_TOPIC } from './contract-event-parser';
+import { EventCategory, RawContractEvent } from './contract-event-parser.types';
+
+export interface ContractEventFixture extends RawContractEvent {
+  eventName: string;
+  category: EventCategory;
+  description: string;
+}
+
+const ADDR_A = 'GA000000000000000000000000000000000000000000000000000000AAAA';
+const ADDR_B = 'GB000000000000000000000000000000000000000000000000000000BBBB';
+const CONTENT_HASH = new Array(32).fill(0x42);
+
+export const CONTRACT_EVENT_FIXTURES: ContractEventFixture[] = [
+  {
+    eventName: 'ConfessionAnchoredEvent', category: 'anchor', topic: 'confession_anchor', eventVersion: 1,
+    values: [1, 1_700_000_000_000, 12345],
+    description: 'Confession hash anchored at ledger 12345',
+  },
+  {
+    eventName: 'VersionCompatibilityCheckedEvent', category: 'anchor', topic: 'version_compatibility_checked', eventVersion: 1,
+    values: [1, 7, 1_700_000_000_001, 1, 0, 0, 1, 1, 0, true],
+    description: 'Upgrade compatibility check from 1.0.0 to 1.1.0',
+  },
+  {
+    eventName: 'SettlementEvent', category: 'tip', topic: 'tip_settl', eventVersion: 1,
+    values: [ADDR_A, 1, 1, 1_000_000, 'txhash:abc123', true, 1_700_000_000_002],
+    description: 'Tip settlement with proof metadata',
+  },
+  {
+    eventName: 'ConfessionEvent', category: 'confession', topic: 'confess', eventVersion: 1,
+    values: [1, 42, ADDR_A, CONTENT_HASH, 3, 1_700_000_000_003, 'corr-conf-1'],
+    description: 'Confession created',
+  },
+  {
+    eventName: 'ReactionEvent', category: 'reaction', topic: 'react', eventVersion: 1,
+    values: [1, 42, ADDR_B, 'heart', 4, 1_700_000_000_004, 'corr-react-1'],
+    description: 'Reaction added to a confession',
+  },
+  {
+    eventName: 'PauseChangedEvent', category: 'pause', topic: 'tip_pause', eventVersion: 1,
+    values: [ADDR_A, true, 'incident_response', 1_700_000_000_005],
+    description: 'Tipping contract paused',
+  },
+  {
+    eventName: 'ReportEvent', category: 'report', topic: 'report', eventVersion: 1,
+    values: [1, 42, ADDR_B, 'spam', 1, 1_700_000_000_010, 'corr1234'],
+    description: 'Confession reported for spam',
+  },
+  {
+    eventName: 'ReportSubmittedLedgerEvent', category: 'report', topic: 'report', eventVersion: 1,
+    values: [42, ADDR_B, 'spam', 1, 2, 1_700_000_000_011],
+    description: 'Report ledger-mirror event (same topic as ReportEvent, shorter shape)',
+  },
+  {
+    eventName: 'RoleEvent', category: 'role', topic: 'role', eventVersion: 1,
+    values: [1, ADDR_A, 'moderator', true, 5, 1_700_000_000_006, 'corr-role-1'],
+    description: 'Moderator role granted',
+  },
+  {
+    eventName: 'GovernanceProposedEvent', category: 'governance', topic: 'gov_prop', eventVersion: 1,
+    values: [1, ADDR_A],
+    description: 'Governance proposal created',
+  },
+  {
+    eventName: 'GovernanceApprovedEvent', category: 'governance', topic: 'gov_app', eventVersion: 1,
+    values: [1, ADDR_B],
+    description: 'Governance proposal approved',
+  },
+  {
+    eventName: 'GovernanceApprovalRevokedEvent', category: 'governance', topic: 'gov_rev', eventVersion: 1,
+    values: [1, ADDR_B],
+    description: 'Governance approval revoked',
+  },
+  {
+    eventName: 'GovernanceExecutedEvent', category: 'governance', topic: 'gov_exec', eventVersion: 1,
+    values: [1, ADDR_A],
+    description: 'Governance proposal executed',
+  },
+  {
+    eventName: 'GovInvariantViolationEvent', category: 'governance', topic: 'gov_inv', eventVersion: 1,
+    values: [6, 1_700_000_000_007, 'gov_execute', 'quorum_not_reached', ADDR_B],
+    description: 'Governance invariant violated during execution',
+  },
+  {
+    eventName: 'GovernanceEvent', category: 'governance', topic: GOVERNANCE_STREAM_TOPIC, eventVersion: 1,
+    values: [1, 'proposal:1:quorum_updated', 8, 1_700_000_000_008],
+    description: 'Governance stream event on a dynamic per-proposal topic',
+  },
+  {
+    eventName: 'BadgeEvent', category: 'reputation', topic: 'badge', eventVersion: 1,
+    values: [1, 1, 'ConfessionStarter', ADDR_A, 'Grant', 9, 1_700_000_000_009],
+    description: 'Badge awarded (generic badge topic, includes nonce)',
+  },
+  {
+    eventName: 'BadgeEvent', category: 'reputation', topic: 'badge_awarded', eventVersion: 1,
+    values: [1, 2, 'PopularVoice', ADDR_B, 'Grant', 1_700_000_000_012],
+    description: 'Badge awarded by admin',
+  },
+  {
+    eventName: 'BadgeEvent', category: 'reputation', topic: 'badge_granted', eventVersion: 1,
+    values: [1, 3, 'GenerousSoul', ADDR_A, 'Grant', 1_700_000_000_013],
+    description: 'Badge self-granted (mint_badge)',
+  },
+  {
+    eventName: 'BadgeEvent', category: 'reputation', topic: 'badge_revoked', eventVersion: 1,
+    values: [1, 3, 'GenerousSoul', ADDR_A, 'Revoke', 1_700_000_000_014],
+    description: 'Badge revoked',
+  },
+  {
+    eventName: 'ReputationAdjustedData', category: 'reputation', topic: 'reputation_adjusted', eventVersion: 1,
+    values: [ADDR_A, 10, 'confession_upvoted', 1_700_000_000_015],
+    description: 'Reputation increased',
+  },
+  {
+    eventName: 'ReputationDecayedData', category: 'reputation', topic: 'reputation_decayed', eventVersion: 1,
+    values: [ADDR_A, 100, 90, 2, 1_700_000_000_016],
+    description: 'Reputation decayed after inactivity epochs',
+  },
+];

--- a/xconfess-backend/src/stellar/event-parser/contract-event-parser.doc-parity.spec.ts
+++ b/xconfess-backend/src/stellar/event-parser/contract-event-parser.doc-parity.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Contract/backend fixture parity test.
+ *
+ * xconfess-contracts/contracts/events.rs defines PUBLIC_EVENT_SCHEMA_FIXTURES
+ * and asserts (in its own #[cfg(test)] block, `public_event_metadata_matches_documented_abi`)
+ * that every entry's event name and fields appear in
+ * docs/contract-abi-reference.md.
+ *
+ * This test closes the loop from the backend side: it parses the same
+ * "Public Event Schema Fixtures" table out of that doc and asserts our
+ * contract-event-parser.ts registry matches it exactly — same topics, same
+ * field order, same row count. Since the contract-side registry is already
+ * pinned to that doc, a passing test here transitively proves the contract
+ * and backend registries agree, without needing a cross-language fixture
+ * loader.
+ *
+ * If this test fails, either:
+ *  - the doc was updated and contract-event-parser.ts needs the matching
+ *    change, or
+ *  - contract-event-parser.ts drifted from the doc and must be corrected.
+ * See docs/contract-event-parser-compatibility.md for the upgrade checklist.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { GOVERNANCE_STREAM_TOPIC, getCompatibilityMatrix } from './contract-event-parser';
+
+interface DocFixtureRow {
+  eventName: string;
+  category: string;
+  topic: string;
+  dataFormat: string;
+  fieldOrder: string[];
+}
+
+function parsePublicEventSchemaFixturesTable(markdown: string): DocFixtureRow[] {
+  const sectionStart = markdown.indexOf('## Public Event Schema Fixtures');
+  expect(sectionStart).toBeGreaterThan(-1);
+  const sectionEnd = markdown.indexOf('\n## ', sectionStart + 1);
+  const section = markdown.slice(sectionStart, sectionEnd === -1 ? undefined : sectionEnd);
+
+  const rowPattern =
+    /^\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|\s*(.+?)\s*\|\s*$/gm;
+
+  const rows: DocFixtureRow[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = rowPattern.exec(section)) !== null) {
+    const [, eventName, category, topic, dataFormat, fieldOrderCell] = match;
+    const fieldOrder = [...fieldOrderCell.matchAll(/`([a-zA-Z0-9_]+)`/g)].map((m) => m[1]);
+    rows.push({ eventName, category, topic, dataFormat, fieldOrder });
+  }
+  return rows;
+}
+
+describe('Backend registry ⇄ docs/contract-abi-reference.md parity', () => {
+  const docPath = path.join(__dirname, '../../../../docs/contract-abi-reference.md');
+  const markdown = fs.readFileSync(docPath, 'utf8');
+  const docRows = parsePublicEventSchemaFixturesTable(markdown);
+  const registryRows = getCompatibilityMatrix();
+
+  it('parsed at least one row from the doc table (sanity check on the parser itself)', () => {
+    expect(docRows.length).toBeGreaterThan(0);
+  });
+
+  it('has exactly one registry entry per documented fixture row (same count)', () => {
+    expect(registryRows).toHaveLength(docRows.length);
+  });
+
+  it.each(docRows.map((row, i) => [i, row.eventName, row.topic, row]))(
+    'doc row %s (%s on "%s") matches a registry entry field-for-field',
+    (_i, _eventName, _topic, row: DocFixtureRow) => {
+      const docTopic = row.topic === '<stream>' ? GOVERNANCE_STREAM_TOPIC : row.topic;
+
+      const registryMatch = registryRows.find(
+        (r) => r.eventName === row.eventName && r.topic === docTopic,
+      );
+
+      expect(registryMatch).toBeDefined();
+      expect(registryMatch!.category).toBe(row.category);
+      expect([...registryMatch!.fieldOrder]).toEqual(row.fieldOrder);
+    },
+  );
+
+  it('has no registry entry that is missing from the docs (no undocumented fixtures)', () => {
+    for (const registryRow of registryRows) {
+      const docTopic =
+        registryRow.topic === GOVERNANCE_STREAM_TOPIC ? '<stream>' : registryRow.topic;
+      const docMatch = docRows.find(
+        (r) => r.eventName === registryRow.eventName && r.topic === docTopic,
+      );
+      expect(docMatch).toBeDefined();
+    }
+  });
+});

--- a/xconfess-backend/src/stellar/event-parser/contract-event-parser.spec.ts
+++ b/xconfess-backend/src/stellar/event-parser/contract-event-parser.spec.ts
@@ -1,0 +1,141 @@
+import {
+  GOVERNANCE_STREAM_TOPIC,
+  getCompatibilityMatrix,
+  parseContractEvent,
+  parseGovernanceStreamEvent,
+} from './contract-event-parser';
+import { ContractEventParseError, EventParseErrorCode } from './contract-event-parser.types';
+import { CONTRACT_EVENT_FIXTURES } from './contract-event-fixtures';
+
+describe('parseContractEvent — fixture coverage', () => {
+  it.each(CONTRACT_EVENT_FIXTURES.map((f) => [f.eventName, f.topic, f]))(
+    'parses %s on topic "%s"',
+    (_name, _topic, fixture) => {
+      const parsed =
+        fixture.topic === GOVERNANCE_STREAM_TOPIC
+          ? parseGovernanceStreamEvent(fixture.eventVersion, fixture.values)
+          : parseContractEvent(fixture);
+
+      expect(parsed.eventName).toBe(fixture.eventName);
+      expect(parsed.category).toBe(fixture.category);
+      expect(parsed.eventVersion).toBe(fixture.eventVersion);
+      expect(Object.keys(parsed.fields)).toHaveLength(fixture.values.length);
+    },
+  );
+
+  it('every documented category from the ABI reference has at least one fixture', () => {
+    const categories = new Set(CONTRACT_EVENT_FIXTURES.map((f) => f.category));
+    const expected = [
+      'anchor',
+      'confession',
+      'governance',
+      'pause',
+      'reaction',
+      'report',
+      'reputation',
+      'role',
+      'tip',
+    ];
+    expect([...categories].sort()).toEqual(expected.sort());
+  });
+
+  it('disambiguates two distinct event shapes sharing the "report" topic by field count', () => {
+    const reportEvent = CONTRACT_EVENT_FIXTURES.find((f) => f.eventName === 'ReportEvent')!;
+    const ledgerEvent = CONTRACT_EVENT_FIXTURES.find(
+      (f) => f.eventName === 'ReportSubmittedLedgerEvent',
+    )!;
+
+    expect(parseContractEvent(reportEvent).eventName).toBe('ReportEvent');
+    expect(parseContractEvent(ledgerEvent).eventName).toBe('ReportSubmittedLedgerEvent');
+  });
+
+  it('maps positional values onto named fields in registry order', () => {
+    const fixture = CONTRACT_EVENT_FIXTURES.find((f) => f.eventName === 'SettlementEvent')!;
+    const parsed = parseContractEvent(fixture);
+
+    expect(parsed.fields).toEqual({
+      recipient: fixture.values[0],
+      event_version: fixture.values[1],
+      settlement_id: fixture.values[2],
+      amount: fixture.values[3],
+      proof_metadata: fixture.values[4],
+      proof_present: fixture.values[5],
+      timestamp: fixture.values[6],
+    });
+  });
+});
+
+describe('parseContractEvent — fixture/registry parity', () => {
+  it('has exactly one compatibility-matrix row per fixture', () => {
+    const matrix = getCompatibilityMatrix();
+    expect(matrix).toHaveLength(CONTRACT_EVENT_FIXTURES.length);
+
+    for (const fixture of CONTRACT_EVENT_FIXTURES) {
+      const row = matrix.find(
+        (r) =>
+          r.eventName === fixture.eventName &&
+          r.topic === fixture.topic &&
+          r.eventVersion === fixture.eventVersion,
+      );
+      expect(row).toBeDefined();
+      expect(row!.fieldOrder).toHaveLength(fixture.values.length);
+    }
+  });
+});
+
+describe('parseContractEvent — error classification (fail closed)', () => {
+  it('throws UNKNOWN_TOPIC (non-retryable) for an unregistered topic', () => {
+    expect.assertions(3);
+    try {
+      parseContractEvent({ topic: 'totally_unknown_topic', eventVersion: 1, values: [] });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractEventParseError);
+      expect((err as ContractEventParseError).code).toBe(EventParseErrorCode.UNKNOWN_TOPIC);
+      expect((err as ContractEventParseError).retryable).toBe(false);
+    }
+  });
+
+  it('throws UNSUPPORTED_VERSION (retryable) when the version is newer than known', () => {
+    expect.assertions(3);
+    try {
+      parseContractEvent({ topic: 'confession_anchor', eventVersion: 99, values: [1, 2, 3] });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractEventParseError);
+      expect((err as ContractEventParseError).code).toBe(EventParseErrorCode.UNSUPPORTED_VERSION);
+      expect((err as ContractEventParseError).retryable).toBe(true);
+    }
+  });
+
+  it('throws UNSUPPORTED_VERSION (non-retryable) when the version is below the known range', () => {
+    expect.assertions(3);
+    try {
+      parseContractEvent({ topic: 'confession_anchor', eventVersion: 0, values: [1, 2, 3] });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractEventParseError);
+      expect((err as ContractEventParseError).code).toBe(EventParseErrorCode.UNSUPPORTED_VERSION);
+      expect((err as ContractEventParseError).retryable).toBe(false);
+    }
+  });
+
+  it('throws MALFORMED_PAYLOAD (non-retryable) when field count does not match any known shape', () => {
+    expect.assertions(4);
+    try {
+      parseContractEvent({ topic: 'confession_anchor', eventVersion: 1, values: [1, 2] });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractEventParseError);
+      expect((err as ContractEventParseError).code).toBe(EventParseErrorCode.MALFORMED_PAYLOAD);
+      expect((err as ContractEventParseError).retryable).toBe(false);
+      expect((err as ContractEventParseError).context.receivedFieldCount).toBe(2);
+    }
+  });
+
+  it('does not depend on live Stellar RPC — parsing is a pure, synchronous function', () => {
+    // No network client, provider, or async I/O is imported by this module.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const moduleSource = require('fs').readFileSync(
+      require.resolve('./contract-event-parser'),
+      'utf8',
+    );
+    expect(moduleSource).not.toMatch(/from ['"].*(soroban|rpc|http|axios).*['"]/i);
+  });
+});

--- a/xconfess-backend/src/stellar/event-parser/contract-event-parser.ts
+++ b/xconfess-backend/src/stellar/event-parser/contract-event-parser.ts
@@ -1,0 +1,218 @@
+import {
+  ContractEventParseError,
+  EventCategory,
+  EventParseErrorCode,
+  ParsedContractEvent,
+  RawContractEvent,
+} from './contract-event-parser.types';
+
+/**
+ * `GovernanceEvent` is emitted on a per-proposal stream topic (documented in
+ * the ABI reference as `<stream>`), so it has no fixed on-chain topic
+ * string. Route it through parseGovernanceStreamEvent() instead of a literal
+ * topic lookup.
+ */
+export const GOVERNANCE_STREAM_TOPIC = '__governance_stream__';
+
+interface EventSchema {
+  eventName: string;
+  category: EventCategory;
+  topic: string;
+  eventVersion: number;
+  fieldOrder: readonly string[];
+}
+
+/**
+ * Versioned event registry — the compatibility layer's single source of truth.
+ *
+ * How to add a new event version safely:
+ * 1. Update docs/contract-abi-reference.md "Public Event Schema Fixtures"
+ *    table first — this registry must match it field-for-field.
+ * 2. Append a NEW EventSchema entry with the bumped `eventVersion`. Never
+ *    mutate or remove an existing entry: historical on-chain events must
+ *    keep parsing under their original schema.
+ * 3. Add a matching fixture to contract-event-fixtures.ts.
+ * 4. Run `npm test -- contract-event-parser` in xconfess-backend — the
+ *    fixture-parity test fails if the fixtures and this registry diverge.
+ *
+ * See docs/contract-event-parser-compatibility.md for the full checklist and
+ * the retry-classification rules for unsupported versions.
+ */
+const EVENT_SCHEMAS: readonly EventSchema[] = [
+  {
+    eventName: 'ConfessionAnchoredEvent', category: 'anchor', topic: 'confession_anchor', eventVersion: 1,
+    fieldOrder: ['event_version', 'timestamp', 'anchor_height'],
+  },
+  {
+    eventName: 'VersionCompatibilityCheckedEvent', category: 'anchor', topic: 'version_compatibility_checked', eventVersion: 1,
+    fieldOrder: ['event_version', 'nonce', 'timestamp', 'from_major', 'from_minor', 'from_patch', 'to_major', 'to_minor', 'to_patch', 'compatible'],
+  },
+  {
+    eventName: 'SettlementEvent', category: 'tip', topic: 'tip_settl', eventVersion: 1,
+    fieldOrder: ['recipient', 'event_version', 'settlement_id', 'amount', 'proof_metadata', 'proof_present', 'timestamp'],
+  },
+  {
+    eventName: 'ConfessionEvent', category: 'confession', topic: 'confess', eventVersion: 1,
+    fieldOrder: ['event_version', 'confession_id', 'author', 'content_hash', 'nonce', 'timestamp', 'correlation_id'],
+  },
+  {
+    eventName: 'ReactionEvent', category: 'reaction', topic: 'react', eventVersion: 1,
+    fieldOrder: ['event_version', 'confession_id', 'reactor', 'reaction_type', 'nonce', 'timestamp', 'correlation_id'],
+  },
+  {
+    eventName: 'PauseChangedEvent', category: 'pause', topic: 'tip_pause', eventVersion: 1,
+    fieldOrder: ['actor', 'paused', 'reason', 'timestamp'],
+  },
+  {
+    eventName: 'ReportEvent', category: 'report', topic: 'report', eventVersion: 1,
+    fieldOrder: ['event_version', 'confession_id', 'reporter', 'reason', 'nonce', 'timestamp', 'correlation_id'],
+  },
+  {
+    // Same topic as ReportEvent but a distinct shape (6 fields, no
+    // correlation_id) — disambiguated at parse time by field count.
+    eventName: 'ReportSubmittedLedgerEvent', category: 'report', topic: 'report', eventVersion: 1,
+    fieldOrder: ['confession_id', 'actor', 'reason', 'event_version', 'nonce', 'timestamp'],
+  },
+  {
+    eventName: 'RoleEvent', category: 'role', topic: 'role', eventVersion: 1,
+    fieldOrder: ['event_version', 'user', 'role', 'granted', 'nonce', 'timestamp', 'correlation_id'],
+  },
+  {
+    eventName: 'GovernanceProposedEvent', category: 'governance', topic: 'gov_prop', eventVersion: 1,
+    fieldOrder: ['proposal_id', 'proposer'],
+  },
+  {
+    eventName: 'GovernanceApprovedEvent', category: 'governance', topic: 'gov_app', eventVersion: 1,
+    fieldOrder: ['proposal_id', 'approver'],
+  },
+  {
+    eventName: 'GovernanceApprovalRevokedEvent', category: 'governance', topic: 'gov_rev', eventVersion: 1,
+    fieldOrder: ['proposal_id', 'actor'],
+  },
+  {
+    eventName: 'GovernanceExecutedEvent', category: 'governance', topic: 'gov_exec', eventVersion: 1,
+    fieldOrder: ['proposal_id', 'executor'],
+  },
+  {
+    eventName: 'GovInvariantViolationEvent', category: 'governance', topic: 'gov_inv', eventVersion: 1,
+    fieldOrder: ['nonce', 'timestamp', 'operation', 'reason', 'attempted_by'],
+  },
+  {
+    eventName: 'GovernanceEvent', category: 'governance', topic: GOVERNANCE_STREAM_TOPIC, eventVersion: 1,
+    fieldOrder: ['event_version', 'metadata', 'nonce', 'timestamp'],
+  },
+  {
+    eventName: 'BadgeEvent', category: 'reputation', topic: 'badge', eventVersion: 1,
+    fieldOrder: ['event_version', 'badge_id', 'badge_type', 'owner', 'action', 'nonce', 'timestamp'],
+  },
+  {
+    eventName: 'BadgeEvent', category: 'reputation', topic: 'badge_awarded', eventVersion: 1,
+    fieldOrder: ['event_version', 'badge_id', 'badge_type', 'owner', 'action', 'timestamp'],
+  },
+  {
+    eventName: 'BadgeEvent', category: 'reputation', topic: 'badge_granted', eventVersion: 1,
+    fieldOrder: ['event_version', 'badge_id', 'badge_type', 'owner', 'action', 'timestamp'],
+  },
+  {
+    eventName: 'BadgeEvent', category: 'reputation', topic: 'badge_revoked', eventVersion: 1,
+    fieldOrder: ['event_version', 'badge_id', 'badge_type', 'owner', 'action', 'timestamp'],
+  },
+  {
+    eventName: 'ReputationAdjustedData', category: 'reputation', topic: 'reputation_adjusted', eventVersion: 1,
+    fieldOrder: ['user', 'amount', 'reason', 'timestamp'],
+  },
+  {
+    eventName: 'ReputationDecayedData', category: 'reputation', topic: 'reputation_decayed', eventVersion: 1,
+    fieldOrder: ['user', 'old_reputation', 'new_reputation', 'epochs_applied', 'timestamp'],
+  },
+];
+
+const SCHEMAS_BY_TOPIC = new Map<string, EventSchema[]>();
+for (const schema of EVENT_SCHEMAS) {
+  const list = SCHEMAS_BY_TOPIC.get(schema.topic) ?? [];
+  list.push(schema);
+  SCHEMAS_BY_TOPIC.set(schema.topic, list);
+}
+
+/**
+ * Parse a raw Stellar contract event into a typed, versioned shape.
+ *
+ * Fails closed: any topic, version, or payload shape that isn't explicitly
+ * registered throws a ContractEventParseError rather than guessing.
+ */
+export function parseContractEvent(raw: RawContractEvent): ParsedContractEvent {
+  const candidates = SCHEMAS_BY_TOPIC.get(raw.topic);
+  if (!candidates || candidates.length === 0) {
+    throw new ContractEventParseError(
+      EventParseErrorCode.UNKNOWN_TOPIC,
+      `No registered event schema for topic "${raw.topic}"`,
+      false,
+      { topic: raw.topic },
+    );
+  }
+
+  const versionMatches = candidates.filter((s) => s.eventVersion === raw.eventVersion);
+  if (versionMatches.length === 0) {
+    const knownVersions = [...new Set(candidates.map((s) => s.eventVersion))].sort(
+      (a, b) => a - b,
+    );
+    const maxKnown = Math.max(...knownVersions);
+    throw new ContractEventParseError(
+      EventParseErrorCode.UNSUPPORTED_VERSION,
+      `Topic "${raw.topic}" event_version ${raw.eventVersion} is not registered (known: ${knownVersions.join(', ')})`,
+      raw.eventVersion > maxKnown,
+      { topic: raw.topic, eventVersion: raw.eventVersion, knownVersions },
+    );
+  }
+
+  const fieldMatch = versionMatches.find((s) => s.fieldOrder.length === raw.values.length);
+  if (!fieldMatch) {
+    throw new ContractEventParseError(
+      EventParseErrorCode.MALFORMED_PAYLOAD,
+      `Topic "${raw.topic}" v${raw.eventVersion} received ${raw.values.length} fields, expected one of [${versionMatches
+        .map((s) => s.fieldOrder.length)
+        .join(', ')}]`,
+      false,
+      {
+        topic: raw.topic,
+        eventVersion: raw.eventVersion,
+        expectedFieldCounts: versionMatches.map((s) => s.fieldOrder.length),
+        receivedFieldCount: raw.values.length,
+      },
+    );
+  }
+
+  const fields: Record<string, unknown> = {};
+  fieldMatch.fieldOrder.forEach((name, i) => {
+    fields[name] = raw.values[i];
+  });
+
+  return {
+    eventName: fieldMatch.eventName,
+    category: fieldMatch.category,
+    topic: fieldMatch.topic,
+    eventVersion: fieldMatch.eventVersion,
+    fields,
+  };
+}
+
+/** Parse a GovernanceEvent emitted on a dynamic per-proposal stream topic. */
+export function parseGovernanceStreamEvent(
+  eventVersion: number,
+  values: unknown[],
+): ParsedContractEvent {
+  return parseContractEvent({ topic: GOVERNANCE_STREAM_TOPIC, eventVersion, values });
+}
+
+export interface CompatibilityMatrixRow {
+  eventName: string;
+  category: EventCategory;
+  topic: string;
+  eventVersion: number;
+  fieldOrder: readonly string[];
+}
+
+/** Snapshot of every registered (topic, version) schema — used in docs/tests. */
+export function getCompatibilityMatrix(): CompatibilityMatrixRow[] {
+  return EVENT_SCHEMAS.map((s) => ({ ...s }));
+}

--- a/xconfess-backend/src/stellar/event-parser/contract-event-parser.types.ts
+++ b/xconfess-backend/src/stellar/event-parser/contract-event-parser.types.ts
@@ -1,0 +1,82 @@
+/**
+ * Types and typed errors for the Stellar contract event compatibility layer.
+ *
+ * @see docs/contract-abi-reference.md#public-event-schema-fixtures — source of
+ *      truth for topic names, categories, and field order used by the
+ *      registry in contract-event-parser.ts.
+ * @see docs/contract-event-parser-compatibility.md — upgrade checklist.
+ */
+
+export type EventCategory =
+  | 'anchor'
+  | 'tip'
+  | 'confession'
+  | 'reaction'
+  | 'report'
+  | 'role'
+  | 'governance'
+  | 'badge'
+  | 'reputation'
+  | 'pause';
+
+export interface RawContractEvent {
+  /** Event topic string as emitted on-chain (first #[topic] symbol). */
+  topic: string;
+  /**
+   * Schema version carried by the event. For events whose payload predates
+   * an `event_version` field, callers pass the documented convention
+   * version (1) — see the registry comment in contract-event-parser.ts.
+   */
+  eventVersion: number;
+  /** Field values in on-chain emission order. */
+  values: unknown[];
+}
+
+export interface ParsedContractEvent<
+  TFields extends Record<string, unknown> = Record<string, unknown>,
+> {
+  eventName: string;
+  category: EventCategory;
+  topic: string;
+  eventVersion: number;
+  fields: TFields;
+}
+
+export enum EventParseErrorCode {
+  UNKNOWN_TOPIC = 'UNKNOWN_TOPIC',
+  UNSUPPORTED_VERSION = 'UNSUPPORTED_VERSION',
+  MALFORMED_PAYLOAD = 'MALFORMED_PAYLOAD',
+}
+
+export interface EventParseErrorContext {
+  topic: string;
+  eventVersion?: number;
+  knownVersions?: number[];
+  expectedFieldCounts?: number[];
+  receivedFieldCount?: number;
+}
+
+/**
+ * Typed, fail-closed error for any event the parser cannot safely decode.
+ *
+ * `retryable` tells an indexer whether re-processing the same payload later
+ * could succeed without a code change:
+ *  - UNKNOWN_TOPIC / MALFORMED_PAYLOAD are never retryable — the topic needs
+ *    a registry entry or the payload is simply invalid.
+ *  - UNSUPPORTED_VERSION is retryable only when the observed version is
+ *    *newer* than anything the registry knows about (the contract was
+ *    upgraded ahead of the backend; reprocessing after deploying a parser
+ *    that registers the new version can succeed). A version below the known
+ *    range is terminal: it was deprecated, not merely not-yet-supported.
+ */
+export class ContractEventParseError extends Error {
+  constructor(
+    public readonly code: EventParseErrorCode,
+    message: string,
+    public readonly retryable: boolean,
+    public readonly context: EventParseErrorContext,
+  ) {
+    super(message);
+    this.name = 'ContractEventParseError';
+  }
+}


### PR DESCRIPTION
## Summary

Adds a durable backend compatibility layer for parsing Stellar contract
events, so contract upgrades or event-version bumps can't silently break
anchoring, tips, reputation, or moderation workflows.

- New module `xconfess-backend/src/stellar/event-parser/` — a versioned
  registry (`parseContractEvent`) covering every public event category
  documented in `docs/contract-abi-reference.md`: anchor, tip settlement,
  confession, reaction, pause, report (two shapes sharing one topic,
  disambiguated by field count), role, governance (including the dynamic
  per-proposal stream topic via `parseGovernanceStreamEvent`), badge, and
  reputation.
- Unknown topics, unsupported versions, and malformed payloads fail closed
  with a typed `ContractEventParseError` carrying a `retryable` flag —
  newer-than-known versions are retryable (reprocess after a backend
  deploy), everything else is terminal.
- Shared fixtures (`contract-event-fixtures.ts`) covering all 21 registered
  event shapes, reused across the coverage and parity tests.
- **Contract/backend fixture parity test**: rather than a cross-language
  fixture loader, `contract-event-parser.doc-parity.spec.ts` parses the same
  ABI-reference table that `xconfess-contracts/contracts/events.rs`'s own
  `public_event_metadata_matches_documented_abi` test checks against, and
  asserts the backend registry matches it row-for-row. Both sides are pinned
  to `docs/contract-abi-reference.md`, so a passing pair of tests transitively
  proves contract/backend parity.
- New doc `docs/contract-event-parser-compatibility.md`: compatibility
  matrix, retry-classification table, and the checklist for adding a new
  event version safely. Linked from the ABI reference and the existing
  version-bump checklist.

Closes #1686

## Test plan

- [x] `cd xconfess-backend && npx jest --config jest.config.js src/stellar/event-parser` — 54/54 passing (fixture coverage for all 9 categories, fixture/registry parity, error classification, 24 doc-parity assertions)
- [x] `cd xconfess-contracts && cargo test -p confession-registry --lib public_event_metadata_matches_documented_abi` — passing, confirming the doc stays the shared source of truth
- [x] `npx tsc --noEmit` — no type errors in the new module
- [x] No live Stellar RPC dependency — parsing is pure/synchronous over already-fetched event data