### PR TITLE
fix: add JSDoc to sanitizeForSearch, standardize health endpoint names, add ThemeToggle test, remove stale stellar README fragment

### DIFF
--- a/xconfess-backend/API_DOCUMENTATION.md
+++ b/xconfess-backend/API_DOCUMENTATION.md
@@ -249,9 +249,17 @@ partial moderation state is committed.
 }
 ```
 
-## Health (`GET /api/health`)
+## Health endpoints
 
-Terminus health bundle used for operations and load balancers:
+Three health routes are active:
+
+| Route | Purpose |
+|---|---|
+| `GET /api/health` | Aggregate Terminus bundle (app + database + redis + schema). |
+| `GET /api/health/live` | **Liveness** probe — returns HTTP 200 when the process is up; used by load balancers to decide whether to restart the container. |
+| `GET /api/health/ready` | **Readiness** probe — returns HTTP 200 only when all downstream dependencies (database, redis, schema) are healthy; used by orchestrators to decide whether to send traffic. |
+
+Terminus health bundle indicators (reported by `GET /api/health` and `GET /api/health/ready`):
 
 - **`app`**: process up.
 - **`database`**: TypeORM ping to PostgreSQL.
@@ -268,6 +276,8 @@ The following list matches active `@Controller(...)` + method decorators.
 |---|---|
 | GET | `/api` |
 | GET | `/api/health` |
+| GET | `/api/health/live` |
+| GET | `/api/health/ready` |
 | GET | `/api/diagnostics/notifications` |
 | POST | `/api/auth/login` |
 | GET | `/api/auth/me` |

--- a/xconfess-backend/src/middleware/sanitization.middleware.ts
+++ b/xconfess-backend/src/middleware/sanitization.middleware.ts
@@ -38,8 +38,13 @@ function sanitizeForPlainText(value: string): string {
   return sanitizeHtml(value, PLAIN_TEXT_OPTIONS).trim();
 }
 
+/**
+ * Sanitizes a search query string.
+ *
+ * Strips HTML tags first, then escapes SQL/regex wildcard characters (`%`, `_`, `\`)
+ * so that user input cannot expand into unintended LIKE patterns or path traversals.
+ */
 function sanitizeForSearch(value: string): string {
-  // Strip HTML then escape SQL/regex special characters used in search
   const stripped = sanitizeHtml(value, PLAIN_TEXT_OPTIONS);
   return stripped.replace(/[%_\\]/g, '\\$&').trim();
 }

--- a/xconfess-backend/src/stellar/README.md
+++ b/xconfess-backend/src/stellar/README.md
@@ -1,17 +1,3 @@
-# Usage Example
-```typescript
-// Get balance
-const balance = await stellarService.getAccountBalance('GB...');
-// Anchor a confession
-await contractService.anchorConfession('hash', Date.now(), 'SC...');
-```
-
-# Security Best Practices
-- Never log or expose secret keys
-- Always validate input (DTOs, addresses, etc.)
-- Use environment variables for all secrets
-- Restrict contract invocation endpoints to admins only
-- Handle all errors and never leak sensitive info in responses
 # Stellar Integration Service (xConfess Backend)
 
 ## Overview

--- a/xconfess-frontend/app/components/common/__tests__/ThemeToggle.test.tsx
+++ b/xconfess-frontend/app/components/common/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeToggle } from "../ThemeToggle";
+
+jest.mock("../../../lib/hooks/useTheme", () => ({
+  useTheme: () => ({ theme: "system", setTheme: jest.fn() }),
+}));
+
+describe("ThemeToggle", () => {
+  it("renders all three accessible mode buttons after mount", () => {
+    render(<ThemeToggle />);
+
+    expect(
+      screen.getByRole("button", { name: "Light mode" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Dark mode" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "System preference" }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #1898
Closes #1899
Closes #1900
Closes #1901

## Changes

**#1898** — Added JSDoc to `sanitizeForSearch` in `xconfess-backend/src/middleware/sanitization.middleware.ts`. The function strips HTML then escapes SQL/regex wildcard characters; the doc comment explains the two-step sanitization and why `%`, `_`, and `\` are escaped.

**#1899** — Updated `xconfess-backend/API_DOCUMENTATION.md` to document `/api/health/live` (liveness) and `/api/health/ready` (readiness) endpoints with a comparison table, and added both routes to the exact route inventory.

**#1900** — Added `xconfess-frontend/app/components/common/__tests__/ThemeToggle.test.tsx`: a snapshot-free render test that asserts all three accessible button names ("Light mode", "Dark mode", "System preference") are present in the DOM. No snapshots used.

**#1901** — Removed the orphaned fragment at the top of `xconfess-backend/src/stellar/README.md` (lines 1–14 were duplicate `# Usage Example` and `# Security Best Practices` blocks that appeared before the document title, duplicating content already present in the body).