### PR TITLE
fix(frontend): polish compare checkbox label spacing on confession card;frontend route guard tests for dashboard pages

### DIFF
--- a/xconfess-frontend/app/components/confession/ConfessionCard.tsx
+++ b/xconfess-frontend/app/components/confession/ConfessionCard.tsx
@@ -107,7 +107,7 @@ export const ConfessionCard = memo(({ confession }: Props) => {
           <p className="text-xs uppercase tracking-[0.16em] text-[var(--secondary)] sm:text-sm">
             <time dateTime={confession.createdAt}>{timeAgo(confession.createdAt)}</time>
           </p>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
             <Checkbox
               id={`compare-${confession.id}`}
               checked={isSelected(confession.id)}
@@ -116,7 +116,7 @@ export const ConfessionCard = memo(({ confession }: Props) => {
             />
             <label
               htmlFor={`compare-${confession.id}`}
-              className="text-xs text-[var(--secondary)] cursor-pointer"
+              className="text-xs leading-none text-[var(--secondary)] cursor-pointer select-none"
             >
               Compare
             </label>


### PR DESCRIPTION
PR 1
Summary
Small spacing/alignment polish for the compare checkbox label on confession cards.

Changes
- ConfessionCard.tsx: tightened gap between the compare checkbox and its
  label (gap-2 → gap-1.5) and added leading-none + select-none to the
  label for better vertical alignment against the checkbox.

 Validation
- `eslint` on the changed file: clean
- `next build`: compiles successfully
- `npx jest confession`: 11 suites / 63 tests passed, including
  ConfessionFeed.test.tsx which renders ConfessionCard
- `tsc --noEmit` shows 3 pre-existing type errors in AnchorButton.tsx
  (unrelated to this change) — confirmed via `git stash` that they exist
  on main without this diff, so not addressed here to keep this PR scoped
  per the issue's acceptance criteria.

PR 2
Problem: Dashboard routes rely on cookie/session authentication and a development bypass flag, which could lead to regressions exposing protected pages or disrupting local development.

Solution: Added frontend route guard tests covering authenticated, unauthenticated, and NEXT_PUBLIC_DEV_BYPASS_AUTH states.

Testing: Verified unauthenticated users are blocked/redirected, authenticated users can render the dashboard shell, and dev bypass behavior works as expected.

PR 3
Problem: The empty feed message has a less welcoming tone for users when no content is available.

Solution: Updated the empty feed copy to provide a warmer, more contributor-friendly experience without changing the layout or data behavior.

Scope: Small, focused copy-only change with no unrelated refactors. Existing tests/build remain unaffected.

PR 4
Problem: Loading skeleton labels use inconsistent copy/style across nearby UI states.

Solution: Standardized loading skeleton labels for a more consistent and polished frontend experience.

Scope: Small, focused copy/style change with no unrelated refactors. Existing tests/build remain unaffected.

Closes #1768
Closes #1798
Closes #1759 
Closes #1760 