### PR TITLE
Add public traction exclusion controls

### DIFF
--- a/docs/implementation-checklist.md
+++ b/docs/implementation-checklist.md
@@ -59,4 +59,4 @@ This checklist tracks implementation against the attached GrantFox readiness bri
 - [x] No private message body in analytics.
 - [x] No email, phone, JWT, auth token, password hash, seed phrase, private key, or raw IP in analytics.
 - [x] Public metrics are aggregate-only.
-- [ ] Test and internal account exclusions are explicit and documented before use.
+- [x] Test and internal account exclusions are explicit and documented before use.

--- a/docs/traction-metrics.md
+++ b/docs/traction-metrics.md
@@ -17,6 +17,9 @@ The endpoint is public, read-only, short-cacheable, rate limited, and versioned 
 - Meaningful actions: login, confession creation, comment creation, reaction creation, message sent, wallet connected, or completed tip.
 - Engagement totals: counts from authoritative domain tables for confessions, comments, reactions, and messages.
 - Stellar totals: counts from verified tip records and privacy-safe analytics events.
+- Test/internal exclusions: configured by ID through
+  `TRACTION_EXCLUDED_USER_IDS`, `TRACTION_EXCLUDED_ANONYMOUS_USER_IDS`, and
+  `TRACTION_EXCLUDED_ACTOR_IDS` before metrics are used in public reporting.
 
 ## Privacy Rules
 
@@ -31,6 +34,11 @@ The analytics ingestion boundary rejects sensitive field names before persistenc
 - Stellar private keys, secret seeds, or seed phrases.
 
 Public responses include aggregates only. They do not expose user-level records, emails, wallet secrets, confession text, message text, or private moderation payloads.
+
+Do not configure exclusions with emails, names, wallet addresses, raw IPs, auth
+tokens, or any other sensitive personal value. Use only comma-separated
+registered user IDs, anonymous user IDs, or analytics actor IDs that have been
+approved as test/internal accounts.
 
 ## Data Integrity
 

--- a/xconfess-backend/.env.example
+++ b/xconfess-backend/.env.example
@@ -88,6 +88,12 @@ CB_PROBE_SUCCESS_THRESHOLD=2
 ANALYTICS_ENABLED=true
 ANALYTICS_RETENTION_DAYS=365
 TRACTION_CACHE_TTL_SECONDS=60
+# Optional comma-separated IDs to remove known test/internal activity from
+# public aggregate traction. Use database IDs only; never use emails, names,
+# wallet seeds, tokens, IPs, or other personal/sensitive values here.
+TRACTION_EXCLUDED_USER_IDS=
+TRACTION_EXCLUDED_ANONYMOUS_USER_IDS=
+TRACTION_EXCLUDED_ACTOR_IDS=
 
 # Optional data export retention settings
 EXPORT_RETENTION_DAYS=7

--- a/xconfess-backend/src/analytics/traction-metrics.service.spec.ts
+++ b/xconfess-backend/src/analytics/traction-metrics.service.spec.ts
@@ -14,6 +14,15 @@ const makeRawCountQuery = (count: string) => ({
   getRawOne: jest.fn().mockResolvedValue({ count }),
 });
 
+const makeQuery = (count = 0, raw: Record<string, string> = { count: String(count) }) => ({
+  select: jest.fn().mockReturnThis(),
+  innerJoin: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  getCount: jest.fn().mockResolvedValue(count),
+  getRawOne: jest.fn().mockResolvedValue(raw),
+});
+
 describe('TractionMetricsService', () => {
   it('returns aggregate-only public metrics with real repository counts', async () => {
     const eventRepo = {
@@ -102,5 +111,102 @@ describe('TractionMetricsService', () => {
     });
     expect(JSON.stringify(result)).not.toContain('content');
     expect(JSON.stringify(result)).not.toContain('email');
+  });
+
+  it('excludes configured test and internal IDs from public aggregates', async () => {
+    const eventQueries = [
+      makeQuery(0, { count: '2' }),
+      makeQuery(0, { count: '3' }),
+      makeQuery(0, { count: '4' }),
+      makeQuery(5),
+      makeQuery(0, { count: '6' }),
+      makeQuery(0, { count: '7' }),
+      makeQuery(0, { count: '1' }),
+      makeQuery(8),
+    ];
+    const eventRepo = {
+      count: jest.fn(),
+      createQueryBuilder: jest.fn(() => eventQueries.shift()),
+    };
+    const userQuery = makeQuery(9);
+    const confessionQuery = makeQuery(10);
+    const commentQuery = makeQuery(11);
+    const reactionQuery = makeQuery(12);
+    const messageQuery = makeQuery(13);
+    const tipCountQuery = makeQuery(14);
+    const tipSumQuery = makeQuery(0, { total: '2.5000000' });
+    const cache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+    } as unknown as CacheService;
+    const config = {
+      get: jest.fn((key: string, fallback?: string) => {
+        const values: Record<string, string> = {
+          STELLAR_NETWORK: 'testnet',
+          TRACTION_CACHE_TTL_SECONDS: '60',
+          TRACTION_EXCLUDED_USER_IDS: '41,42',
+          TRACTION_EXCLUDED_ANONYMOUS_USER_IDS: 'anon-test,anon-internal',
+          TRACTION_EXCLUDED_ACTOR_IDS: 'actor-smoke',
+        };
+        return values[key] ?? fallback;
+      }),
+    } as unknown as ConfigService;
+
+    const service = new TractionMetricsService(
+      eventRepo as any,
+      { createQueryBuilder: jest.fn(() => userQuery) } as any,
+      { createQueryBuilder: jest.fn(() => confessionQuery) } as any,
+      { createQueryBuilder: jest.fn(() => commentQuery) } as any,
+      { createQueryBuilder: jest.fn(() => reactionQuery) } as any,
+      { createQueryBuilder: jest.fn(() => messageQuery) } as any,
+      {
+        createQueryBuilder: jest
+          .fn()
+          .mockReturnValueOnce(tipCountQuery)
+          .mockReturnValueOnce(tipSumQuery),
+      } as any,
+      makeCountRepo(1) as any,
+      cache,
+      config,
+    );
+
+    const result = await service.getPublicMetrics();
+
+    expect(result.users).toMatchObject({ totalRegistered: 9, dau: 2, wau: 3, mau: 4 });
+    expect(result.engagement).toMatchObject({
+      confessionsCreated: 10,
+      commentsCreated: 11,
+      reactionsCreated: 12,
+      messagesSent: 13,
+    });
+    expect(result.stellar).toMatchObject({
+      walletsConnected: 5,
+      submittedTransactions: 6,
+      confirmedTransactions: 14,
+      failedTransactions: 1,
+      successfulTips: 14,
+      tipVolumeByAsset: { XLM: '2.5' },
+      sorobanEventsIndexed: 8,
+    });
+
+    expect(userQuery.where).toHaveBeenCalledWith(
+      'user.id NOT IN (:...excludedRegisteredUserIds)',
+      { excludedRegisteredUserIds: [41, 42] },
+    );
+    expect(confessionQuery.andWhere).toHaveBeenCalledWith(
+      'confession.anonymousUserId NOT IN (:...excludedAnonymousUserIds)',
+      { excludedAnonymousUserIds: ['anon-test', 'anon-internal'] },
+    );
+    expect(commentQuery.andWhere).toHaveBeenCalledWith(
+      'anonymousUser.id NOT IN (:...excludedAnonymousUserIds)',
+      { excludedAnonymousUserIds: ['anon-test', 'anon-internal'] },
+    );
+    expect(messageQuery.where).toHaveBeenCalledWith(
+      'sender.id NOT IN (:...excludedAnonymousUserIds)',
+      { excludedAnonymousUserIds: ['anon-test', 'anon-internal'] },
+    );
+    expect(eventRepo.count).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain('actor-smoke');
+    expect(JSON.stringify(result)).not.toContain('anon-test');
   });
 });

--- a/xconfess-backend/src/analytics/traction-metrics.service.ts
+++ b/xconfess-backend/src/analytics/traction-metrics.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { createHash } from 'crypto';
 import { CacheService } from '../cache/cache.service';
 import { Comment } from '../comment/entities/comment.entity';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
@@ -81,11 +82,15 @@ export class TractionMetricsService {
   ) {}
 
   async getPublicMetrics(): Promise<TractionMetrics> {
-    const cacheKey = 'analytics:traction:public:v1';
+    const cacheKey = `analytics:traction:public:v1:${this.exclusionFingerprint()}`;
     const cached = await this.cacheService.get<TractionMetrics>(cacheKey);
     if (cached) {
       return cached;
     }
+
+    const excludedRegisteredUserIds = this.getExcludedRegisteredUserIds();
+    const excludedAnonymousUserIds = this.getExcludedAnonymousUserIds();
+    const excludedActorIds = this.getExcludedActorIds();
 
     const [
       totalRegistered,
@@ -104,22 +109,20 @@ export class TractionMetricsService {
       tipVolumeXlm,
       sorobanEventsIndexed,
     ] = await Promise.all([
-      this.userRepository.count(),
-      this.countActiveUsers(1),
-      this.countActiveUsers(7),
-      this.countActiveUsers(30),
-      this.confessionRepository.count({ where: { isDeleted: false } }),
-      this.commentRepository.count({ where: { isDeleted: false } }),
-      this.reactionRepository.count(),
-      this.messageRepository.count(),
-      this.countEvents('wallet_connected'),
-      this.countDistinctTransactionEvents('stellar_tx_submitted'),
-      this.countDistinctTransactionEvents('stellar_tx_confirmed'),
-      this.countDistinctTransactionEvents('stellar_tx_failed'),
-      this.tipRepository.count({
-        where: { verificationStatus: TipVerificationStatus.VERIFIED },
-      }),
-      this.sumVerifiedTips(),
+      this.countRegisteredUsers(excludedRegisteredUserIds),
+      this.countActiveUsers(1, excludedActorIds),
+      this.countActiveUsers(7, excludedActorIds),
+      this.countActiveUsers(30, excludedActorIds),
+      this.countConfessionsCreated(excludedAnonymousUserIds),
+      this.countCommentsCreated(excludedAnonymousUserIds),
+      this.countReactionsCreated(excludedAnonymousUserIds),
+      this.countMessagesSent(excludedAnonymousUserIds),
+      this.countEvents('wallet_connected', excludedActorIds),
+      this.countDistinctTransactionEvents('stellar_tx_submitted', excludedActorIds),
+      this.countDistinctTransactionEvents('stellar_tx_confirmed', excludedActorIds),
+      this.countDistinctTransactionEvents('stellar_tx_failed', excludedActorIds),
+      this.countVerifiedTips(excludedAnonymousUserIds),
+      this.sumVerifiedTips(excludedAnonymousUserIds),
       this.countSorobanEvidence(),
     ]);
 
@@ -172,46 +175,173 @@ export class TractionMetricsService {
     return result;
   }
 
-  private async countActiveUsers(days: number): Promise<number> {
+  private async countRegisteredUsers(excludedRegisteredUserIds: number[]): Promise<number> {
+    if (excludedRegisteredUserIds.length === 0) {
+      return this.userRepository.count();
+    }
+
+    return this.userRepository
+      .createQueryBuilder('user')
+      .where('user.id NOT IN (:...excludedRegisteredUserIds)', {
+        excludedRegisteredUserIds,
+      })
+      .getCount();
+  }
+
+  private async countActiveUsers(
+    days: number,
+    excludedActorIds: string[],
+  ): Promise<number> {
     const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-    const row = await this.analyticsEventRepository
+    const query = this.analyticsEventRepository
       .createQueryBuilder('event')
       .select('COUNT(DISTINCT event.actorId)', 'count')
       .where('event.occurredAt >= :since', { since })
       .andWhere('event.actorId IS NOT NULL')
       .andWhere('event.eventName IN (:...eventNames)', {
         eventNames: MEANINGFUL_ACTIVE_EVENTS,
-      })
-      .getRawOne<{ count?: string }>();
+      });
+
+    this.applyActorExclusion(query, excludedActorIds, false);
+
+    const row = await query.getRawOne<{ count?: string }>();
 
     return Number(row?.count ?? 0);
   }
 
-  private async countEvents(eventName: AnalyticsEventName): Promise<number> {
-    return this.analyticsEventRepository.count({ where: { eventName } });
+  private async countConfessionsCreated(
+    excludedAnonymousUserIds: string[],
+  ): Promise<number> {
+    if (excludedAnonymousUserIds.length === 0) {
+      return this.confessionRepository.count({ where: { isDeleted: false } });
+    }
+
+    return this.confessionRepository
+      .createQueryBuilder('confession')
+      .where('confession.isDeleted = :isDeleted', { isDeleted: false })
+      .andWhere('confession.anonymousUserId NOT IN (:...excludedAnonymousUserIds)', {
+        excludedAnonymousUserIds,
+      })
+      .getCount();
+  }
+
+  private async countCommentsCreated(
+    excludedAnonymousUserIds: string[],
+  ): Promise<number> {
+    if (excludedAnonymousUserIds.length === 0) {
+      return this.commentRepository.count({ where: { isDeleted: false } });
+    }
+
+    return this.commentRepository
+      .createQueryBuilder('comment')
+      .innerJoin('comment.anonymousUser', 'anonymousUser')
+      .where('comment.isDeleted = :isDeleted', { isDeleted: false })
+      .andWhere('anonymousUser.id NOT IN (:...excludedAnonymousUserIds)', {
+        excludedAnonymousUserIds,
+      })
+      .getCount();
+  }
+
+  private async countReactionsCreated(
+    excludedAnonymousUserIds: string[],
+  ): Promise<number> {
+    if (excludedAnonymousUserIds.length === 0) {
+      return this.reactionRepository.count();
+    }
+
+    return this.reactionRepository
+      .createQueryBuilder('reaction')
+      .innerJoin('reaction.anonymousUser', 'anonymousUser')
+      .where('anonymousUser.id NOT IN (:...excludedAnonymousUserIds)', {
+        excludedAnonymousUserIds,
+      })
+      .getCount();
+  }
+
+  private async countMessagesSent(excludedAnonymousUserIds: string[]): Promise<number> {
+    if (excludedAnonymousUserIds.length === 0) {
+      return this.messageRepository.count();
+    }
+
+    return this.messageRepository
+      .createQueryBuilder('message')
+      .innerJoin('message.sender', 'sender')
+      .where('sender.id NOT IN (:...excludedAnonymousUserIds)', {
+        excludedAnonymousUserIds,
+      })
+      .getCount();
+  }
+
+  private async countEvents(
+    eventName: AnalyticsEventName,
+    excludedActorIds: string[] = this.getExcludedActorIds(),
+  ): Promise<number> {
+    if (excludedActorIds.length === 0) {
+      return this.analyticsEventRepository.count({ where: { eventName } });
+    }
+
+    const query = this.analyticsEventRepository
+      .createQueryBuilder('event')
+      .where('event.eventName = :eventName', { eventName });
+
+    this.applyActorExclusion(query, excludedActorIds, true);
+
+    return query.getCount();
   }
 
   private async countDistinctTransactionEvents(
     eventName: AnalyticsEventName,
+    excludedActorIds: string[],
   ): Promise<number> {
-    const row = await this.analyticsEventRepository
+    const query = this.analyticsEventRepository
       .createQueryBuilder('event')
       .select('COUNT(DISTINCT event.txHash)', 'count')
       .where('event.eventName = :eventName', { eventName })
-      .andWhere('event.txHash IS NOT NULL')
-      .getRawOne<{ count?: string }>();
+      .andWhere('event.txHash IS NOT NULL');
+
+    this.applyActorExclusion(query, excludedActorIds, true);
+
+    const row = await query.getRawOne<{ count?: string }>();
 
     return Number(row?.count ?? 0);
   }
 
-  private async sumVerifiedTips(): Promise<number> {
-    const row = await this.tipRepository
+  private async countVerifiedTips(excludedAnonymousUserIds: string[]): Promise<number> {
+    if (excludedAnonymousUserIds.length === 0) {
+      return this.tipRepository.count({
+        where: { verificationStatus: TipVerificationStatus.VERIFIED },
+      });
+    }
+
+    return this.tipRepository
+      .createQueryBuilder('tip')
+      .innerJoin('tip.confession', 'confession')
+      .where('tip.verificationStatus = :status', {
+        status: TipVerificationStatus.VERIFIED,
+      })
+      .andWhere('confession.anonymousUserId NOT IN (:...excludedAnonymousUserIds)', {
+        excludedAnonymousUserIds,
+      })
+      .getCount();
+  }
+
+  private async sumVerifiedTips(excludedAnonymousUserIds: string[]): Promise<number> {
+    const query = this.tipRepository
       .createQueryBuilder('tip')
       .select('COALESCE(SUM(tip.amount), 0)', 'total')
       .where('tip.verificationStatus = :status', {
         status: TipVerificationStatus.VERIFIED,
-      })
-      .getRawOne<{ total?: string }>();
+      });
+
+    if (excludedAnonymousUserIds.length > 0) {
+      query
+        .innerJoin('tip.confession', 'confession')
+        .andWhere('confession.anonymousUserId NOT IN (:...excludedAnonymousUserIds)', {
+          excludedAnonymousUserIds,
+        });
+    }
+
+    const row = await query.getRawOne<{ total?: string }>();
 
     return Number(row?.total ?? 0);
   }
@@ -232,5 +362,68 @@ export class TractionMetricsService {
   private getCacheTtlSeconds(): number {
     const ttl = Number(this.configService.get<string>('TRACTION_CACHE_TTL_SECONDS', '60'));
     return Number.isFinite(ttl) && ttl > 0 ? ttl : 60;
+  }
+
+  private applyActorExclusion(
+    query: {
+      andWhere: (condition: string, parameters?: Record<string, unknown>) => unknown;
+    },
+    excludedActorIds: string[],
+    keepAnonymousEvents: boolean,
+  ): void {
+    if (excludedActorIds.length === 0) {
+      return;
+    }
+
+    query.andWhere(
+      keepAnonymousEvents
+        ? '(event.actorId IS NULL OR event.actorId NOT IN (:...excludedActorIds))'
+        : 'event.actorId NOT IN (:...excludedActorIds)',
+      { excludedActorIds },
+    );
+  }
+
+  private getExcludedRegisteredUserIds(): number[] {
+    return this.parseCsv('TRACTION_EXCLUDED_USER_IDS')
+      .map((value) => Number(value))
+      .filter((value) => Number.isInteger(value) && value > 0);
+  }
+
+  private getExcludedAnonymousUserIds(): string[] {
+    return this.parseCsv('TRACTION_EXCLUDED_ANONYMOUS_USER_IDS');
+  }
+
+  private getExcludedActorIds(): string[] {
+    return [
+      ...this.parseCsv('TRACTION_EXCLUDED_ACTOR_IDS'),
+      ...this.getExcludedAnonymousUserIds(),
+      ...this.getExcludedRegisteredUserIds().map(String),
+    ].filter((value, index, values) => values.indexOf(value) === index);
+  }
+
+  private exclusionFingerprint(): string {
+    const values = [
+      ...this.getExcludedActorIds(),
+      ...this.getExcludedAnonymousUserIds(),
+      ...this.getExcludedRegisteredUserIds().map(String),
+    ].sort();
+
+    if (values.length === 0) {
+      return 'none';
+    }
+
+    return createHash('sha256').update(values.join('\n')).digest('hex').slice(0, 12);
+  }
+
+  private parseCsv(key: string): string[] {
+    const raw = this.configService.get<string>(key, '');
+    if (!raw) {
+      return [];
+    }
+
+    return raw
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value, index, values) => value.length > 0 && values.indexOf(value) === index);
   }
 }

--- a/xconfess-backend/src/config/env.validation.spec.ts
+++ b/xconfess-backend/src/config/env.validation.spec.ts
@@ -38,6 +38,33 @@ describe('Environment Validation', () => {
     expect(value.CONFESSION_ENCRYPTION_KEY).toBe(validKey);
   });
 
+  it('should validate traction exclusion IDs without sensitive personal values', () => {
+    const config = {
+      ...baseConfig,
+      CONFESSION_ENCRYPTION_KEY: validKey,
+      TRACTION_EXCLUDED_USER_IDS: '1,2',
+      TRACTION_EXCLUDED_ANONYMOUS_USER_IDS: 'anon-test,anon_internal',
+      TRACTION_EXCLUDED_ACTOR_IDS: 'actor-smoke,41',
+    };
+
+    const { error } = envValidationSchema.validate(config);
+
+    expect(error).toBeUndefined();
+  });
+
+  it('should reject email-like values in traction exclusions', () => {
+    const config = {
+      ...baseConfig,
+      CONFESSION_ENCRYPTION_KEY: validKey,
+      TRACTION_EXCLUDED_ACTOR_IDS: 'qa@example.com',
+    };
+
+    const { error } = envValidationSchema.validate(config);
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain('TRACTION_EXCLUDED_ACTOR_IDS');
+  });
+
   it('should fail if CONFESSION_ENCRYPTION_KEY is missing', () => {
     const config = { ...baseConfig };
     const { error } = envValidationSchema.validate(config);

--- a/xconfess-backend/src/config/env.validation.ts
+++ b/xconfess-backend/src/config/env.validation.ts
@@ -206,6 +206,18 @@ export const envValidationSchema = Joi.object({
   ANALYTICS_ENABLED: Joi.string().valid('true', 'false').default('true'),
   ANALYTICS_RETENTION_DAYS: Joi.number().min(1).default(365),
   TRACTION_CACHE_TTL_SECONDS: Joi.number().min(1).max(3600).default(60),
+  TRACTION_EXCLUDED_USER_IDS: Joi.string()
+    .allow('')
+    .pattern(/^\d+(,\d+)*$/)
+    .default(''),
+  TRACTION_EXCLUDED_ANONYMOUS_USER_IDS: Joi.string()
+    .allow('')
+    .pattern(/^[A-Za-z0-9:_-]+(,[A-Za-z0-9:_-]+)*$/)
+    .default(''),
+  TRACTION_EXCLUDED_ACTOR_IDS: Joi.string()
+    .allow('')
+    .pattern(/^[A-Za-z0-9:_-]+(,[A-Za-z0-9:_-]+)*$/)
+    .default(''),
 
   // â”€â”€ DLQ retention â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
   DLQ_RETENTION_DAYS: Joi.number().default(14),


### PR DESCRIPTION
## Summary
- adds explicit public traction exclusion config for registered users, anonymous users, and analytics actor IDs
- applies exclusions at aggregate-query time without changing raw analytics ingestion or exposing configured IDs in responses
- documents the ID-only privacy rule and marks the GrantFox checklist privacy gap complete

## Validation
- npm run backend:test -- src/analytics/traction-metrics.service.spec.ts src/config/env.validation.spec.ts
- npm run backend:build
- npm run backend:lint
- git diff --check