### PR TITLE
Add production readiness scorecard output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build/
 .next/
 coverage/
 test-results/
+readiness-results/
 test_snapshots/
 target/
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ﻿# xConfess
 
-![CI](https://github.com/Dataguru-tech/Xconfess/actions/workflows/ci.yml/badge.svg)
-![License](https://img.shields.io/github/license/Dataguru-tech/Xconfess)
-![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)
+![CI](https://github.com/Xconfess/Xconfess/actions/workflows/ci.yml/badge.svg)
+![License](https://img.shields.io/github/license/Xconfess/Xconfess)
+![Node](https://img.shields.io/badge/node-22.x-brightgreen)
 
 
 xConfess is a privacy-first anonymous social app powered by Stellar.
@@ -13,6 +13,7 @@ xConfess is a privacy-first anonymous social app powered by Stellar.
 - Network: Stellar testnet by default, configurable for mainnet
 - Contract deployments: [deployments/README.md](deployments/README.md)
 - Metrics methodology: [docs/traction-metrics.md](docs/traction-metrics.md)
+- Readiness evidence: [docs/grantfox-readiness.md](docs/grantfox-readiness.md)
 
 ## Live Product Metrics
 
@@ -265,7 +266,7 @@ cd xconfess-contracts
 # Format
 cargo fmt --all
 
-# Lint (clippy, warnings as errors â€” mirrors CI)
+# Lint (clippy, warnings as errors - mirrors CI)
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 # Tests
@@ -340,7 +341,7 @@ npm run contract:lint
 npm run ci
 ```
 
-This runs `ci:backend`, `ci:frontend`, and `ci:contract` in sequence â€” build, lint, and test for each package.
+This runs `ci:backend`, `ci:frontend`, and `ci:contract` in sequence - build, lint, and test for each package.
 
 ## Contributing
 

--- a/docs/grantfox-readiness.md
+++ b/docs/grantfox-readiness.md
@@ -1,6 +1,6 @@
 # Xconfess GrantFox Readiness
 
-Date: 2026-09-07
+Date: 2026-09-08
 
 This document summarizes the current GrantFox readiness evidence in the
 repository. It does not fabricate users, traction, transaction counts, or live
@@ -47,20 +47,27 @@ are valid and must not be replaced with projected or manually edited metrics.
 Local readiness command:
 
 ```bash
-npm run production:readiness
+npm run readiness
 ```
 
-Latest local result observed on 2026-09-07:
+The readiness command also writes a schema-versioned JSON scorecard and a
+human-readable Markdown scorecard under ignored local `readiness-results/`.
+See `docs/production-readiness-scorecard.md`.
+
+Latest local result observed on 2026-09-08:
 
 - Backend build: passed.
 - Backend lint: passed.
-- Focused backend readiness tests: passed, 83 tests across analytics, config,
-  Stellar, and tipping suites.
+- Focused backend readiness tests: passed, 63 tests across analytics,
+  public traction, chain reconciliation, Soroban checkpointing, Stellar
+  diagnostics/configuration, and health suites.
 - Frontend lint: passed with no warnings.
 - Frontend typecheck: passed.
+- Focused frontend readiness tests: passed, 3 tests covering traction and the
+  public traction proxy.
 - Frontend production build: passed.
 - Contract environment verification: passed for testnet metadata.
-- Deploy preflight: passed.
+- Secret scanner self-test: passed.
 - Dependency audit: 0 critical, 0 high, and 0 moderate findings. Two accepted
   low findings remain from `csurf`'s bundled `cookie` dependency and are
   documented in `docs/dependency-security-audit.md`.

--- a/docs/implementation-checklist.md
+++ b/docs/implementation-checklist.md
@@ -45,6 +45,7 @@ This checklist tracks implementation against the attached GrantFox readiness bri
 - [x] Review dependency vulnerabilities and document remaining accepted low-risk findings.
 - [x] Add production readiness command.
 - [x] Run local production readiness command.
+- [x] Add machine-readable and human-readable production readiness scorecard output.
 - [x] Resolve live deployed smoke failure: deployed smoke now retries Render
   hibernate wake responses and passed without mutation mode on 2026-09-07.
 

--- a/docs/production-readiness-scorecard.md
+++ b/docs/production-readiness-scorecard.md
@@ -1,0 +1,44 @@
+# Production Readiness Scorecard
+
+Xconfess uses one command as the reviewer-facing readiness gate:
+
+```bash
+npm run readiness
+```
+
+That command delegates to `npm run production:readiness`, runs the focused
+backend/frontend/Stellar/privacy checks, and writes generated local reports to
+`readiness-results/`:
+
+- `production-readiness-scorecard.json`
+- `production-readiness-scorecard.md`
+
+The generated JSON is schema-versioned and machine-readable:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "ISO_DATE",
+  "startedAt": "ISO_DATE",
+  "mode": "local",
+  "status": "passed",
+  "durationMs": 1,
+  "checks": [
+    {
+      "name": "backend build",
+      "status": "PASS",
+      "exitCode": 0
+    }
+  ]
+}
+```
+
+Use deployed mode before campaign review windows:
+
+```bash
+npm run production:readiness:deployed
+```
+
+Deployed mode adds deploy preflight and the public smoke test. It must only run
+against configured staging or production URLs and must not submit mainnet
+transactions in CI.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "ci": "npm run ci:backend && npm run ci:frontend && npm run ci:contract",
     "deploy:preflight": "npm run contracts:verify-env && node scripts/deploy-preflight.js",
     "deploy:smoke": "node scripts/deployed-smoke.js",
+    "readiness": "npm run production:readiness",
+    "readiness:test": "node --test scripts/__tests__/production-readiness.test.js",
     "production:readiness": "node scripts/production-readiness.js",
     "production:readiness:full": "node scripts/production-readiness.js --full",
     "production:readiness:deployed": "node scripts/production-readiness.js --production --smoke",

--- a/scripts/__tests__/production-readiness.test.js
+++ b/scripts/__tests__/production-readiness.test.js
@@ -1,0 +1,65 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  buildChecks,
+  createScorecard,
+  parseOptions,
+  renderMarkdownReport,
+} = require('../production-readiness');
+
+test('parseOptions enables production smoke checks', () => {
+  const options = parseOptions(['--production']);
+
+  assert.equal(options.mode, 'production');
+  assert.equal(options.includeSmoke, true);
+  assert.equal(options.includeFullTests, false);
+  assert.equal(options.writeReport, true);
+});
+
+test('buildChecks keeps local readiness focused by default', () => {
+  const checks = buildChecks(parseOptions([])).map(([name]) => name);
+
+  assert.deepEqual(checks, [
+    'backend build',
+    'backend lint',
+    'backend focused readiness tests',
+    'frontend lint',
+    'frontend typecheck',
+    'frontend focused readiness tests',
+    'frontend build',
+    'contract env verification',
+    'secret scanner self-test',
+  ]);
+});
+
+test('createScorecard returns a schema-versioned failure when any check fails', () => {
+  const scorecard = createScorecard({
+    mode: 'local',
+    startedAt: Date.UTC(2026, 8, 8, 12, 0, 0),
+    durationMs: 25,
+    results: [
+      { name: 'backend build', status: 'passed', code: 0 },
+      { name: 'frontend build', status: 'failed', code: 1 },
+    ],
+  });
+
+  assert.equal(scorecard.schemaVersion, 1);
+  assert.equal(scorecard.status, 'failed');
+  assert.equal(scorecard.checks[0].status, 'PASS');
+  assert.equal(scorecard.checks[1].status, 'FAIL');
+  assert.equal(scorecard.checks[1].exitCode, 1);
+});
+
+test('renderMarkdownReport includes reviewer-readable scorecard rows', () => {
+  const markdown = renderMarkdownReport({
+    generatedAt: '2026-09-08T12:00:00.000Z',
+    mode: 'production',
+    status: 'passed',
+    durationMs: 10,
+    checks: [{ name: 'deployed smoke', status: 'PASS', exitCode: 0 }],
+  });
+
+  assert.match(markdown, /# Production Readiness Scorecard/);
+  assert.match(markdown, /\| deployed smoke \| PASS \| 0 \|/);
+});

--- a/scripts/production-readiness.js
+++ b/scripts/production-readiness.js
@@ -1,64 +1,87 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
-const args = new Set(process.argv.slice(2));
-const mode = args.has('--production') ? 'production' : 'local';
-const includeFullTests = args.has('--full');
-const includeSmoke = args.has('--smoke') || mode === 'production';
+const SCORECARD_SCHEMA_VERSION = 1;
+const DEFAULT_REPORT_DIR = 'readiness-results';
 
-const checks = [
-  ['backend build', 'npm', ['run', 'backend:build']],
-  ['backend lint', 'npm', ['run', 'backend:lint']],
-  [
-    'backend focused readiness tests',
-    'npm',
-    [
-      'test',
-      '--workspace=xconfess-backend',
-      '--',
-      'analytics-event.service',
-      'traction-metrics',
-      'public-traction.controller',
-      'chain-reconciliation',
-      'soroban-event-checkpoint',
-      'stellar-diagnostics.service',
-      'stellar-config.service',
-      'health.controller',
-      '--runInBand',
-    ],
-  ],
-  ['frontend lint', 'npm', ['run', 'frontend:lint']],
-  ['frontend typecheck', 'npm', ['run', 'frontend:typecheck']],
-  [
-    'frontend focused readiness tests',
-    'npm',
-    [
-      'test',
-      '--workspace=xconfess-frontend',
-      '--',
-      'traction',
-      'api/public/traction',
-      '--runInBand',
-    ],
-  ],
-  ['frontend build', 'npm', ['run', 'frontend:build']],
-  ['contract env verification', 'npm', ['run', 'contracts:verify-env']],
-  ['secret scanner self-test', 'npm', ['run', 'secret-scan:self-test']],
-];
+function parseOptions(argv = process.argv.slice(2)) {
+  const args = new Set(argv);
+  const reportDirArg = argv.find((arg) => arg.startsWith('--report-dir='));
 
-if (mode === 'production') {
-  checks.splice(0, 0, ['deploy preflight', 'npm', ['run', 'deploy:preflight']]);
+  return {
+    mode: args.has('--production') ? 'production' : 'local',
+    includeFullTests: args.has('--full'),
+    includeSmoke: args.has('--smoke') || args.has('--production'),
+    writeReport: !args.has('--no-report'),
+    reportDir: reportDirArg
+      ? reportDirArg.slice('--report-dir='.length)
+      : DEFAULT_REPORT_DIR,
+  };
 }
 
-if (includeFullTests) {
-  checks.push(['backend full tests', 'npm', ['run', 'backend:test']]);
-  checks.push(['frontend full tests', 'npm', ['run', 'frontend:test']]);
-  checks.push(['contract tests', 'npm', ['run', 'contract:test']]);
-}
+function buildChecks({ mode, includeFullTests, includeSmoke }) {
+  const checks = [
+    ['backend build', 'npm', ['run', 'backend:build']],
+    ['backend lint', 'npm', ['run', 'backend:lint']],
+    [
+      'backend focused readiness tests',
+      'npm',
+      [
+        'test',
+        '--workspace=xconfess-backend',
+        '--',
+        'analytics-event.service',
+        'traction-metrics',
+        'public-traction.controller',
+        'chain-reconciliation',
+        'soroban-event-checkpoint',
+        'stellar-diagnostics.service',
+        'stellar-config.service',
+        'health.controller',
+        '--runInBand',
+      ],
+    ],
+    ['frontend lint', 'npm', ['run', 'frontend:lint']],
+    ['frontend typecheck', 'npm', ['run', 'frontend:typecheck']],
+    [
+      'frontend focused readiness tests',
+      'npm',
+      [
+        'test',
+        '--workspace=xconfess-frontend',
+        '--',
+        'traction',
+        'api/public/traction',
+        '--runInBand',
+      ],
+    ],
+    ['frontend build', 'npm', ['run', 'frontend:build']],
+    ['contract env verification', 'npm', ['run', 'contracts:verify-env']],
+    ['secret scanner self-test', 'npm', ['run', 'secret-scan:self-test']],
+  ];
 
-if (includeSmoke) {
-  checks.push(['deployed smoke', 'npm', ['run', 'deploy:smoke']]);
+  if (mode === 'production') {
+    checks.splice(0, 0, [
+      'deploy preflight',
+      'npm',
+      ['run', 'deploy:preflight'],
+    ]);
+  }
+
+  if (includeFullTests) {
+    checks.push(['backend full tests', 'npm', ['run', 'backend:test']]);
+    checks.push(['frontend full tests', 'npm', ['run', 'frontend:test']]);
+    checks.push(['contract tests', 'npm', ['run', 'contract:test']]);
+  }
+
+  if (includeSmoke) {
+    checks.push(['deployed smoke', 'npm', ['run', 'deploy:smoke']]);
+  }
+
+  return checks;
 }
 
 function runCheck([name, command, commandArgs]) {
@@ -76,21 +99,102 @@ function runCheck([name, command, commandArgs]) {
   };
 }
 
-const started = Date.now();
-const results = checks.map(runCheck);
-const failed = results.filter((result) => result.status !== 'passed');
+function createScorecard({ mode, startedAt, durationMs, results }) {
+  const failed = results.filter((result) => result.status !== 'passed');
 
-console.log('\nProduction readiness summary');
-for (const result of results) {
-  console.log(`- ${result.status.toUpperCase()}: ${result.name}`);
+  return {
+    schemaVersion: SCORECARD_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    startedAt: new Date(startedAt).toISOString(),
+    mode,
+    status: failed.length === 0 ? 'passed' : 'failed',
+    durationMs,
+    checks: results.map((result) => ({
+      name: result.name,
+      status: result.status === 'passed' ? 'PASS' : 'FAIL',
+      exitCode: result.code,
+    })),
+  };
 }
-console.log(`Duration: ${Math.max(1, Date.now() - started)}ms`);
 
-if (failed.length > 0) {
-  console.error(
-    `\nReadiness failed: ${failed.map((result) => result.name).join(', ')}`,
-  );
-  process.exit(1);
+function renderMarkdownReport(scorecard) {
+  const lines = [
+    '# Production Readiness Scorecard',
+    '',
+    `Generated: ${scorecard.generatedAt}`,
+    `Mode: ${scorecard.mode}`,
+    `Status: ${scorecard.status.toUpperCase()}`,
+    `Duration: ${scorecard.durationMs}ms`,
+    '',
+    '| Check | Result | Exit code |',
+    '| --- | --- | --- |',
+  ];
+
+  for (const check of scorecard.checks) {
+    lines.push(`| ${check.name} | ${check.status} | ${check.exitCode} |`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
 }
 
-console.log('\nReadiness passed.');
+function writeScorecardReports(scorecard, reportDir) {
+  const outputDir = path.resolve(process.cwd(), reportDir || DEFAULT_REPORT_DIR);
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const jsonPath = path.join(outputDir, 'production-readiness-scorecard.json');
+  const markdownPath = path.join(outputDir, 'production-readiness-scorecard.md');
+
+  fs.writeFileSync(jsonPath, `${JSON.stringify(scorecard, null, 2)}\n`);
+  fs.writeFileSync(markdownPath, renderMarkdownReport(scorecard));
+
+  return { jsonPath, markdownPath };
+}
+
+function main() {
+  const options = parseOptions();
+  const checks = buildChecks(options);
+  const started = Date.now();
+  const results = checks.map(runCheck);
+  const durationMs = Math.max(1, Date.now() - started);
+  const scorecard = createScorecard({
+    mode: options.mode,
+    startedAt: started,
+    durationMs,
+    results,
+  });
+
+  console.log('\nProduction readiness summary');
+  for (const result of results) {
+    console.log(`- ${result.status.toUpperCase()}: ${result.name}`);
+  }
+  console.log(`Duration: ${durationMs}ms`);
+
+  if (options.writeReport) {
+    const written = writeScorecardReports(scorecard, options.reportDir);
+    console.log(`Scorecard JSON: ${written.jsonPath}`);
+    console.log(`Scorecard Markdown: ${written.markdownPath}`);
+  }
+
+  if (scorecard.status !== 'passed') {
+    const failed = results.filter((result) => result.status !== 'passed');
+    console.error(
+      `\nReadiness failed: ${failed.map((result) => result.name).join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  console.log('\nReadiness passed.');
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildChecks,
+  createScorecard,
+  parseOptions,
+  renderMarkdownReport,
+  writeScorecardReports,
+};


### PR DESCRIPTION
## Summary
- add a root `npm run readiness` alias for the production readiness gate
- make the readiness runner emit schema-versioned JSON and Markdown scorecards under ignored `readiness-results/`
- document the scorecard contract and refresh production readiness evidence from the 2026-09-08 local run
- correct README repository badges, Node runtime badge, and visible encoding artifacts

## Validation
- npm run readiness:test
- npm run readiness
- git diff --check

## Notes
- No fabricated users, traction numbers, Stellar transactions, or usage statistics are introduced.
- Generated readiness reports are ignored locally; reviewers can reproduce them with `npm run readiness`.