### PR TITLE
a11y: add aria-live to AnchorButton status region

### DIFF
--- a/xconfess-frontend/components/confession/AnchorButton.tsx
+++ b/xconfess-frontend/components/confession/AnchorButton.tsx
@@ -98,7 +98,7 @@ export function AnchorButton({
   }
 
   return (
-    <div className="anchor-action flex flex-col gap-2">
+    <div className="anchor-action flex flex-col gap-2" aria-live="polite">
       <button
         type="button"
         onClick={handleAnchor}


### PR DESCRIPTION
Closes #1896 

Add screen reader notification for async status
Summary

Add a small accessibility improvement to ensure an async success/error status in the frontend is announced to screen readers.

Changes
Added the appropriate accessibility notification for the existing async status.
Preserved existing behavior and UI.
No unrelated formatting, refactoring, or copy changes.
Testing
Run the narrowest relevant check for the touched frontend file.
Confirm the async success/error status is announced by screen readers.