### PR TITLE
test(tipping): add boundary and overflow tests for tip amount arithmetic

### DIFF
--- a/xconfess-contracts/contracts/anonymous-tipping/src/lib.rs
+++ b/xconfess-contracts/contracts/anonymous-tipping/src/lib.rs
@@ -247,6 +247,14 @@ impl AnonymousTipping {
     }
 
     /// Send anonymous tip with optional bounded settlement proof metadata.
+    ///
+    /// # Fee and rounding policy
+    /// This contract performs a direct peer-to-peer token transfer with **no platform fee**.
+    /// The full `amount` (in stroops) is credited to `recipient`. There is no fee deduction,
+    /// no rounding, and no basis-point calculation — `amount` must be an exact integer of
+    /// stroops between 1 and `MAX_TIP_AMOUNT` (inclusive). Any future fee mechanism must
+    /// document its rounding direction here; the canonical choice for fee-on-top is
+    /// round-up (ceiling) so the protocol never subsidises the sender.
     pub fn send_tip_with_proof(
         env: Env,
         sender: Address,

--- a/xconfess-contracts/contracts/anonymous-tipping/src/test.rs
+++ b/xconfess-contracts/contracts/anonymous-tipping/src/test.rs
@@ -144,3 +144,63 @@ fn boundary_amounts_are_accepted() {
     assert_eq!(id2, 2);
     assert_eq!(client.get_tip_balance(&recipient), 1 + max_amount);
 }
+
+// ── #1665 boundary / overflow regression tests ────────────────────────────────
+
+#[test]
+fn i128_min_is_rejected() {
+    // i128::MIN is negative — must be rejected as InvalidTipAmount, not panic.
+    let (env, client, _token_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    assert_eq!(
+        client.try_send_tip(&sender, &recipient, &i128::MIN),
+        Err(Ok(Error::InvalidTipAmount))
+    );
+    assert_eq!(client.get_tip_balance(&recipient), 0);
+}
+
+#[test]
+fn one_below_max_is_accepted_and_one_above_max_is_rejected() {
+    // MAX_TIP_AMOUNT - 1: last valid amount before the ceiling.
+    // MAX_TIP_AMOUNT + 1: first invalid amount above the ceiling.
+    // Verifies the boundary is inclusive on the correct side.
+    let (env, client, token_id) = setup();
+    let token = TestTokenClient::new(&env, &token_id);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let below_max = AnonymousTipping::MAX_TIP_AMOUNT - 1;
+    token.mint(&sender, &below_max);
+    let id = client.send_tip(&sender, &recipient, &below_max);
+    assert_eq!(id, 1);
+    assert_eq!(client.get_tip_balance(&recipient), below_max);
+
+    assert_eq!(
+        client.try_send_tip(&sender, &recipient, &(AnonymousTipping::MAX_TIP_AMOUNT + 1)),
+        Err(Ok(Error::InvalidTipAmount))
+    );
+}
+
+#[test]
+fn settlement_id_is_monotonically_increasing_across_senders() {
+    // Each successful tip increments the global settlement counter regardless
+    // of which sender/recipient pair is involved.
+    let (env, client, token_id) = setup();
+    let token = TestTokenClient::new(&env, &token_id);
+    let sender_a = Address::generate(&env);
+    let sender_b = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    token.mint(&sender_a, &500);
+    token.mint(&sender_b, &500);
+
+    let id1 = client.send_tip(&sender_a, &recipient, &100);
+    let id2 = client.send_tip(&sender_b, &recipient, &200);
+    let id3 = client.send_tip(&sender_a, &recipient, &50);
+
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+    assert_eq!(id3, 3);
+    assert_eq!(client.get_tip_balance(&recipient), 350);
+}


### PR DESCRIPTION
Closes #1662
Closes #1663
Closes #1664
Closes #1665

Adds three regression tests to `anonymous-tipping/src/test.rs` covering untested edge cases in tip amount validation:

- **`i128_min_is_rejected`** — verifies `i128::MIN` (most-negative i128) is rejected as `InvalidTipAmount` without panicking, since it is negative.
- **`one_below_max_is_accepted_and_one_above_max_is_rejected`** — explicitly tests that `MAX_TIP_AMOUNT - 1` is accepted and `MAX_TIP_AMOUNT + 1` is rejected, pinning the boundary to its correct inclusive/exclusive sides.
- **`settlement_id_is_monotonically_increasing_across_senders`** — asserts the global settlement counter increments across different sender/recipient pairs, confirming the counter is truly global and not per-sender.

Also adds a doc comment on `send_tip_with_proof` documenting the **no platform fee, direct peer-to-peer transfer** policy and the canonical rounding direction (`ceil`) for any future fee mechanism, satisfying the issue's requirement to document rounding policy inline.