### PR TITLE
ci: run deploy:preflight as a required PR check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,35 @@ jobs:
       - run: npm install --global npm@10.9.3
       - run: npm ci --include=optional --no-audit --no-fund
       - run: npm run ci:apps
-  env:
-    BACKEND_API_URL: http://localhost:5000/api
-    NEXT_PUBLIC_API_URL: http://localhost:5000/api
-    NEXT_PUBLIC_WS_URL: ws://localhost:5000
-    NEXT_PUBLIC_APP_URL: http://localhost:3000
+
+  deploy-preflight:
+    name: Deploy Preflight
+    needs: [audit, secret-scan]
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
+      JWT_SECRET: ci-deploy-preflight-dummy-jwt-secret-32chars-min
+      APP_SECRET: ci-deploy-preflight-dummy-app-secret-32chars-min
+      CONFESSION_ENCRYPTION_KEY: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+      ENCRYPTION_MASTER_KEY_v1: b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3
+      TYPEORM_SYNCHRONIZE: false
+      TYPEORM_MIGRATIONS_RUN: true
+      STELLAR_FEATURES_ENABLED: true
+      STELLAR_NETWORK: testnet
+      STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+      STELLAR_SOROBAN_RPC_URL: https://soroban-testnet.stellar.org
+      CONFESSION_ANCHOR_CONTRACT_ID: CBFR2MDZBQPTNBIJCT32MTDDQLW2AQNDWNO777F3QT6ANYKTHETQZWD3
+      REPUTATION_BADGES_CONTRACT_ID: CBFR2MDZBQPTNBIJCT32MTDDQLW2AQNDWNO777F3QT6ANYKTHETQZWD3
+      TIPPING_SYSTEM_CONTRACT_ID: CBFR2MDZBQPTNBIJCT32MTDDQLW2AQNDWNO777F3QT6ANYKTHETQZWD3
+      BACKEND_API_URL: https://xconfess-backend-preflight.onrender.com
+      NEXT_PUBLIC_API_URL: https://xconfess-backend-preflight.onrender.com/api
+      FRONTEND_URL: https://xconfess-frontend-preflight.onrender.com
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm run deploy:preflight
 
   contracts:
     name: Contracts

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -204,3 +204,5 @@ npm run ci
 ```
 
 The full gate includes frontend type-checking, frontend tests, backend tests, and Rust contract tests. Contract tests need enough free disk space for the MSVC linker on Windows.
+
+`npm run deploy:preflight` checks Render config drift, migration timestamp duplicates, and required production env vars. It now also runs automatically as a required GitHub Actions check (`Deploy Preflight`) on every pull request against `main`, using dummy production-shaped env values — no live secrets are needed for the check to run.


### PR DESCRIPTION
 Fixes #1722,1761,1757,1762 — `deploy:preflight` never ran on GitHub before merge

### What was wrong
`npm run deploy:preflight` existed locally and on Render, but nothing ran it on GitHub — a bad Render config or a duplicate migration timestamp could land on `main` undetected.
 What changed
- Added a `deploy-preflight` job to `ci.yml` that runs `npm run deploy:preflight` on every PR against `main`, using dummy production-shaped env values (fake JWT/encryption keys, testnet Stellar config, Render-shaped URLs). No real secrets required — the script has zero external dependencies, so the job needs no `npm ci`/install step.
- **Also fixed a pre-existing bug found while auditing this file:** `ci.yml` had a malformed orphaned `env:` block between two jobs, missing required `runs-on`/`steps` fields. Confirmed with `actionlint` that this made the **entire workflow file invalid** — no CI checks could run on any PR at all before this fix. Directly blocked this issue's own goal, so it was in scope to fix here.
- Added a line to `DEPLOYMENT.md` noting the check now runs automatically in CI.

 Review evidence
Verified locally against the real repo files:
- Simulated Render `healthCheckPath` drift → correctly caught and failed
- Simulated a duplicate migration timestamp → correctly caught and failed
- Full production-shaped dummy env → passes cleanly
- `actionlint` clean on the modified workflow (and confirmed it flags the *original* broken file, proving the fix was necessary)

No existing tests or workflows touched beyond `ci.yml`.
closes #1722 
closes #1761 
closes #1762 
closes #1757 