### PR TITLE
feat: standardize proxy 405s, baseline-decision tests, auth request-id tracing

### DIFF
--- a/scripts/__tests__/render-prestart.test.js
+++ b/scripts/__tests__/render-prestart.test.js
@@ -1,0 +1,60 @@
+const { evaluateBaselineDecision } = require('../render-prestart');
+
+/**
+ * Coverage for the render:prestart baseline decision logic (#1727).
+ * The script protects sync-created Render databases, so the rules are:
+ *   - never baseline a fresh database
+ *   - never duplicate rows into an existing migration history
+ *   - baseline only when core tables exist and history is empty
+ */
+describe('render:prestart baseline decision (#1727)', () => {
+  const base = {
+    baselineEnabled: true,
+    migrationsRunEnabled: true,
+    migrationsAvailable: true,
+    coreTablesPresent: true,
+    migrationHistoryCount: 0,
+  };
+
+  it('skips when the baseline feature flag is disabled', () => {
+    const decision = evaluateBaselineDecision({ ...base, baselineEnabled: false });
+    expect(decision.action).toBe('skip');
+    expect(decision.reason).toMatch(/TYPEORM_BASELINE_EXISTING_SCHEMA/);
+  });
+
+  it('skips when migrations are not configured to run', () => {
+    const decision = evaluateBaselineDecision({ ...base, migrationsRunEnabled: false });
+    expect(decision.action).toBe('skip');
+    expect(decision.reason).toMatch(/TYPEORM_MIGRATIONS_RUN/);
+  });
+
+  it('errors when no compiled migrations are present (build did not run)', () => {
+    const decision = evaluateBaselineDecision({ ...base, migrationsAvailable: false });
+    expect(decision.action).toBe('error');
+    expect(decision.reason).toMatch(/Build must run/);
+  });
+
+  it('does not baseline a fresh database (core tables missing)', () => {
+    const decision = evaluateBaselineDecision({ ...base, coreTablesPresent: false });
+    expect(decision.action).toBe('skip');
+    expect(decision.action).not.toBe('baseline');
+    expect(decision.reason).toMatch(/pre-synchronized/);
+  });
+
+  it('does not duplicate rows when migration history already exists', () => {
+    const decision = evaluateBaselineDecision({ ...base, migrationHistoryCount: 12 });
+    expect(decision.action).toBe('skip');
+    expect(decision.action).not.toBe('baseline');
+    expect(decision.reason).toMatch(/already has entries/);
+  });
+
+  it('baselines only when core tables exist and migration history is empty', () => {
+    const decision = evaluateBaselineDecision(base);
+    expect(decision.action).toBe('baseline');
+  });
+
+  it('treats a stringified count from pg (SELECT COUNT(*)) as populated history', () => {
+    const decision = evaluateBaselineDecision({ ...base, migrationHistoryCount: '3' });
+    expect(decision.action).toBe('skip');
+  });
+});

--- a/scripts/deploy-preflight.js
+++ b/scripts/deploy-preflight.js
@@ -162,9 +162,54 @@ function validateRenderYaml() {
   }
 }
 
+// Guards the render:prestart baseline logic that protects sync-created Render
+// databases (#1727): it must never baseline a fresh DB and never duplicate
+// migration rows into an existing history.
+function validateRenderPrestartBaseline() {
+  let evaluateBaselineDecision;
+  try {
+    ({ evaluateBaselineDecision } = require('./render-prestart'));
+  } catch (error) {
+    fail(`Unable to load render-prestart baseline logic: ${error.message}`);
+    return;
+  }
+
+  if (typeof evaluateBaselineDecision !== 'function') {
+    fail('render-prestart must export evaluateBaselineDecision for baseline coverage.');
+    return;
+  }
+
+  const ready = {
+    baselineEnabled: true,
+    migrationsRunEnabled: true,
+    migrationsAvailable: true,
+    coreTablesPresent: true,
+    migrationHistoryCount: 0,
+  };
+
+  const cases = [
+    ['disabled baseline flag skips', { ...ready, baselineEnabled: false }, 'skip'],
+    ['disabled migrations run skips', { ...ready, migrationsRunEnabled: false }, 'skip'],
+    ['missing compiled migrations errors', { ...ready, migrationsAvailable: false }, 'error'],
+    ['fresh database is never baselined', { ...ready, coreTablesPresent: false }, 'skip'],
+    ['existing migration history is never re-baselined', { ...ready, migrationHistoryCount: 5 }, 'skip'],
+    ['synchronized schema with empty history is baselined', ready, 'baseline'],
+  ];
+
+  for (const [label, state, expected] of cases) {
+    const decision = evaluateBaselineDecision(state);
+    if (!decision || decision.action !== expected) {
+      fail(
+        `render-prestart baseline logic: "${label}" expected action "${expected}" but got "${decision && decision.action}".`,
+      );
+    }
+  }
+}
+
 const failures = [];
 validateWorkspaceDependencies();
 validateRenderYaml();
+validateRenderPrestartBaseline();
 validateMigrations();
 validateFrontendUrls();
 validateProductionSecrets();

--- a/scripts/render-prestart.js
+++ b/scripts/render-prestart.js
@@ -111,20 +111,81 @@ async function ensureConfessionReadinessIndexes(client) {
   console.log('Render prestart ensured confession readiness indexes.');
 }
 
-async function main() {
-  if (!enabled('TYPEORM_BASELINE_EXISTING_SCHEMA')) {
-    console.log('Render prestart baseline skipped: TYPEORM_BASELINE_EXISTING_SCHEMA is not enabled.');
-    return;
-  }
+/**
+ * Pure decision logic for the Render prestart baseline step. Kept side-effect
+ * free so it can be unit tested against the four cases that matter:
+ *   - the feature flags are disabled                -> skip
+ *   - no compiled migrations are on disk            -> error (build did not run)
+ *   - the database is fresh (core tables missing)   -> skip, never baseline
+ *   - migration history already has rows            -> skip, never duplicate rows
+ *   - core tables exist and history is empty        -> baseline
+ *
+ * @param {{
+ *   baselineEnabled: boolean,
+ *   migrationsRunEnabled: boolean,
+ *   migrationsAvailable: boolean,
+ *   coreTablesPresent: boolean,
+ *   migrationHistoryCount: number,
+ * }} state
+ * @returns {{ action: 'skip' | 'baseline' | 'error', reason: string }}
+ */
+function evaluateBaselineDecision(state) {
+  const {
+    baselineEnabled,
+    migrationsRunEnabled,
+    migrationsAvailable,
+    coreTablesPresent,
+    migrationHistoryCount,
+  } = state;
 
-  if (!enabled('TYPEORM_MIGRATIONS_RUN')) {
-    console.log('Render prestart baseline skipped: TYPEORM_MIGRATIONS_RUN is not enabled.');
+  if (!baselineEnabled) {
+    return { action: 'skip', reason: 'TYPEORM_BASELINE_EXISTING_SCHEMA is not enabled.' };
+  }
+  if (!migrationsRunEnabled) {
+    return { action: 'skip', reason: 'TYPEORM_MIGRATIONS_RUN is not enabled.' };
+  }
+  if (!migrationsAvailable) {
+    return {
+      action: 'error',
+      reason: 'No compiled migrations found. Build must run before render:prestart.',
+    };
+  }
+  if (!coreTablesPresent) {
+    return { action: 'skip', reason: 'database does not look pre-synchronized.' };
+  }
+  if (Number(migrationHistoryCount) > 0) {
+    return { action: 'skip', reason: 'migrations table already has entries.' };
+  }
+  return { action: 'baseline', reason: 'core tables exist and migration history is empty.' };
+}
+
+async function main() {
+  const baselineEnabled = enabled('TYPEORM_BASELINE_EXISTING_SCHEMA');
+  const migrationsRunEnabled = enabled('TYPEORM_MIGRATIONS_RUN');
+
+  // Resolve everything we can decide before touching the database.
+  const flagDecision = evaluateBaselineDecision({
+    baselineEnabled,
+    migrationsRunEnabled,
+    migrationsAvailable: true,
+    coreTablesPresent: true,
+    migrationHistoryCount: 0,
+  });
+  if (flagDecision.action === 'skip') {
+    console.log(`Render prestart baseline skipped: ${flagDecision.reason}`);
     return;
   }
 
   const migrations = loadMigrations();
-  if (migrations.length === 0) {
-    throw new Error('No compiled migrations found. Build must run before render:prestart.');
+  const noMigrationsDecision = evaluateBaselineDecision({
+    baselineEnabled,
+    migrationsRunEnabled,
+    migrationsAvailable: migrations.length > 0,
+    coreTablesPresent: true,
+    migrationHistoryCount: 0,
+  });
+  if (noMigrationsDecision.action === 'error') {
+    throw new Error(noMigrationsDecision.reason);
   }
 
   const client = new Client({
@@ -139,9 +200,17 @@ async function main() {
   try {
     const hasUserTable = await tableExists(client, 'user');
     const hasConfessionsTable = await tableExists(client, 'anonymous_confessions');
+    const coreTablesPresent = hasUserTable && hasConfessionsTable;
 
-    if (!hasUserTable || !hasConfessionsTable) {
-      console.log('Render prestart baseline skipped: database does not look pre-synchronized.');
+    if (!coreTablesPresent) {
+      const decision = evaluateBaselineDecision({
+        baselineEnabled,
+        migrationsRunEnabled,
+        migrationsAvailable: true,
+        coreTablesPresent,
+        migrationHistoryCount: 0,
+      });
+      console.log(`Render prestart baseline skipped: ${decision.reason}`);
       return;
     }
 
@@ -157,8 +226,18 @@ async function main() {
     `);
 
     const existing = await client.query('SELECT COUNT(*)::int AS count FROM "migrations";');
-    if (existing.rows[0]?.count > 0) {
-      console.log('Render prestart baseline skipped: migrations table already has entries.');
+    const migrationHistoryCount = existing.rows[0]?.count ?? 0;
+
+    const decision = evaluateBaselineDecision({
+      baselineEnabled,
+      migrationsRunEnabled,
+      migrationsAvailable: migrations.length > 0,
+      coreTablesPresent,
+      migrationHistoryCount,
+    });
+
+    if (decision.action !== 'baseline') {
+      console.log(`Render prestart baseline skipped: ${decision.reason}`);
       return;
     }
 
@@ -179,7 +258,11 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+module.exports = { evaluateBaselineDecision, loadMigrations };
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}

--- a/xconfess-backend/src/user/user-public.controller.spec.ts
+++ b/xconfess-backend/src/user/user-public.controller.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Request } from 'express';
+import { UserPublicController } from './user-public.controller';
+import { UserService } from './user.service';
+import { CryptoUtil } from '../common/crypto.util';
+import { RegisterDto } from '../auth/dto/register.dto';
+
+describe('UserPublicController (#1730 request id)', () => {
+  let controller: UserPublicController;
+  const mockUserService = { create: jest.fn() };
+
+  const fakeUser = {
+    id: 7,
+    username: 'alice',
+    role: 'user',
+    is_active: true,
+    emailEncrypted: 'enc',
+    emailIv: 'iv',
+    emailTag: 'tag',
+    notificationPreferences: {},
+    isDiscoverable: () => true,
+    canReceiveReplies: () => true,
+    shouldShowReactions: () => true,
+    hasDataProcessingConsent: () => true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserPublicController],
+      providers: [{ provide: UserService, useValue: mockUserService }],
+    }).compile();
+
+    controller = module.get(UserPublicController);
+    jest.clearAllMocks();
+    jest.spyOn(CryptoUtil, 'decrypt').mockReturnValue('alice@example.com');
+    mockUserService.create.mockResolvedValue(fakeUser);
+  });
+
+  const dto = {
+    email: 'alice@example.com',
+    password: 'Str0ng!Pass#1',
+    username: 'alice',
+  } as RegisterDto;
+
+  it('forwards the middleware request id to UserService.create', async () => {
+    const req = { requestId: 'req-abc-123' } as unknown as Request;
+
+    await controller.register(dto, req);
+
+    expect(mockUserService.create).toHaveBeenCalledWith(
+      dto.email,
+      dto.password,
+      dto.username,
+      'req-abc-123',
+    );
+  });
+
+  it('passes undefined when no request id is present', async () => {
+    const req = {} as Request;
+
+    await controller.register(dto, req);
+
+    expect(mockUserService.create).toHaveBeenCalledWith(
+      dto.email,
+      dto.password,
+      dto.username,
+      undefined,
+    );
+  });
+});

--- a/xconfess-backend/src/user/user-public.controller.ts
+++ b/xconfess-backend/src/user/user-public.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Req } from '@nestjs/common';
+import type { Request } from 'express';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RegisterDto } from '../auth/dto/register.dto';
 import { CryptoUtil } from '../common/crypto.util';
@@ -18,11 +19,18 @@ export class UserPublicController {
     status: 201,
     description: 'Account created.',
   })
-  async register(@Body() dto: RegisterDto): Promise<{ user: UserResponse }> {
+  async register(
+    @Body() dto: RegisterDto,
+    @Req() req: Request,
+  ): Promise<{ user: UserResponse }> {
+    // Set by RequestIdMiddleware; forwarded so registration failures are
+    // traceable from the frontend x-request-id to backend logs (#1730).
+    const requestId = (req as Request & { requestId?: string }).requestId;
     const user = await this.userService.create(
       dto.email,
       dto.password,
       dto.username,
+      requestId,
     );
 
     return { user: this.toUserResponse(user) };

--- a/xconfess-backend/src/user/user.service.spec.ts
+++ b/xconfess-backend/src/user/user.service.spec.ts
@@ -424,6 +424,85 @@ describe('UserService', () => {
     });
   });
 
+  describe('create — request id tracing (#1730)', () => {
+    const data = {
+      email: 'trace@example.com',
+      password: 'password123',
+      username: 'traceuser',
+    };
+    let errorSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashedpassword' as never);
+      errorSpy = jest
+        .spyOn((service as any).logger, 'error')
+        .mockImplementation(() => undefined);
+      warnSpy = jest
+        .spyOn((service as any).logger, 'warn')
+        .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it('includes the request id in the failure log and never logs credentials', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      mockRepository.create.mockReturnValue(mockUser);
+      mockRepository.save.mockRejectedValue(new Error('Database exploded'));
+
+      await expect(
+        service.create(data.email, data.password, data.username, 'req-trace-1'),
+      ).rejects.toThrow(InternalServerErrorException);
+
+      expect(errorSpy).toHaveBeenCalled();
+      const logged = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('req-trace-1');
+      expect(logged).not.toContain(data.email);
+      expect(logged).not.toContain(data.password);
+    });
+
+    it('tags conflict rejections with the request id without leaking the email', async () => {
+      mockRepository.findOne.mockResolvedValueOnce(mockUser);
+
+      await expect(
+        service.create(data.email, data.password, data.username, 'req-trace-2'),
+      ).rejects.toMatchObject({ status: 409 });
+
+      const logged = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('req-trace-2');
+      expect(logged).not.toContain(data.email);
+    });
+
+    it('does not log the email address when the welcome email fails', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      mockRepository.create.mockReturnValue(mockUser);
+      mockRepository.save.mockResolvedValue(mockUser);
+      mockEmailService.sendWelcomeEmail.mockRejectedValue(new Error('smtp down'));
+
+      await service.create(data.email, data.password, data.username, 'req-trace-3');
+
+      const logged = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('req-trace-3');
+      expect(logged).not.toContain(data.email);
+    });
+
+    it('omits the request id marker when none is provided', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      mockRepository.create.mockReturnValue(mockUser);
+      mockRepository.save.mockRejectedValue(new Error('Database exploded'));
+
+      await expect(
+        service.create(data.email, data.password, data.username),
+      ).rejects.toThrow(InternalServerErrorException);
+
+      const logged = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).not.toContain('requestId=');
+    });
+  });
+
   describe('deactivateAccount', () => {
     it('should deactivate a user account', async () => {
       const userId = 1;

--- a/xconfess-backend/src/user/user.service.ts
+++ b/xconfess-backend/src/user/user.service.ts
@@ -84,10 +84,17 @@ export class UserService {
     email: string,
     password: string,
     username: string,
+    requestId?: string,
   ): Promise<User> {
+    // Correlation suffix for log lines so a failed registration can be traced
+    // from the frontend x-request-id to backend logs (#1730). Never log the
+    // email, password, or username values themselves.
+    const trace = requestId ? ` [requestId=${requestId}]` : '';
+
     const normalizedEmail = email.trim().toLowerCase();
     const existing = await this.findByEmail(normalizedEmail);
     if (existing) {
+      this.logger.warn(`Registration rejected: email already in use${trace}`);
       throw new AppException(
         'An account with this email already exists.',
         ErrorCode.ALREADY_EXISTS,
@@ -97,6 +104,7 @@ export class UserService {
     }
     const existingUsername = await this.findByUsername(username);
     if (existingUsername) {
+      this.logger.warn(`Registration rejected: username already taken${trace}`);
       throw new AppException(
         'This username is already taken.',
         ErrorCode.ALREADY_EXISTS,
@@ -128,9 +136,10 @@ export class UserService {
           savedUser.username,
         );
       } catch (err) {
-        // Ignore email sending failures as they shouldn't block user creation
+        // Ignore email sending failures as they shouldn't block user creation.
+        // Reference the new user by id — never log the email address.
         this.logger.warn(
-          `Failed to send welcome email to ${normalizedEmail}: ${
+          `Failed to send welcome email for user ${savedUser.id}${trace}: ${
             err instanceof Error ? err.message : err
           }`,
         );
@@ -141,6 +150,9 @@ export class UserService {
         throw error;
       }
       if ((error as { code?: string })?.code === '23505') {
+        this.logger.warn(
+          `Registration rejected: unique constraint violation${trace}`,
+        );
         throw new AppException(
           'Email or username already in use.',
           ErrorCode.ALREADY_EXISTS,
@@ -148,7 +160,7 @@ export class UserService {
         );
       }
       this.logger.error(
-        `Failed to create user: ${
+        `Failed to create user${trace}: ${
           error instanceof Error ? error.message : String(error)
         }`,
         error instanceof Error ? error.stack : undefined,

--- a/xconfess-frontend/app/(auth)/login/page.tsx
+++ b/xconfess-frontend/app/(auth)/login/page.tsx
@@ -9,6 +9,8 @@ import { Input } from '@/app/components/ui/input';
 import { BrandLogo } from '@/app/components/brand/BrandLogo';
 import { useAuth } from '@/app/lib/hooks/useAuth';
 import { isSafeAuthRedirect } from '@/app/lib/utils/auth-redirect';
+import { extractRequestId } from '@/app/lib/utils/errorHandler';
+import { RequestIdNotice } from '@/app/components/auth/RequestIdNotice';
 import {
   validateLoginForm,
   parseLoginForm,
@@ -25,6 +27,7 @@ export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState<ValidationErrors>({});
+  const [errorRequestId, setErrorRequestId] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
 
   const doMockAdminLogin = async () => {
@@ -63,6 +66,7 @@ export default function LoginPage() {
 
     setLoading(true);
     setErrors({});
+    setErrorRequestId(undefined);
     try {
       const user = await login({
         email: parsed.data.email,
@@ -76,6 +80,7 @@ export default function LoginPage() {
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Login failed';
       setErrors({ password: message });
+      setErrorRequestId(extractRequestId(e));
     } finally {
       setLoading(false);
     }
@@ -118,6 +123,10 @@ export default function LoginPage() {
               <div className="mt-5 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-200">
                 {errors.password}
               </div>
+            )}
+
+            {errorRequestId && (errors.email || errors.password) && (
+              <RequestIdNotice requestId={errorRequestId} />
             )}
 
             <div className="mt-6 space-y-4">

--- a/xconfess-frontend/app/(auth)/register/page.tsx
+++ b/xconfess-frontend/app/(auth)/register/page.tsx
@@ -9,8 +9,9 @@ import { Button } from '@/app/components/ui/button';
 import { Input } from '@/app/components/ui/input';
 import { BrandLogo } from '@/app/components/brand/BrandLogo';
 import { useAuth } from '@/app/lib/hooks/useAuth';
-import { getErrorMessage } from '@/app/lib/utils/errorHandler';
+import { getErrorMessage, extractRequestId } from '@/app/lib/utils/errorHandler';
 import { getAuthFieldError } from '@/app/lib/api/authService';
+import { RequestIdNotice } from '@/app/components/auth/RequestIdNotice';
 import {
   validateRegisterForm,
   parseRegisterForm,
@@ -40,6 +41,7 @@ export default function RegisterPage() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [errors, setErrors] = useState<ValidationErrors>({});
   const [submitError, setSubmitError] = useState('');
+  const [errorRequestId, setErrorRequestId] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -56,6 +58,7 @@ export default function RegisterPage() {
     if (field === 'confirmPassword') setConfirmPassword(value);
 
     setSubmitError('');
+    setErrorRequestId(undefined);
     if (errors[field]) {
       setErrors((prev) => ({ ...prev, [field]: undefined }));
     }
@@ -68,6 +71,7 @@ export default function RegisterPage() {
     const validationErrors = validateRegisterForm(formData);
     setErrors(validationErrors);
     setSubmitError('');
+    setErrorRequestId(undefined);
 
     if (hasErrors(validationErrors)) {
       return;
@@ -90,6 +94,7 @@ export default function RegisterPage() {
     } catch (error) {
       const field = getAuthFieldError(error);
       const message = getErrorMessage(error);
+      setErrorRequestId(extractRequestId(error));
       if (field) {
         setErrors((prev) => ({ ...prev, [field]: message }));
         setSubmitError('');
@@ -148,6 +153,10 @@ export default function RegisterPage() {
               >
                 {submitError}
               </div>
+            )}
+
+            {errorRequestId && (submitError || hasErrors(errors)) && (
+              <RequestIdNotice requestId={errorRequestId} />
             )}
 
             <div className="mt-6 grid gap-4 sm:grid-cols-2">

--- a/xconfess-frontend/app/api/auth/session/route.ts
+++ b/xconfess-frontend/app/api/auth/session/route.ts
@@ -5,7 +5,7 @@ import {
   NormalizedAuthError,
 } from "@/lib/normalizeAuthError";
 import { getOrCreateRequestId, requestIdResponseHeaders } from "@/app/lib/utils/requestId";
-import { methodNotAllowed, resolveBackendRoute } from "@/app/lib/api/proxy";
+import { methodNotAllowedHandlers, resolveBackendRoute } from "@/app/lib/api/proxy";
 
 const SESSION_COOKIE_NAME = "xconfess_session";
 const MAX_RETRIES = 1;
@@ -122,7 +122,7 @@ export async function POST(request: Request) {
                 message: "Email and password are required",
                 status: 400,
             });
-            return createErrorResponse(normalized);
+            return createErrorResponse(normalized, requestId);
         }
 
         const backend = resolveBackendRoute(request, "/auth/login");
@@ -132,7 +132,7 @@ export async function POST(request: Request) {
         }, backend.requestId);
 
         if (!result.success) {
-            return createErrorResponse(result.normalized!);
+            return createErrorResponse(result.normalized!, requestId);
         }
 
         const data = result.data as Record<string, unknown>;
@@ -156,7 +156,7 @@ export async function POST(request: Request) {
         return res;
     } catch (error) {
         const normalized = normalizeAuthError(error);
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 }
 
@@ -171,7 +171,7 @@ export async function GET(request: Request) {
             message: "Not authenticated",
             status: 401,
         });
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 
     try {
@@ -200,7 +200,7 @@ export async function GET(request: Request) {
             if (result.normalized?.originalStatus === 401) {
                 cookieStore.delete(SESSION_COOKIE_NAME);
             }
-            return createErrorResponse(result.normalized!);
+            return createErrorResponse(result.normalized!, requestId);
         }
 
         const user = result.data as Record<string, unknown>;
@@ -209,7 +209,7 @@ export async function GET(request: Request) {
         return response;
     } catch (error) {
         const normalized = normalizeAuthError(error);
-        return createErrorResponse(normalized);
+        return createErrorResponse(normalized, requestId);
     }
 }
 
@@ -219,15 +219,16 @@ export async function DELETE() {
     return NextResponse.json({ success: true });
 }
 
-export async function PUT() {
-  return methodNotAllowed("PUT", ["GET", "POST", "DELETE"]);
-}
+export const { PUT, PATCH } = methodNotAllowedHandlers(["GET", "POST", "DELETE"]);
 
 /**
  * Convert normalized auth error to JSON response.
  * Output shape matches NormalizedAuthError so AuthProvider can consume it directly.
  */
-function createErrorResponse(normalized: NormalizedAuthError): Response {
+function createErrorResponse(
+  normalized: NormalizedAuthError,
+  requestId?: string,
+): Response {
   const isExpectedMissingSession =
     normalized.code === "INVALID_SESSION" && normalized.originalStatus === 401;
 
@@ -244,6 +245,9 @@ function createErrorResponse(normalized: NormalizedAuthError): Response {
 
   const status = normalized.originalStatus || 500;
 
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (requestId) headers["x-request-id"] = requestId;
+
   return new Response(
     JSON.stringify({
       type: normalized.type,
@@ -251,10 +255,11 @@ function createErrorResponse(normalized: NormalizedAuthError): Response {
       message: normalized.message,
       retryable: normalized.retryable,
       originalStatus: normalized.originalStatus,
+      requestId,
     }),
     {
       status,
-      headers: { "Content-Type": "application/json" },
+      headers,
     }
   );
 }

--- a/xconfess-frontend/app/api/comments/[confessionId]/route.ts
+++ b/xconfess-frontend/app/api/comments/[confessionId]/route.ts
@@ -1,6 +1,7 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
 import { getOrCreateRequestId } from "@/app/lib/utils/requestId";
+import { methodNotAllowedHandlers } from "@/app/lib/api/proxy";
 
 
 async function sha256Hex(input: string): Promise<string> {
@@ -170,3 +171,5 @@ export async function POST(
     });
   }
 }
+
+export const { GET, PUT, PATCH, DELETE } = methodNotAllowedHandlers(["POST"]);

--- a/xconfess-frontend/app/api/confessions/__tests__/route.methodNotAllowed.test.ts
+++ b/xconfess-frontend/app/api/confessions/__tests__/route.methodNotAllowed.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PUT, PATCH, DELETE, GET, POST } from "../route";
+
+describe("/api/confessions method-not-allowed", () => {
+  it("keeps GET and POST as real handlers", () => {
+    expect(typeof GET).toBe("function");
+    expect(typeof POST).toBe("function");
+  });
+
+  it.each([
+    ["PUT", PUT],
+    ["PATCH", PATCH],
+    ["DELETE", DELETE],
+  ])("returns a standardized 405 for %s", async (method, handler) => {
+    const response = handler();
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe("GET, POST");
+
+    const body = await response.json();
+    expect(body.code).toBe("METHOD_NOT_ALLOWED");
+    expect(body.message).toContain(method);
+  });
+});

--- a/xconfess-frontend/app/api/confessions/route.ts
+++ b/xconfess-frontend/app/api/confessions/route.ts
@@ -2,6 +2,7 @@ import { normalizeConfession } from "../../lib/utils/normalizeConfession";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
 import { getOrCreateRequestId, requestIdResponseHeaders } from "@/app/lib/utils/requestId";
+import { methodNotAllowedHandlers } from "@/app/lib/api/proxy";
 
 export async function POST(request: Request) {
   const BASE_API_URL = getApiBaseUrl();
@@ -170,4 +171,6 @@ export async function GET(request: Request) {
     });
   }
 }
+
+export const { PUT, PATCH, DELETE } = methodNotAllowedHandlers(["GET", "POST"]);
 

--- a/xconfess-frontend/app/api/notifications/__tests__/route.methodNotAllowed.test.ts
+++ b/xconfess-frontend/app/api/notifications/__tests__/route.methodNotAllowed.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import { GET, POST, PUT, PATCH, DELETE } from "../route";
+
+describe("/api/notifications method-not-allowed", () => {
+  it("keeps GET as a real handler", () => {
+    expect(typeof GET).toBe("function");
+  });
+
+  it.each([
+    ["POST", POST],
+    ["PUT", PUT],
+    ["PATCH", PATCH],
+    ["DELETE", DELETE],
+  ])("returns a standardized 405 for %s", async (method, handler) => {
+    const response = handler();
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe("GET");
+
+    const body = await response.json();
+    expect(body.code).toBe("METHOD_NOT_ALLOWED");
+    expect(body.message).toContain(method);
+  });
+});

--- a/xconfess-frontend/app/api/notifications/preference/route.ts
+++ b/xconfess-frontend/app/api/notifications/preference/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
+import { methodNotAllowedHandlers } from "@/app/lib/api/proxy";
 
 
 export async function GET(request: NextRequest) {
@@ -74,4 +75,6 @@ export async function PUT(request: NextRequest) {
     });
   }
 }
+
+export const { POST, PATCH, DELETE } = methodNotAllowedHandlers(["GET", "PUT"]);
 

--- a/xconfess-frontend/app/api/notifications/route.ts
+++ b/xconfess-frontend/app/api/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
+import { methodNotAllowedHandlers } from "@/app/lib/api/proxy";
 
 
 export async function GET(request: NextRequest) {
@@ -49,4 +50,6 @@ export async function GET(request: NextRequest) {
     });
   }
 }
+
+export const { POST, PUT, PATCH, DELETE } = methodNotAllowedHandlers(["GET"]);
 

--- a/xconfess-frontend/app/api/users/profile/route.ts
+++ b/xconfess-frontend/app/api/users/profile/route.ts
@@ -1,5 +1,6 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
 import { getApiBaseUrl } from "@/app/lib/config";
+import { methodNotAllowedHandlers } from "@/app/lib/api/proxy";
 
 
 export async function GET(request: Request) {
@@ -93,4 +94,6 @@ export async function PATCH(request: Request) {
     });
   }
 }
+
+export const { POST, PUT, DELETE } = methodNotAllowedHandlers(["GET", "PATCH"]);
 

--- a/xconfess-frontend/app/api/users/register/route.ts
+++ b/xconfess-frontend/app/api/users/register/route.ts
@@ -1,5 +1,5 @@
 import { createApiErrorResponse } from "@/lib/apiErrorHandler";
-import { methodNotAllowed, resolveBackendRoute } from "@/app/lib/api/proxy";
+import { methodNotAllowedHandlers, resolveBackendRoute } from "@/app/lib/api/proxy";
 
 export async function POST(request: Request) {
   let correlationId = request.headers.get("X-Request-ID") || request.headers.get("X-Correlation-ID") || "unknown";
@@ -51,6 +51,4 @@ export async function POST(request: Request) {
   }
 }
 
-export async function GET() {
-  return methodNotAllowed("GET", ["POST"]);
-}
+export const { GET, PUT, PATCH, DELETE } = methodNotAllowedHandlers(["POST"]);

--- a/xconfess-frontend/app/components/auth/RequestIdNotice.tsx
+++ b/xconfess-frontend/app/components/auth/RequestIdNotice.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+interface RequestIdNoticeProps {
+  requestId?: string | null;
+  className?: string;
+}
+
+/**
+ * Compact, mobile-friendly display of the failed request's correlation id so
+ * users and maintainers can trace it in backend logs (issue #1729).
+ * Renders nothing when no id is available.
+ */
+export function RequestIdNotice({ requestId, className }: RequestIdNoticeProps) {
+  const [copied, setCopied] = useState(false);
+
+  if (!requestId) return null;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(requestId);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — the value stays
+      // selectable so it can still be copied manually.
+    }
+  };
+
+  return (
+    <div
+      className={`mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--secondary)] ${className ?? ''}`}
+    >
+      <span className="shrink-0">Request ID</span>
+      <code
+        data-testid="auth-request-id"
+        className="max-w-full select-all break-all rounded bg-[var(--surface-strong)] px-1.5 py-0.5 font-mono text-[var(--foreground)]"
+      >
+        {requestId}
+      </code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[var(--primary-deep)] hover:bg-[var(--surface-strong)] hover:text-[var(--primary)]"
+        aria-label="Copy request ID"
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}

--- a/xconfess-frontend/app/lib/api/authService.ts
+++ b/xconfess-frontend/app/lib/api/authService.ts
@@ -69,6 +69,35 @@ apiClient.interceptors.response.use(
 );
 
 /**
+ * Pull the correlation / request id out of a proxy error response so failed
+ * auth attempts can surface it to the user for log tracing (issue #1729).
+ * Prefers the `x-request-id` response header, then common body fields.
+ */
+export function extractResponseRequestId(
+  response: Pick<Response, 'headers'>,
+  body?: unknown,
+): string | undefined {
+  // Header names are case-insensitive per the Fetch spec.
+  const headerId =
+    response.headers.get('x-request-id') ||
+    response.headers.get('x-correlation-id');
+  if (headerId && headerId.trim().length > 0) {
+    return headerId.trim();
+  }
+
+  if (body && typeof body === 'object') {
+    const record = body as Record<string, unknown>;
+    const bodyId =
+      record.requestId ?? record.request_id ?? record.correlationId;
+    if (typeof bodyId === 'string' && bodyId.trim().length > 0) {
+      return bodyId.trim();
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Authentication API service
  */
 export const authApi = {
@@ -96,6 +125,7 @@ export const authApi = {
             responseBody: body,
             path: '/api/auth/session',
             normalized,
+            requestId: extractResponseRequestId(response, body),
           });
           logError(appError, 'authApi.login', { status: response.status });
           throw appError;
@@ -117,6 +147,7 @@ export const authApi = {
           path: '/api/auth/session',
           upstreamMessage:
             typeof rawApi === 'string' ? rawApi : undefined,
+          requestId: extractResponseRequestId(response, body),
         });
         logError(apiError, 'authApi.login', { status, url: '/api/auth/session' });
         throw apiError;
@@ -153,6 +184,7 @@ export const authApi = {
           responseBody: body,
           path: '/api/users/register',
           field,
+          requestId: extractResponseRequestId(response, body),
         });
       }
 

--- a/xconfess-frontend/app/lib/api/proxy.ts
+++ b/xconfess-frontend/app/lib/api/proxy.ts
@@ -40,18 +40,43 @@ export function resolveBackendRoute(
 }
 
 export function methodNotAllowed(method: string, allowed: string[]): Response {
-  return Response.json(
-    {
+  const allowHeader = allowed.join(', ');
+  return new Response(
+    JSON.stringify({
       code: 'METHOD_NOT_ALLOWED',
-      message: `Method ${method} is not allowed. Use ${allowed.join(', ')}.`,
-    },
+      message: `Method ${method} is not allowed. Use ${allowHeader}.`,
+    }),
     {
       status: 405,
       headers: {
-        Allow: allowed.join(', '),
+        'Content-Type': 'application/json',
+        Allow: allowHeader,
       },
     },
   );
+}
+
+// Methods a proxy route may need an explicit 405 for. OPTIONS/HEAD are left to
+// Next.js so CORS preflight and HEAD-of-GET keep working.
+const STANDARD_HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
+
+/**
+ * Build route handlers that return a standardized 405 for every standard HTTP
+ * method not in `allowed`. Spread the result into a route module, e.g.:
+ *
+ *   export const { PUT, PATCH, DELETE } = methodNotAllowedHandlers(['GET', 'POST']);
+ */
+export function methodNotAllowedHandlers(
+  allowed: string[],
+): Record<string, () => Response> {
+  const allowedSet = new Set(allowed.map((method) => method.toUpperCase()));
+  const handlers: Record<string, () => Response> = {};
+  for (const method of STANDARD_HTTP_METHODS) {
+    if (!allowedSet.has(method)) {
+      handlers[method] = () => methodNotAllowed(method, allowed);
+    }
+  }
+  return handlers;
 }
 
 export async function proxyRequest<T = unknown>(

--- a/xconfess-frontend/lib/apiErrorHandler.ts
+++ b/xconfess-frontend/lib/apiErrorHandler.ts
@@ -87,6 +87,17 @@ export function createApiErrorResponse(
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
+  // Always echo the correlation / request id so failed calls can be traced from
+  // the frontend to backend logs (issue #1729).
+  const requestId =
+    normalized.requestId ??
+    normalized.correlationId ??
+    context.upstreamResponse?.headers.get('x-request-id') ??
+    (context.correlationId && context.correlationId !== 'unknown'
+      ? context.correlationId
+      : undefined);
+  if (requestId) headers['X-Request-Id'] = requestId;
+
   // Forward rate-limit headers from the upstream backend response
   if (normalized.status === 429) {
     const upstream = context.upstreamResponse;

--- a/xconfess-frontend/tests/accessibility/auth-feed-admin.a11y.spec.tsx
+++ b/xconfess-frontend/tests/accessibility/auth-feed-admin.a11y.spec.tsx
@@ -88,6 +88,10 @@ jest.mock("lucide-react", () => {
     Eye: icon("eye"),
     EyeOff: icon("eye-off"),
     ShieldCheck: icon("shield-check"),
+    UserPlus: icon("user-plus"),
+    LogIn: icon("log-in"),
+    Check: icon("check"),
+    Copy: icon("copy"),
   };
 });
 

--- a/xconfess-frontend/tests/auth/auth-error-request-id.spec.ts
+++ b/xconfess-frontend/tests/auth/auth-error-request-id.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Verifies failed login/register attempts carry the proxy request id so it can
+ * be surfaced to the user for log tracing (issue #1729).
+ */
+jest.mock("axios", () => {
+  const actual = jest.requireActual("axios");
+  const instance = {
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+    get: jest.fn(),
+    post: jest.fn(),
+  };
+  return {
+    ...actual,
+    default: { ...actual.default, create: () => instance },
+    create: () => instance,
+  };
+});
+
+jest.mock("@/app/lib/config", () => ({ getApiBaseUrl: () => "" }));
+
+import { AppError } from "@/app/lib/utils/errorHandler";
+import { extractRequestId } from "@/app/lib/utils/errorHandler";
+import { authApi, extractResponseRequestId } from "@/app/lib/api/authService";
+
+describe("extractResponseRequestId", () => {
+  it("prefers the x-request-id response header", () => {
+    const response = new Response("{}", {
+      headers: { "x-request-id": "hdr-1" },
+    });
+    expect(extractResponseRequestId(response, { correlationId: "body-1" })).toBe(
+      "hdr-1",
+    );
+  });
+
+  it("falls back to the body correlation id", () => {
+    const response = new Response("{}");
+    expect(
+      extractResponseRequestId(response, { correlationId: "body-1" }),
+    ).toBe("body-1");
+  });
+});
+
+describe("auth errors expose the request id", () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("attaches the request id to a failed login", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ code: "UNAUTHORIZED", message: "nope" }),
+        { status: 401, headers: { "x-request-id": "login-req-9" } },
+      ),
+    );
+
+    const error = await authApi
+      .login({ email: "a@b.com", password: "secret12" })
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(AppError);
+    expect(extractRequestId(error)).toBe("login-req-9");
+  });
+
+  it("attaches the request id to a failed registration", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          message: "Email already exists",
+          code: "ALREADY_EXISTS",
+          correlationId: "reg-req-4",
+        }),
+        { status: 409 },
+      ),
+    );
+
+    const error = await authApi
+      .register({ email: "a@b.com", password: "secret12", username: "alice" })
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(AppError);
+    expect(extractRequestId(error)).toBe("reg-req-4");
+  });
+});

--- a/xconfess-frontend/tests/auth/register-request-id.spec.tsx
+++ b/xconfess-frontend/tests/auth/register-request-id.spec.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AppError } from "@/app/lib/utils/errorHandler";
+
+const mockPush = jest.fn();
+const mockRegister = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/app/lib/hooks/useAuth", () => ({
+  useAuth: () => ({ register: mockRegister }),
+}));
+
+import RegisterPage from "@/app/(auth)/register/page";
+
+async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText("Username"), "alice42");
+  await user.type(screen.getByLabelText("Email"), "alice@example.com");
+  await user.type(screen.getByLabelText("Password"), "Str0ng!Pass#1");
+  await user.type(screen.getByLabelText("Confirm password"), "Str0ng!Pass#1");
+}
+
+describe("RegisterPage request id affordance", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("surfaces the request id when registration fails", async () => {
+    mockRegister.mockRejectedValueOnce(
+      new AppError("Email already exists", "ALREADY_EXISTS", 409, {
+        requestId: "reg-req-77",
+        responseBody: { message: "Email already exists" },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<RegisterPage />);
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    const requestId = await screen.findByTestId("auth-request-id");
+    expect(requestId).toHaveTextContent("reg-req-77");
+
+    await user.click(screen.getByRole("button", { name: /copy request id/i }));
+    expect(await screen.findByText(/copied/i)).toBeInTheDocument();
+    await waitFor(async () =>
+      expect(await navigator.clipboard.readText()).toBe("reg-req-77"),
+    );
+  });
+
+  it("does not render the notice when no request id is present", async () => {
+    mockRegister.mockRejectedValueOnce(
+      new AppError("Something went wrong", "REGISTER_FAILED", 500, {}),
+    );
+
+    const user = userEvent.setup();
+    render(<RegisterPage />);
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("auth-request-id")).not.toBeInTheDocument();
+  });
+});

--- a/xconfess-frontend/tests/auth/request-id-notice.spec.tsx
+++ b/xconfess-frontend/tests/auth/request-id-notice.spec.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RequestIdNotice } from "@/app/components/auth/RequestIdNotice";
+
+describe("RequestIdNotice", () => {
+  it("renders nothing without a request id", () => {
+    const { container } = render(<RequestIdNotice requestId={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a selectable request id and copies it on click", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<RequestIdNotice requestId="req-abc-123" />);
+
+    const value = screen.getByTestId("auth-request-id");
+    expect(value).toHaveTextContent("req-abc-123");
+    // `select-all` keeps the id manually selectable as a fallback.
+    expect(value).toHaveClass("select-all");
+
+    await userEvent.click(screen.getByRole("button", { name: /copy request id/i }));
+    expect(writeText).toHaveBeenCalledWith("req-abc-123");
+    expect(await screen.findByText(/copied/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements four issues spanning the Next.js proxy layer, the deploy tooling, the
auth UI, and the backend register flow.

Closes #1718
Closes #1727
Closes #1729
Closes #1730

---

### #1718 — Standardize method-not-allowed responses across proxy routes

- Added `methodNotAllowedHandlers(allowed[])` to `app/lib/api/proxy.ts`. It
  builds `405` handlers for every standard HTTP method **not** in `allowed`,
  reusing the existing `methodNotAllowed` helper. `OPTIONS`/`HEAD` are left to
  Next.js so CORS preflight and HEAD-of-GET keep working.
- Switched `methodNotAllowed` from `Response.json` (absent under jsdom / older
  runtimes) to `new Response(JSON.stringify(...))` with an explicit
  `Content-Type`. Response shape is unchanged: `{ code: "METHOD_NOT_ALLOWED", message }`
  with an `Allow` header.
- Applied the helper to the high-traffic auth / users / confessions / comments /
  notifications routes:
  `auth/session`, `users/register`, `users/profile`, `confessions`,
  `comments/[confessionId]`, `notifications`, `notifications/preference`.
- Focused route tests added for two routes:
  - `app/api/confessions/__tests__/route.methodNotAllowed.test.ts`
  - `app/api/notifications/__tests__/route.methodNotAllowed.test.ts`

**Validation**
```
npm run test --workspace=xconfess-frontend -- app/api --runInBand
# 7 suites / 30 tests pass
```

---

### #1727 — Migration baseline script tests

- Refactored `scripts/render-prestart.js`: extracted the skip/baseline logic into
  a pure, side-effect-free `evaluateBaselineDecision(state)` returning
  `{ action: 'skip' | 'baseline' | 'error', reason }`. `main()` now consults it,
  execution is guarded by `require.main === module`, and the function is exported.
- Added `validateRenderPrestartBaseline()` to `scripts/deploy-preflight.js` so the
  stated validation command exercises all four cases on every deploy preflight:
  disabled flag, no compiled migrations, fresh database, existing migration
  history, and synchronized-schema-with-empty-history.
- Added `scripts/__tests__/render-prestart.test.js` (matches the existing
  `scripts/__tests__` pattern) covering the same cases plus the stringified
  `SELECT COUNT(*)` value that `pg` returns.

Guarantees preserved: never baseline a fresh DB, never duplicate migration rows,
baseline only when core tables exist and migration history is empty.

**Validation**
```
npm run deploy:preflight        # passes
npx jest scripts/__tests__/render-prestart.test.js   # 7/7 pass
```

---

### #1729 — Auth error display with request ID copy affordance

- `app/lib/api/authService.ts`: added `extractResponseRequestId(response, body)`
  (prefers the `x-request-id` response header, falls back to body
  `requestId` / `request_id` / `correlationId`) and attaches it as
  `details.requestId` on the `AppError` thrown by failed `login()` / `register()`.
- Proxy error responses now consistently surface the id:
  - `lib/apiErrorHandler.ts` — `createApiErrorResponse` always sets the
    `X-Request-Id` header when a correlation id is available (was 429-only).
  - `app/api/auth/session/route.ts` — `createErrorResponse` now threads the
    request id into both the `x-request-id` header and the JSON body.
- New `app/components/auth/RequestIdNotice.tsx`: compact, mobile-friendly
  (`flex-wrap`, `text-xs`, `break-all`), `select-all` request-id text plus a copy
  button with a "Copied" confirmation. Renders nothing when no id is present.
- Wired into the login and register pages — shown on failed sign-in / sign-up
  whenever a request id is available.
- Tests: `tests/auth/request-id-notice.spec.tsx`,
  `tests/auth/auth-error-request-id.spec.ts`,
  `tests/auth/register-request-id.spec.tsx`.
- Also fixed a pre-existing failure in
  `tests/accessibility/auth-feed-admin.a11y.spec.tsx` (the local `lucide-react`
  mock was missing `UserPlus` / `LogIn`, which already broke the login/register
  a11y specs; added those plus `Check` / `Copy`).

**Validation**
```
npm run test --workspace=xconfess-frontend -- auth --runInBand
# 14 suites / 148 tests pass (5 suites / 9 tests were failing on main)
```

---

### #1730 — Register errors include request ID in logs

- `src/user/user-public.controller.ts`: `register()` now reads the incoming
  `req.requestId` (set by `RequestIdMiddleware`) and forwards it to
  `UserService.create(...)`.
- `src/user/user.service.ts`: `create(email, password, username, requestId?)` —
  every registration failure log now carries a `[requestId=…]` marker:
  - the `Failed to create user` error log,
  - the unique-constraint (`23505`) path,
  - both `409` conflict paths (email / username) now emit a `warn` where there
    was previously no log line at all.
- Removed PII from logs: the welcome-email failure warning no longer logs the
  email address — it references `user.id` instead. No email, password, or
  username values are logged anywhere in this path.
- Tests: new request-id block in `src/user/user.service.spec.ts` (asserts the id
  appears in logs and that the email/password never do) and a new
  `src/user/user-public.controller.spec.ts` (verifies the id is forwarded, and
  `undefined` is passed when absent).

**Validation**
```
npm run test --workspace=xconfess-backend -- user --runInBand
# 6 suites / 53 tests pass
```

---

## Notes

- `frontend:typecheck` and a raw backend `tsc --noEmit` both fail on **pre-existing**
  issues on `main` (uninstalled `@radix-ui/*` / `vaul` / `sonner` deps under
  `components/ui/*`; unrelated backend spec type errors). None of the files
  changed in this PR are implicated, and every issue's stated validation command
  passes.