### PR TITLE
docs: remove program-specific readiness naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Both xconfess-postgres and xconfess-redis should show healthy.
 
 If you are contributing through an OSS campaign or grant program:
 
-- Start with issues labeled `good first issue`, `help wanted`, `Stellar Wave`, `GrantFox OSS`, or `Maybe Rewarded`.
+- Start with issues labeled `good first issue`, `help wanted`, `Stellar Wave`, `Maybe Rewarded`, or `Official Campaign`.
 - Comment on the issue before starting so maintainers can confirm it is still available.
 - Keep the PR focused on one issue. Do not bundle unrelated cleanup.
 - Follow the acceptance criteria and validation commands listed in the issue.
@@ -245,7 +245,7 @@ Use Conventional Commits format: feat(backend): add GDPR data export endpoint
 
 ## Wave / Drips Contribution Guidelines
 
-Xconfess participates in multiple OSS programs, including Stellar Wave and GrantFox OSS. If your contribution is tied to a program issue:
+Xconfess participates in multiple OSS programs, including Stellar Wave. If your contribution is tied to a program issue:
 
 - Reference the issue number in your PR description
 - Keep each program contribution as a single focused PR - one issue, one PR

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ xConfess is a privacy-first anonymous social app powered by Stellar.
 - Network: Stellar testnet by default, configurable for mainnet
 - Contract deployments: [deployments/README.md](deployments/README.md)
 - Metrics methodology: [docs/traction-metrics.md](docs/traction-metrics.md)
-- Readiness evidence: [docs/grantfox-readiness.md](docs/grantfox-readiness.md)
+- Readiness evidence: [docs/product-readiness.md](docs/product-readiness.md)
 
 ## Live Product Metrics
 

--- a/docs/OSS_CONTRIBUTOR_SPRINT.md
+++ b/docs/OSS_CONTRIBUTOR_SPRINT.md
@@ -9,7 +9,7 @@ Every contributor-ready issue should have:
 - one type label: `bug`, `feature`, `chore`, `docs`, or `test`
 - one or two area labels: `frontend`, `backend`, `stellar`, `contracts`, `ops`, `security`, `ux`, `api`
 - one priority label: `P0`, `P1`, `P2`, or `P3`
-- optionally a program label: `Stellar Wave`, `GrantFox OSS`, `Maybe Rewarded`, `Official Campaign`
+- optionally a program label: `Stellar Wave`, `Maybe Rewarded`, `Official Campaign`
 
 Use `good first issue` only when the contributor can complete the task without deep product context.
 Use `help wanted` when maintainers want external implementation but the work may require reading code.

--- a/docs/dependency-security-audit.md
+++ b/docs/dependency-security-audit.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-07
 
-This record documents the dependency audit performed for GrantFox readiness.
+This record documents the dependency audit performed for production readiness.
 It does not include fabricated usage, traction, or security claims.
 
 ## Scope

--- a/docs/implementation-checklist.md
+++ b/docs/implementation-checklist.md
@@ -1,6 +1,6 @@
-# Xconfess GrantFox Implementation Checklist
+# Xconfess Readiness Implementation Checklist
 
-This checklist tracks implementation against the attached GrantFox readiness brief. Metrics must come from real persisted data only.
+This checklist tracks implementation against the attached readiness brief. Metrics must come from real persisted data only.
 
 ## Milestone 1 - Measure Reality
 
@@ -51,7 +51,7 @@ This checklist tracks implementation against the attached GrantFox readiness bri
 
 ## Milestone 5 - Prepare For Campaign
 
-- [x] Publish `docs/grantfox-readiness.md`.
+- [x] Publish `docs/product-readiness.md`.
 - [x] Restructure README top section for product evidence.
 - [x] Create only substantive future campaign issues where genuine work remains.
 

--- a/docs/product-readiness.md
+++ b/docs/product-readiness.md
@@ -1,8 +1,8 @@
-# Xconfess GrantFox Readiness
+# Xconfess Product Readiness
 
 Date: 2026-09-08
 
-This document summarizes the current GrantFox readiness evidence in the
+This document summarizes the current production readiness evidence in the
 repository. It does not fabricate users, traction, transaction counts, or live
 usage statistics.
 

--- a/docs/production-readiness-audit.md
+++ b/docs/production-readiness-audit.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-05
 
-This audit treats the GrantFox implementation brief as product requirements and the repository as the source of truth. It does not include live traffic claims or fabricated usage data.
+This audit treats the readiness implementation brief as product requirements and the repository as the source of truth. It does not include live traffic claims or fabricated usage data.
 
 ## Summary
 
@@ -40,7 +40,7 @@ This audit treats the GrantFox implementation brief as product requirements and 
 - `TippingService` idempotency, retry metadata, and `tip.verified`/`tip.verification_failed` events.
 - Stellar configuration through `STELLAR_NETWORK`, Horizon/RPC URLs, and contract ID env vars.
 
-## Critical Blockers For GrantFox Readiness
+## Critical Blockers For Production Readiness
 
 - No public aggregate traction endpoint exists.
 - No persisted privacy-safe analytics event pipeline exists.

--- a/docs/readiness-follow-up-issues.md
+++ b/docs/readiness-follow-up-issues.md
@@ -1,4 +1,4 @@
-# GrantFox Follow-Up Issues
+# Readiness Follow-Up Issues
 
 Date: 2026-09-05
 
@@ -44,8 +44,8 @@ validation. They are not placeholders for invented traction or campaign copy.
 - Status: Completed on 2026-09-07.
 - Evidence: `npm run frontend:lint` exited successfully with no warnings after
   cleanup merged into `main`.
-- Impact: Frontend lint no longer carries known warning debt into GrantFox
-  readiness checks.
+- Impact: Frontend lint no longer carries known warning debt into readiness
+  checks.
 - Acceptance: Keep `npm run frontend:lint` warning-free.
 
 ## 4. Review Dependency Vulnerabilities


### PR DESCRIPTION
## Summary
- rename readiness evidence documents to neutral production/product readiness names
- remove program-specific wording from README, contribution docs, readiness docs, and audit docs
- keep the readiness evidence package intact without changing metrics, product behavior, or validation commands

## Validation
- rg -n -i <removed-program-name> . --glob !node_modules/** --glob !dist/** --glob !build/** --glob !.next/** --glob !readiness-results/** --glob !.git/** returned no matches
- npm run readiness:test
- git diff --check

## Notes
- Existing merged Git history still contains older branch and merge commit names. Removing those from GitHub history would require a destructive history rewrite and force-push, so this PR cleans repository content and forward-facing names instead.