### PR TITLE
chore(notifications): clarify unread-count sync error log message (closes #1897)

### DIFF
--- a/xconfess-backend/src/notifications/gateways/notification.gateway.ts
+++ b/xconfess-backend/src/notifications/gateways/notification.gateway.ts
@@ -224,7 +224,10 @@ export class NotificationGateway
         timestamp: new Date().toISOString(),
       });
     } catch (error) {
-      this.logger.error(`Error syncing unread notifications:`, error);
+      this.logger.error(
+        `Failed to sync unread notification count for user ${userId}`,
+        error,
+      );
       client.emit('notifications:sync-failed', {
         message: 'Failed to sync unread notifications',
         timestamp: new Date().toISOString(),


### PR DESCRIPTION
Closes #1897.

## Change

Small, low-risk log-message clarification in the notification gateway (`xconfess-backend/src/notifications/gateways/notification.gateway.ts`):

- **Before:** `Error syncing unread notifications:` (vague, dangling colon)
- **After:** `Failed to sync unread notification count for user <userId>`

The new wording names what failed (syncing the unread notification count) and for which user, so operators can act on the log line. The error object is still passed as the structured-log context.

## Scope

- No behavior change - copy-only log wording.
- No unrelated formatting churn or refactors.
- Existing client `notifications:sync-failed` event is untouched.

## Validation

- Type-check of the touched file is clean (`tsc -p tsconfig.build.json` reports only pre-existing errors in unrelated files: `structured-logging.interceptor.ts`, `health.controller.ts`, `main.ts`).
- No test asserts the previous log string.